### PR TITLE
return empty array in case that json_decode returns not an array.

### DIFF
--- a/src/PayPal/Client/AbstractClient.php
+++ b/src/PayPal/Client/AbstractClient.php
@@ -65,7 +65,7 @@ abstract class AbstractClient
 
     private function decodeJsonResponse(string $response): array
     {
-        return \json_decode($response, true);
+        return \json_decode($response, true) ?? [];
     }
 
     private function handleRequestException(RequestException $requestException, array $data): PayPalApiException


### PR DESCRIPTION
currently we are using the AbstractClient for a subscription implementation. There is as example the following API https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_cancel wich returns a "204 - no content" result. This will fail with the current implementation because the strict check throws a type error.

Since i don't want to catch a TypeError the fix could be like in this pull request.

I didn't find any tests regarding this, so i didn't wrote anything