### PR TITLE
fix: Always patch PayPal ordernumber

### DIFF
--- a/src/OrdersApi/Builder/OrderFromOrderBuilder.php
+++ b/src/OrdersApi/Builder/OrderFromOrderBuilder.php
@@ -95,7 +95,13 @@ class OrderFromOrderBuilder extends AbstractOrderBuilder
         $purchaseUnit->setShipping($shipping);
         $purchaseUnit->setCustomId($orderTransaction->getId());
         $orderNumber = $order->getOrderNumber();
+
         if ($orderNumber !== null) {
+            if ($settings->getSendOrderNumber()) {
+                $orderNumberPrefix = (string) $settings->getOrderNumberPrefix();
+                $orderNumber = $orderNumberPrefix . $orderNumber;
+            }
+
             $purchaseUnit->setInvoiceId($orderNumber);
         }
 

--- a/tests/OrdersApi/Builder/OrderFromOrderBuilderTest.php
+++ b/tests/OrdersApi/Builder/OrderFromOrderBuilderTest.php
@@ -103,4 +103,24 @@ class OrderFromOrderBuilderTest extends TestCase
             $customer
         );
     }
+
+    public function testGetOrderPrefix(): void
+    {
+        $paymentTransaction = $this->createPaymentTransactionStruct(ConstantsForTesting::VALID_ORDER_ID);
+        $salesChannelContext = $this->createSalesChannelContext($this->getContainer(), new PaymentMethodCollection());
+        $customer = $salesChannelContext->getCustomer();
+        static::assertNotNull($customer);
+
+        $settings = $this->createDefaultSettingStruct();
+        $settings->setOrderNumberPrefix('foo');
+        $orderBuilder = $this->createOrderBuilder($settings);
+
+        $order = $orderBuilder->getOrder(
+            $paymentTransaction,
+            $salesChannelContext,
+            $customer
+        );
+
+        static::assertStringStartsWith('foo', $order->getPurchaseUnits()[0]->getInvoiceId());
+    }
 }


### PR DESCRIPTION
A customer of ours wanted to have a prefix but with PayPal Plus disabled.
In this case the order number is not patched and the standard Shopware order number is used, see:
https://github.com/shopwareLabs/SwagPayPal/blob/2.2.5/src/Checkout/Payment/Handler/PayPalHandler.php#L144

I guess this PR is not complete, since there are probably cases when the order number should not be patched, looking forward to some feedback.