### PR TITLE
Fixed return value of ItemListProvider::getTaxRate()

### DIFF
--- a/src/OrdersApi/Builder/Util/ItemListProvider.php
+++ b/src/OrdersApi/Builder/Util/ItemListProvider.php
@@ -163,7 +163,7 @@ class ItemListProvider
             return 0.0;
         }
 
-        return $calculatedTax->getTaxRate();
+        return round($calculatedTax->getTaxRate(), 4);
     }
 
     private function hasMismatchingPrice(OrderLineItemEntity|LineItem $lineItem, Item $item, bool $isNet, string $currencyCode): bool


### PR DESCRIPTION
$calculatedTax->getTaxRate() may return float values that are invalid with the PayPal API