### PR TITLE
PPI-992: Adding processor_response mapping on API V2 capture response

### DIFF
--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -1301,12 +1301,18 @@ export interface components {
       seller_protection: components["schemas"]["swag_paypal_v2_order_purchase_unit_payments_common_seller_protection"];
       final_capture: boolean;
       seller_receivable_breakdown: components["schemas"]["swag_paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown"];
+      processor_response: components["schemas"]["swag_paypal_v2_order_purchase_unit_payments_capture_processor_response"];
       disbursement_mode: string;
     };
     swag_paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown: {
       gross_amount: components["schemas"]["swag_paypal_v2_common_money"];
       paypal_fee: components["schemas"]["swag_paypal_v2_common_money"];
       net_amount: components["schemas"]["swag_paypal_v2_common_money"];
+    };
+    swag_paypal_v2_order_purchase_unit_payments_capture_processor_response: {
+      avs_code: string | null;
+      cvv_code: string | null;
+      response_code: string | null;
     };
     swag_paypal_v2_order_purchase_unit_payments_common_seller_protection: {
       status: string;

--- a/src/RestApi/V2/Api/Order/PurchaseUnit/Payments/Capture.php
+++ b/src/RestApi/V2/Api/Order/PurchaseUnit/Payments/Capture.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments;
 
 use OpenApi\Attributes as OA;
 use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments\Capture\ProcessorResponse;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments\Capture\SellerReceivableBreakdown;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments\Common\SellerProtection;
 
@@ -29,6 +30,9 @@ class Capture extends Payment
 
     #[OA\Property(ref: SellerReceivableBreakdown::class)]
     protected SellerReceivableBreakdown $sellerReceivableBreakdown;
+
+    #[OA\Property(ref: ProcessorResponse::class)]
+    protected ProcessorResponse $processorResponse;
 
     #[OA\Property(type: 'string')]
     protected string $disbursementMode;
@@ -109,5 +113,15 @@ class Capture extends Payment
     public function setDisbursementMode(string $disbursementMode): void
     {
         $this->disbursementMode = $disbursementMode;
+    }
+
+    public function getProcessorResponse(): ProcessorResponse
+    {
+        return $this->processorResponse;
+    }
+
+    public function setProcessorResponse(ProcessorResponse $processorResponse): void
+    {
+        $this->processorResponse = $processorResponse;
     }
 }

--- a/src/RestApi/V2/Api/Order/PurchaseUnit/Payments/Capture/ProcessorResponse.php
+++ b/src/RestApi/V2/Api/Order/PurchaseUnit/Payments/Capture/ProcessorResponse.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments\Capture;
+
+use OpenApi\Attributes as OA;
+use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\RestApi\PayPalApiStruct;
+
+#[OA\Schema(schema: 'swag_paypal_v2_order_purchase_unit_payments_capture_processor_response')]
+#[Package('checkout')]
+class ProcessorResponse extends PayPalApiStruct
+{
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $avsCode = null;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $cvvCode = null;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $responseCode = null;
+
+    public function getAvsCode(): ?string
+    {
+        return $this->avsCode;
+    }
+
+    public function setAvsCode(?string $avsCode): void
+    {
+        $this->avsCode = $avsCode;
+    }
+
+    public function getCvvCode(): ?string
+    {
+        return $this->cvvCode;
+    }
+
+    public function setCvvCode(?string $cvvCode): void
+    {
+        $this->cvvCode = $cvvCode;
+    }
+
+    public function getResponseCode(): ?string
+    {
+        return $this->responseCode;
+    }
+
+    public function setResponseCode(?string $responseCode): void
+    {
+        $this->responseCode = $responseCode;
+    }
+}

--- a/tests/Mock/PayPal/Client/_fixtures/V2/GetCapture.php
+++ b/tests/Mock/PayPal/Client/_fixtures/V2/GetCapture.php
@@ -49,6 +49,11 @@ class GetCapture
                     'value' => '55.35',
                 ],
             ],
+            'processor_response' => [
+                'response_code' => '1000',
+                'avs_code' => 'N',
+                'cvv_code' => 'M',
+            ],
             'invoice_id' => 'testCaptureInvoiceId',
             'links' => [
                 0 => [


### PR DESCRIPTION
Having processor_response mapped and available on Capture response is usefull to understand eventual declines on Credit Card payments processed through Paypal "Advanced Payments".

ProcessorResponse->responseCode in detail, can help support operators to understand the reason of decline on card capture.