### PR TITLE
Fixed self closing tags for apple pay and google pay

### DIFF
--- a/src/Resources/views/storefront/component/ecs-spb-checkout/ecs-spb-data.html.twig
+++ b/src/Resources/views/storefront/component/ecs-spb-checkout/ecs-spb-data.html.twig
@@ -97,8 +97,8 @@
             <div
                 class="swag-paypal-ecs-spb-apple-pay"
                 data-swag-paypal-apple-pay="true"
-                data-swag-paypal-apple-pay-options="{{ applePayData|json_encode }}"
-            />
+                data-swag-paypal-apple-pay-options="{{ applePayData|json_encode }}">
+            </div>
         {% endblock %}
 
     {% elseif googlePayData and googlePayData.paymentMethodId is same as(context.paymentMethod.id) %}
@@ -107,8 +107,8 @@
             <div
                 class="swag-paypal-ecs-spb-google-pay"
                 data-swag-paypal-google-pay="true"
-                data-swag-paypal-google-pay-options="{{ googlePayData|json_encode }}"
-            />
+                data-swag-paypal-google-pay-options="{{ googlePayData|json_encode }}">
+            </div>
         {% endblock %}
 
     {% endif %}


### PR DESCRIPTION
The self closing ```</div>``` for apple pay and google pay result in invalid HTML. Empty tags don't work in some browsers and lead to content shift in the DOM, which also decreases compatibility with third party extensions.