### PR TITLE
fix: PayPal upon invoice disclaimer position

### DIFF
--- a/src/Resources/views/storefront/component/ecs-spb-checkout/ecs-spb-data.html.twig
+++ b/src/Resources/views/storefront/component/ecs-spb-checkout/ecs-spb-data.html.twig
@@ -63,7 +63,6 @@
             <input type="hidden" name="{{ constant('Swag\\PayPal\\Checkout\\Payment\\Method\\PUIHandler::PUI_FRAUD_NET_SESSION_ID') }}" value="{{ puiFraudnetData.sessionIdentifier }}">
         {% endblock %}
 
-        <div class="text-muted mb-3">{{ "paypal.payUponInvoice.checkout.confirmDisclaimer"|trans|raw }}</div>
     {% elseif sepaData and sepaData.paymentMethodId is same as(context.paymentMethod.id) %}
 
         {% block swag_paypal_ecs_spb_data_sepa_fields %}

--- a/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -4,6 +4,12 @@
 } %}
 
 {% block page_checkout_confirm_form_submit %}
+    {# @var \Swag\PayPal\Checkout\PUI\PUIFraudNetData acdcFieldData #}
+    {% set puiFraudnetData = page.extensions[constant('Swag\\PayPal\\Checkout\\PUI\\PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID')] %}
+    {% if puiFraudnetData and puiFraudnetData.paymentMethodId is same as(context.paymentMethod.id) %}
+        <div class="text-muted mb-3">{{ "paypal.payUponInvoice.checkout.confirmDisclaimer"|trans|raw }}</div>
+    {% endif %}
+    
     {{ parent() }}
 
     {% block page_checkout_confirm_form_submit_paypal_container %}


### PR DESCRIPTION
From a legal point of view, a disclaimer positioned after the Buy button is not part of the purchase contract. For this reason, the disclaimer should be positioned before the buy button.

With this change, I have moved the disclaimer before the buy button to ensure that the disclaimer is part of the purchase contract.

See also https://feedback.shopware.com/forums/942607-shopware-6-product-feedback-ideas/suggestions/46909828-paypal-invoice-disclaimer-above-the-button