### PR TITLE
the detail error fields may vary on each output which causes some notice exceptions.

### DIFF
--- a/src/PayPal/Client/AbstractClient.php
+++ b/src/PayPal/Client/AbstractClient.php
@@ -91,7 +91,12 @@ abstract class AbstractClient
         if (isset($error['details'])) {
             $message .= ': ';
             foreach ($error['details'] as $detail) {
-                $message .= $detail['issue'] . ' (' . $detail['field'] . ') ';
+                if (isset($detail['issue'])) {
+                    $message .= $detail['issue'];
+                }
+                if (isset($detail['field'])) {
+                    $message .= ' (' . $detail['field'] . ') ';
+                }
             }
         }
 


### PR DESCRIPTION

As stated here https://developer.paypal.com/docs/api/reference/api-responses/#http-status-codes 
"Note: The fields returned in the details array vary by error."

This causes currently a notice exception. Below is an example.


```
^ array:5 [
  "name" => "RESOURCE_NOT_FOUND"
  "message" => "The specified resource does not exist."
  "debug_id" => "95ccc8447dfd1"
  "details" => array:1 [
    0 => array:2 [
      "issue" => "INVALID_RESOURCE_ID"
      "description" => "Requested resource ID was not found."
    ]
  ]
  "links" => array:1 [
    0 => array:3 [
      "href" => "https://developer.paypal.com/docs/api/v1/billing/subscriptions#RESOURCE_NOT_FOUND"
      "rel" => "information_link"
      "method" => "GET"
    ]
  ]
]
```