### PR TITLE
⚠️ Broken WebHook: Fix wrong class for Amount in LastPayment - Swag\PayPal 8.4.1 

### DIFF
--- a/src/RestApi/V1/Api/Subscription/BillingInfo/LastPayment.php
+++ b/src/RestApi/V1/Api/Subscription/BillingInfo/LastPayment.php
@@ -10,7 +10,7 @@ namespace Swag\PayPal\RestApi\V1\Api\Subscription\BillingInfo;
 use OpenApi\Attributes as OA;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\RestApi\PayPalApiStruct;
-use Swag\PayPal\RestApi\V1\Api\Common\Amount;
+use Swag\PayPal\RestApi\V1\Api\Common\Money;
 
 /**
  * @codeCoverageIgnore
@@ -24,18 +24,18 @@ use Swag\PayPal\RestApi\V1\Api\Common\Amount;
 #[Package('checkout')]
 class LastPayment extends PayPalApiStruct
 {
-    #[OA\Property(ref: Amount::class)]
-    protected Amount $amount;
+    #[OA\Property(ref: Money::class)]
+    protected Money $amount;
 
     #[OA\Property(type: 'string')]
     protected string $time;
 
-    public function getAmount(): Amount
+    public function getAmount(): Money
     {
         return $this->amount;
     }
 
-    public function setAmount(Amount $amount): void
+    public function setAmount(Money $amount): void
     {
         $this->amount = $amount;
     }


### PR DESCRIPTION
### LastPayment is Using the Wrong Class for Amount

_**Base of Change is Tag 8.4.0**_

Hello,

Since updating from _PayPal 7_ to _PayPal 8_, **in Subscriptions (Api V1)** any attempt to access the `$amount` property inside `LastPayment` will fail. This issue arises because [a specific Amount class that was previously used has been changed to the Common Amount class](https://github.com/shopware/SwagPayPal/commit/39bb25eebb7266bb58c9c2fbab9552e3cbf6859c#diff-b974693fc393c01cc6f5bc0f35e76be8ef0a02ad135e70a149eb515f7f5e5094L13).

This change is understandable, given that the property name in the `LastPayment`-class is "amount," which could lead to confusion. In reality, the [amount structure in the PayPal-Api Json](https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_get) matches the [structure of the `Common/Money` class.](https://github.com/shopware/SwagPayPal/blob/trunk/src/RestApi/V1/Api/Common/Money.php) You can compare the two in the screenshots at the bottom.


The original `Amount`-Class of `LastPayment` was actually also just an extension of the `Money`-Class [as you can see here](https://github.com/shopware/SwagPayPal/blob/7.4.0/src/RestApi/V1/Api/Subscription/BillingInfo/LastPayment/Amount.php).

This issue is correctly handled in the case of [`$shippingAmount` in Subscription.php](https://github.com/shopware/SwagPayPal/commit/39bb25eebb7266bb58c9c2fbab9552e3cbf6859c#diff-7080230b6b8514dc34d5a2a1a1b5154b51a5eda6198f953200c6d836ac0876edR55). 

Currently, the `$amount`-property of `LastPayment` will always be `Null`, as the `Amount`-class cannot be instantiated due to non-matching property names [during assignment](https://github.com/shopware/SwagPayPal/blob/cabfbd170fcc64fd77f7169f22a8048906592070/src/RestApi/PayPalApiStruct.php#L23). This is a minor, non-invasive fix that should restore functionality.

####  This fix should be back-ported to all currently supported versions (8, 9 and the upcoming 10).

----
### Comparison of Api and Class
#### PayPal Api JSON

![image](https://github.com/user-attachments/assets/8c74c842-daa5-49cf-bd9d-af117649e354)

####  Common\Money Class
![image](https://github.com/user-attachments/assets/85fb1bba-e58e-4382-b9fe-75bff232bbae)
