### PR TITLE
feature: added possibility to have a proxied webhook url

### DIFF
--- a/src/Resources/config/packages/shopware.yaml
+++ b/src/Resources/config/packages/shopware.yaml
@@ -8,3 +8,6 @@ shopware:
             SWAG_PAYPAL__API_CANNOT_BE_ZERO_OR_NEGATIVE: notice
             SWAG_PAYPAL__API_PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED: notice
             SWAG_PAYPAL__API_PAYMENT_SOURCE_DECLINED_BY_PROCESSOR: notice
+    paypal:
+        webhook_proxy_url: null
+

--- a/src/Resources/config/services/webhook.xml
+++ b/src/Resources/config/services/webhook.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="Swag\PayPal\Webhook\WebhookRegistry"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="router"/>
+            <argument>%shopware.paypal.webhook_proxy_url%</argument>
         </service>
 
         <!-- handler registry -->


### PR DESCRIPTION
The reason for this pr is a structure where shopware is not accessible from the internet. Only required endpoints are to be routed to shopware (`/store-api/`, WebHooks, ...) using a proxy.

This PR is to make this possible for SwagPayPal.