### PR TITLE
added a get for the resource id (in this case it's the sale resource …

### DIFF
--- a/src/PayPal/Api/Webhook/Resource.php
+++ b/src/PayPal/Api/Webhook/Resource.php
@@ -15,6 +15,11 @@ use Swag\PayPal\PayPal\Api\Webhook\Resource\TransactionFee;
 class Resource extends PayPalStruct
 {
     /**
+     * @var string
+     */
+    protected $id;
+
+    /**
      * @var string|null
      */
     protected $parentPayment;
@@ -77,12 +82,12 @@ class Resource extends PayPalStruct
     /**
      * @var string
      */
-    private $id;
-
-    /**
-     * @var string
-     */
     private $state;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
 
     public function getParentPayment(): ?string
     {


### PR DESCRIPTION
…-> https://developer.paypal.com/docs/api/payments/v1/?mark=sale#definition-sale) so that the system can work with it (or other applications)