### PR TITLE
fixed finalize route

### DIFF
--- a/src/Checkout/Plus/PlusPaymentFinalizeController.php
+++ b/src/Checkout/Plus/PlusPaymentFinalizeController.php
@@ -49,7 +49,7 @@ class PlusPaymentFinalizeController extends AbstractController
 
     /**
      * @RouteScope(scopes={"storefront"})
-     * @Route("/paypal/plus/payment/finalize-transaction", name="paypal.plus.payment.finalize.transaction", methods={"GET"}, defaults={"auth_required"=false})
+     * @Route("/paypal/plus/payment/finalize-transaction", name="payment.paypal.plus.finalize.transaction", methods={"GET"}, defaults={"auth_required"=false})
      *
      * @throws InvalidTransactionException
      * @throws CustomerCanceledAsyncPaymentException

--- a/src/Checkout/Plus/Service/PlusDataService.php
+++ b/src/Checkout/Plus/Service/PlusDataService.php
@@ -69,7 +69,7 @@ class PlusDataService
         SwagPayPalSettingStruct $settings
     ): ?PlusData {
         $finishUrl = $this->router->generate(
-            'paypal.plus.payment.finalize.transaction',
+            'payment.paypal.plus.finalize.transaction',
             [PayPalPaymentHandler::PAYPAL_PLUS_CHECKOUT_REQUEST_PARAMETER => true],
             UrlGeneratorInterface::ABSOLUTE_URL
         );

--- a/src/DependencyInjection/plus.xml
+++ b/src/DependencyInjection/plus.xml
@@ -8,7 +8,7 @@
         <service id="Swag\PayPal\Checkout\Plus\Service\PlusDataService">
             <argument type="service" id="Swag\PayPal\Payment\Builder\CartPaymentBuilder"/>
             <argument type="service" id="Swag\PayPal\PayPal\Resource\PaymentResource"/>
-            <argument type="service" id="router.default"/>
+            <argument type="service" id="router"/>
             <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <argument type="service" id="Swag\PayPal\Util\LocaleCodeProvider"/>
         </service>


### PR DESCRIPTION
If you have your sales channel domain defined as my-shop.com/shop then the generated finalize url misses the /shop and generates a url like my-shop.com/paypal/plus/payment/finalize-transaction. This breaks the callback from paypal because shopware does not find a sales channel for that domain.

The /shop is missing because the router.default only knows the domain but doesn't recognize the /shop as required part of the url.

If you change router.default to router, then the shopware router only creates the correct url, if the route name begins with frontend., widgets. or payment. because only those urls are recognized as storefront urls.