### PR TITLE
make parentPayment nullable and added billingAgreementId.

### DIFF
--- a/src/PayPal/Api/Webhook/Resource.php
+++ b/src/PayPal/Api/Webhook/Resource.php
@@ -15,9 +15,14 @@ use Swag\PayPal\PayPal\Api\Webhook\Resource\TransactionFee;
 class Resource extends PayPalStruct
 {
     /**
-     * @var string
+     * @var ?string
      */
     protected $parentPayment;
+
+    /**
+     * @var ?string
+     */
+    protected $billingAgreementId;
 
     /**
      * @var string
@@ -79,7 +84,7 @@ class Resource extends PayPalStruct
      */
     private $state;
 
-    public function getParentPayment(): string
+    public function getParentPayment(): ?string
     {
         return $this->parentPayment;
     }
@@ -87,6 +92,16 @@ class Resource extends PayPalStruct
     protected function setParentPayment(string $parentPayment): void
     {
         $this->parentPayment = $parentPayment;
+    }
+
+    public function getBillingAgreementId(): ?string
+    {
+        return $this->billingAgreementId;
+    }
+
+    protected function setBillingAgreementId(string $billingAgreementId): void
+    {
+        $this->billingAgreementId = $billingAgreementId;
     }
 
     protected function setUpdateTime(string $updateTime): void

--- a/src/PayPal/Api/Webhook/Resource.php
+++ b/src/PayPal/Api/Webhook/Resource.php
@@ -89,7 +89,7 @@ class Resource extends PayPalStruct
         return $this->parentPayment;
     }
 
-    protected function setParentPayment(string $parentPayment): void
+    protected function setParentPayment(?string $parentPayment): void
     {
         $this->parentPayment = $parentPayment;
     }
@@ -97,9 +97,10 @@ class Resource extends PayPalStruct
     public function getBillingAgreementId(): ?string
     {
         return $this->billingAgreementId;
+
     }
 
-    protected function setBillingAgreementId(string $billingAgreementId): void
+    protected function setBillingAgreementId(?string $billingAgreementId): void
     {
         $this->billingAgreementId = $billingAgreementId;
     }

--- a/src/Webhook/Exception/ParentPaymentIdNotFoundException.php
+++ b/src/Webhook/Exception/ParentPaymentIdNotFoundException.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Swag\PayPal\Webhook\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ParentPaymentIdNotFoundException extends WebhookException
+{
+    public function __construct(string $eventType)
+    {
+        parent::__construct(
+            $eventType,
+            '[PayPal {{ eventType }} Webhook] Could not find a parent payment id, perhaps it\'s a subscription?',
+            [
+                'eventType' => $eventType
+            ]
+        );
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__WEBHOOK_PARENT_PAYMENT_ID_NOT_FOUND';
+    }
+}

--- a/src/Webhook/Handler/AbstractWebhookHandler.php
+++ b/src/Webhook/Handler/AbstractWebhookHandler.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Swag\PayPal\PayPal\Api\Webhook;
 use Swag\PayPal\SwagPayPal;
+use Swag\PayPal\Webhook\Exception\ParentPaymentIdNotFoundException;
 use Swag\PayPal\Webhook\Exception\WebhookException;
 use Swag\PayPal\Webhook\Exception\WebhookOrderTransactionNotFoundException;
 use Swag\PayPal\Webhook\WebhookHandler;
@@ -55,7 +56,7 @@ abstract class AbstractWebhookHandler implements WebhookHandler
         $payPalTransactionId = $webhook->getResource()->getParentPayment();
 
         if (!$payPalTransactionId) {
-            throw new WebhookException($this->getEventType(), 'no parent payment was given by paypal.');
+            throw new ParentPaymentIdNotFoundException($this->getEventType());
         }
 
         $criteria = new Criteria();

--- a/src/Webhook/Handler/AbstractWebhookHandler.php
+++ b/src/Webhook/Handler/AbstractWebhookHandler.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Swag\PayPal\PayPal\Api\Webhook;
 use Swag\PayPal\SwagPayPal;
+use Swag\PayPal\Webhook\Exception\WebhookException;
 use Swag\PayPal\Webhook\Exception\WebhookOrderTransactionNotFoundException;
 use Swag\PayPal\Webhook\WebhookHandler;
 
@@ -47,10 +48,16 @@ abstract class AbstractWebhookHandler implements WebhookHandler
 
     /**
      * @throws WebhookOrderTransactionNotFoundException
+     * @throws WebhookException
      */
     protected function getOrderTransaction(Webhook $webhook, Context $context): OrderTransactionEntity
     {
         $payPalTransactionId = $webhook->getResource()->getParentPayment();
+
+        if (!$payPalTransactionId) {
+            throw new WebhookException($this->getEventType(), 'no parent payment was given by paypal.');
+        }
+
         $criteria = new Criteria();
         $criteria->addFilter(
             new EqualsFilter(


### PR DESCRIPTION
As said before we are currently implementing a subscription. It seems that in case of a subscription the PAYMENT.SALES.COMPLETED event is also triggered (https://developer.paypal.com/docs/api-basics/notifications/webhooks/event-names/#subscriptions) but instead a parent_payment there is a billing_agreement_id.

Since this is the case, the webhook will fail with a 500 error. This PR fixes this behaviour.
Example Payload (from sandbox webhook):

```json
{
	"id": "WH-0J860224XT5422720-1LE673646T867051E",
	"event_version": "1.0",
	"create_time": "2020-08-06T08:09:33.898Z",
	"resource_type": "sale",
	"event_type": "PAYMENT.SALE.COMPLETED",
	"summary": "Payment completed for EUR 21.6 EUR",
	"resource": {
		"billing_agreement_id": "I-DTVVSNCENF7M",
		"amount": {
			"total": "21.60",
			"currency": "EUR",
			"details": {
				"subtotal": "21.60"
			}
		},
		"payment_mode": "INSTANT_TRANSFER",
		"update_time": "2020-08-06T08:08:36Z",
		"create_time": "2020-08-06T08:08:36Z",
		"protection_eligibility_type": "ITEM_NOT_RECEIVED_ELIGIBLE,UNAUTHORIZED_PAYMENT_ELIGIBLE",
		"transaction_fee": {
			"currency": "EUR",
			"value": "0.76"
		},
		"protection_eligibility": "ELIGIBLE",
		"links": [
			{
				"method": "GET",
				"rel": "self",
				"href": "https://api.sandbox.paypal.com/v1/payments/sale/1A615453BF810315T"
			},
			{
				"method": "POST",
				"rel": "refund",
				"href": "https://api.sandbox.paypal.com/v1/payments/sale/1A615453BF810315T/refund"
			}
		],
		"id": "1A615453BF810315T",
		"state": "completed",
		"invoice_number": ""
	},
	"links": [
		{
			"href": "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-0J860224XT5422720-1LE673646T867051E",
			"rel": "self",
			"method": "GET"
		},
		{
			"href": "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-0J860224XT5422720-1LE673646T867051E/resend",
			"rel": "resend",
			"method": "POST"
		}
	]
}
```