### PR TITLE
Fix: make  Webhook resource-type subscription compatible

### DIFF
--- a/src/RestApi/V1/Api/Webhook.php
+++ b/src/RestApi/V1/Api/Webhook.php
@@ -26,6 +26,7 @@ class Webhook extends PayPalApiStruct
     public const RESOURCE_TYPE_CAPTURE = 'capture';
     public const RESOURCE_TYPE_REFUND = 'refund';
     public const RESOURCE_TYPE_PAYMENT_TOKEN = 'payment_token';
+    public const RESOURCE_TYPE_SUBSCRIPTION = 'subscription'; 
 
     #[OA\Property(type: 'string')]
     protected string $id;
@@ -45,6 +46,7 @@ class Webhook extends PayPalApiStruct
         new OA\Schema(ref: Capture::class),
         new OA\Schema(ref: Refund::class),
         new OA\Schema(ref: Resource::class),
+        new OA\Schema(ref: Subscription::class),
     ])]
     protected ?PayPalApiStruct $resource = null;
 
@@ -188,6 +190,7 @@ class Webhook extends PayPalApiStruct
                 self::RESOURCE_TYPE_AUTHORIZATION => Authorization::class,
                 self::RESOURCE_TYPE_CAPTURE => Capture::class,
                 self::RESOURCE_TYPE_REFUND => Refund::class,
+                self::RESOURCE_TYPE_SUBSCRIPTION => Subscription::class,
                 default => null,
             },
             default => Resource::class,


### PR DESCRIPTION
### Webhooks are not compatible with Subscriptions since version 8.0.0

The current [Webhook.php](https://github.com/shopware/SwagPayPal/blob/trunk/src/RestApi/V1/Api/Webhook.php) is missing compatibility for the _resource type_ `'subscription'`.

Here you can see on [developer.paypal.com](https://developer.paypal.com) how a webhook can send this resource type:
![image](https://github.com/user-attachments/assets/5edd512d-35bf-4f47-9bd7-167ae7046628)

The resource itself is structurally compatible with [Subscription.php](https://github.com/shopware/SwagPayPal/blob/trunk/src/RestApi/V1/Api/Subscription.php).

You can see this with this example JSON here:
![image](https://github.com/user-attachments/assets/3fba909a-1d8e-4f06-81b7-525b8c43eb34)

I tested it with the changes below, and it works.
Before, the serializer would default the `resource` property to `null`.

### Affected Versions

The changes need to be implemented for older versions as well. They should be applied **to all versions from 8.0 onward**.

I hope this information is sufficient.

Thank you for your work.