### PR TITLE
added sale_id & refund_reason_code to Webhook Resource

### DIFF
--- a/src/PayPal/Api/Webhook/Resource.php
+++ b/src/PayPal/Api/Webhook/Resource.php
@@ -30,6 +30,16 @@ class Resource extends PayPalStruct
     protected $billingAgreementId;
 
     /**
+     * @var string|null
+     */
+    protected $saleId;
+
+    /**
+     * @var string|null
+     */
+    protected $refundReasonCode;
+
+    /**
      * @var string
      */
     protected $updateTime;
@@ -112,6 +122,26 @@ class Resource extends PayPalStruct
     public function setBillingAgreementId(?string $billingAgreementId): void
     {
         $this->billingAgreementId = $billingAgreementId;
+    }
+
+    public function getSaleId(): ?string
+    {
+        return $this->saleId;
+    }
+
+    public function setSaleId(?string $saleId): void
+    {
+        $this->saleId = $saleId;
+    }
+
+    public function getRefundReasonCode(): ?string
+    {
+        return $this->refundReasonCode;
+    }
+
+    public function setRefundReasonCode(?string $refundReasonCode): void
+    {
+        $this->refundReasonCode = $refundReasonCode;
     }
 
     public function getUpdateTime(): string


### PR DESCRIPTION
In case of a subscription paypal sends on a refunded event a sale_id which needs to be processed

```
{
	"id": "WH-4WC41486LS255750P-0CT33585DP757742C",
	"create_time": "2020-10-01T13:25:03.806Z",
	"resource_type": "refund",
	"event_type": "PAYMENT.SALE.REFUNDED",
	"summary": "A EUR 0.12 EUR sale payment was refunded",
	"resource": {
		"sale_id": "3B674008WD805193D",
		"refund_reason_code": "REFUND",
....
```