### PR TITLE
fix: remove prefixes from openapi schemas

### DIFF
--- a/src/Administration/PayPalPaymentMethodController.php
+++ b/src/Administration/PayPalPaymentMethodController.php
@@ -33,12 +33,12 @@ class PayPalPaymentMethodController extends AbstractController
      * @phpstan-ignore-next-line
      */
     #[OA\Post(
-        path: '/api/_action/paypal/saleschannel-default',
+        path: '/_action/paypal/saleschannel-default',
         operationId: 'setPayPalAsDefault',
-        description: 'Sets PayPal as the default payment method for a given Saleschannel, or all.',
+        description: 'Sets PayPal as the default payment method for a given SalesChannel, or all.',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [new OA\Property(
             property: 'salesChannelId',
-            description: 'The id of the Saleschannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel.',
+            description: 'The id of the SalesChannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel.',
             type: 'string',
             nullable: true
         )])),

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -47,7 +47,7 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
     }
 
     #[OA\Post(
-        path: '/store-api/paypal/express/create-order',
+        path: '/paypal/express/create-order',
         operationId: 'createPayPalExpressOrder',
         description: 'Creates a PayPal order from the existing cart',
         tags: ['Store API', 'PayPal'],

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
@@ -49,7 +49,7 @@ class ExpressPrepareCheckoutRoute extends AbstractExpressPrepareCheckoutRoute
     }
 
     #[OA\Post(
-        path: '/store-api/paypal/express/prepare-checkout',
+        path: '/paypal/express/prepare-checkout',
         operationId: 'preparePayPalExpressCheckout',
         description: 'Logs in a guest customer, with the data of a paypal order',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [new OA\Property(

--- a/src/Checkout/PUI/SalesChannel/PUIPaymentInstructionsRoute.php
+++ b/src/Checkout/PUI/SalesChannel/PUIPaymentInstructionsRoute.php
@@ -42,7 +42,7 @@ class PUIPaymentInstructionsRoute extends AbstractPUIPaymentInstructionsRoute
      * @throws ShopwareHttpException
      */
     #[OA\Get(
-        path: '/store-api/paypal/pui/payment-instructions/{transactionId}',
+        path: '/paypal/pui/payment-instructions/{transactionId}',
         operationId: 'getPUIPaymentInstructions',
         description: 'Tries to get payment instructions for PUI payments',
         tags: ['Store API', 'PayPal'],

--- a/src/Checkout/SalesChannel/ClearVaultRoute.php
+++ b/src/Checkout/SalesChannel/ClearVaultRoute.php
@@ -38,7 +38,7 @@ class ClearVaultRoute extends AbstractClearVaultRoute
     }
 
     #[OA\Post(
-        path: '/store-api/paypal/vault/clear',
+        path: '/paypal/vault/clear',
         operationId: 'paypalVaultClear',
         description: 'Clears the vault for the current customer',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [

--- a/src/Checkout/SalesChannel/CreateOrderRoute.php
+++ b/src/Checkout/SalesChannel/CreateOrderRoute.php
@@ -69,7 +69,7 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
      * @throws CustomerNotLoggedInException
      */
     #[OA\Post(
-        path: '/store-api/paypal/create-order',
+        path: '/paypal/create-order',
         operationId: 'createPayPalOrder',
         description: 'Creates a PayPal order from the existing cart or an order',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [

--- a/src/Checkout/SalesChannel/MethodEligibilityRoute.php
+++ b/src/Checkout/SalesChannel/MethodEligibilityRoute.php
@@ -56,7 +56,7 @@ class MethodEligibilityRoute extends AbstractMethodEligibilityRoute
      * @phpstan-ignore-next-line
      */
     #[OA\Post(
-        path: '/store-api/paypal/payment-method-eligibility',
+        path: '/paypal/payment-method-eligibility',
         operationId: 'setPaymentMethodEligibility',
         description: 'Sets ineligible payment methods to be removed from the session',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [

--- a/src/Dispute/Administration/DisputeController.php
+++ b/src/Dispute/Administration/DisputeController.php
@@ -36,7 +36,7 @@ class DisputeController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/dispute',
+        path: '/paypal/dispute',
         operationId: 'disputeList',
         description: 'Loads a list of PayPal disputes',
         tags: ['Admin API', 'PayPal'],
@@ -82,7 +82,7 @@ class DisputeController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/dispute/{disputeId}',
+        path: '/paypal/dispute/{disputeId}',
         operationId: 'disputeDetails',
         description: 'Loads the dispute details of the given PayPal dispute ID',
         tags: ['Admin API', 'PayPal'],

--- a/src/OrdersApi/Administration/PayPalOrdersController.php
+++ b/src/OrdersApi/Administration/PayPalOrdersController.php
@@ -56,7 +56,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal-v2/order/{orderTransactionId}/{paypalOrderId}',
+        path: '/paypal-v2/order/{orderTransactionId}/{paypalOrderId}',
         operationId: 'orderDetails',
         description: 'Loads the order details of the given PayPal order ID',
         tags: ['Admin API', 'PayPal'],
@@ -104,7 +104,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal-v2/authorization/{orderTransactionId}/{authorizationId}',
+        path: '/paypal-v2/authorization/{orderTransactionId}/{authorizationId}',
         operationId: 'authorizationDetails',
         description: 'Loads the authorization details of the given PayPal authorization ID',
         tags: ['Admin API', 'PayPal'],
@@ -144,7 +144,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal-v2/capture/{orderTransactionId}/{captureId}',
+        path: '/paypal-v2/capture/{orderTransactionId}/{captureId}',
         operationId: 'captureDetails',
         description: 'Loads the capture details of the given PayPal capture ID',
         tags: ['Admin API', 'PayPal'],
@@ -184,7 +184,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal-v2/refund/{orderTransactionId}/{refundId}',
+        path: '/paypal-v2/refund/{orderTransactionId}/{refundId}',
         operationId: 'refundDetails',
         description: 'Loads the refund details of the given PayPal refund ID',
         tags: ['Admin API', 'PayPal'],
@@ -224,7 +224,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}',
+        path: '/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}',
         operationId: 'refundCapture',
         description: 'Refunds the PayPal capture and sets the state of the Shopware order transaction accordingly',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
@@ -267,7 +267,7 @@ class PayPalOrdersController extends AbstractController
             content: new OA\JsonContent(ref: Order\PurchaseUnit\Payments\Refund::class)
         )]
     )]
-    #[Route(path: '/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}', name: 'api.action.paypal_v2.refund_capture', defaults: ['_acl' => ['order.editor']], methods: ['POST'])]
+    #[Route(path: '/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}', name: 'api.action.paypal_v2.refund_capture', defaults: ['_acl' => ['order.editor']], methods: ['POST'])]
     public function refundCapture(
         string $orderTransactionId,
         string $captureId,
@@ -294,7 +294,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}',
+        path: '/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}',
         operationId: 'captureAuthorization',
         description: 'Captures the PayPal authorization and sets the state of the Shopware order transaction accordingly',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
@@ -330,7 +330,7 @@ class PayPalOrdersController extends AbstractController
             content: new OA\JsonContent(ref: Order\PurchaseUnit\Payments\Capture::class)
         )]
     )]
-    #[Route(path: '/api/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}', name: 'api.action.paypal_v2.capture_authorization', defaults: ['_acl' => ['order.editor']], methods: ['POST'])]
+    #[Route(path: '/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}', name: 'api.action.paypal_v2.capture_authorization', defaults: ['_acl' => ['order.editor']], methods: ['POST'])]
     public function captureAuthorization(
         string $orderTransactionId,
         string $authorizationId,
@@ -353,7 +353,7 @@ class PayPalOrdersController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}',
+        path: '/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}',
         operationId: 'voidAuthorization',
         description: 'Voids the PayPal authorization and sets the state of the Shopware order transaction accordingly',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [

--- a/src/PaymentsApi/Administration/PayPalPaymentController.php
+++ b/src/PaymentsApi/Administration/PayPalPaymentController.php
@@ -85,7 +85,7 @@ class PayPalPaymentController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/payment-details/{orderId}/{paymentId}',
+        path: '/paypal/payment-details/{orderId}/{paymentId}',
         operationId: 'paymentDetails',
         description: 'Loads the Payment details of the given PayPal ID',
         tags: ['Admin API', 'PayPal'],
@@ -128,7 +128,7 @@ class PayPalPaymentController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/resource-details/{resourceType}/{resourceId}/{orderId}',
+        path: '/paypal/resource-details/{resourceType}/{resourceId}/{orderId}',
         operationId: 'resourceDetails',
         description: 'Loads the PayPal resource details of the given resource ID',
         tags: ['Admin API', 'PayPal'],
@@ -200,7 +200,7 @@ class PayPalPaymentController extends AbstractController
      * @deprecated tag:v10.0.0 - will be removed without replacement
      */
     #[OA\Post(
-        path: '/api/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}',
+        path: '/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}',
         operationId: 'paypalRefundPayment',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -276,7 +276,7 @@ class PayPalPaymentController extends AbstractController
      * @deprecated tag:v10.0.0 - will be removed without replacement
      */
     #[OA\Post(
-        path: '/api/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}',
+        path: '/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}',
         operationId: 'paypalCapturePayment',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -347,7 +347,7 @@ class PayPalPaymentController extends AbstractController
      * @deprecated tag:v10.0.0 - will be removed without replacement
      */
     #[OA\Post(
-        path: '/api/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}',
+        path: '/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}',
         operationId: 'paypalVoidPayment',
         tags: ['Admin Api', 'PayPal'],
         parameters: [

--- a/src/Pos/PosSyncController.php
+++ b/src/Pos/PosSyncController.php
@@ -51,7 +51,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/{salesChannelId}/products',
+        path: '/_action/paypal/pos/sync/{salesChannelId}/products',
         operationId: 'posSyncProducts',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -83,7 +83,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/{salesChannelId}/images',
+        path: '/_action/paypal/pos/sync/{salesChannelId}/images',
         operationId: 'posSyncImages',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -115,7 +115,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/{salesChannelId}/inventory',
+        path: '/_action/paypal/pos/sync/{salesChannelId}/inventory',
         operationId: 'posSyncInventory',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -147,7 +147,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/{salesChannelId}',
+        path: '/_action/paypal/pos/sync/{salesChannelId}',
         operationId: 'posSync',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -179,7 +179,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/abort/{runId}',
+        path: '/_action/paypal/pos/sync/abort/{runId}',
         operationId: 'posSyncAbort',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -202,7 +202,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/sync/reset/{salesChannelId}',
+        path: '/_action/paypal/pos/sync/reset/{salesChannelId}',
         operationId: 'posSyncReset',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -227,7 +227,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/log/cleanup/{salesChannelId}',
+        path: '/_action/paypal/pos/log/cleanup/{salesChannelId}',
         operationId: 'posSyncCleanup',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -252,7 +252,7 @@ class PosSyncController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/pos/product-log/{salesChannelId}',
+        path: '/paypal/pos/product-log/{salesChannelId}',
         operationId: 'posProductLog',
         tags: ['Admin Api', 'PayPal'],
         parameters: [

--- a/src/Pos/Setting/SettingsController.php
+++ b/src/Pos/Setting/SettingsController.php
@@ -42,7 +42,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/validate-api-credentials',
+        path: '/_action/paypal/pos/validate-api-credentials',
         operationId: 'posValidateApiCredentials',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
             new OA\Property(
@@ -87,7 +87,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/paypal/pos/fetch-information',
+        path: '/paypal/pos/fetch-information',
         operationId: 'posFetchInformation',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
             new OA\Property(
@@ -118,7 +118,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/clone-product-visibility',
+        path: '/_action/paypal/pos/clone-product-visibility',
         operationId: 'posCloneProductVisibility',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
             new OA\Property(
@@ -150,7 +150,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/paypal/pos/product-count',
+        path: '/paypal/pos/product-count',
         operationId: 'posGetProductCounts',
         tags: ['Admin Api', 'PayPal'],
         parameters: [

--- a/src/Pos/Webhook/WebhookController.php
+++ b/src/Pos/Webhook/WebhookController.php
@@ -47,7 +47,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/webhook/registration/{salesChannelId}',
+        path: '/_action/paypal/pos/webhook/registration/{salesChannelId}',
         operationId: 'registerPosWebhook',
         tags: ['Admin Api', 'SwagPayPalPosWebhook'],
         parameters: [new OA\Parameter(
@@ -67,7 +67,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Delete(
-        path: '/api/_action/paypal/pos/webhook/registration/{salesChannelId}',
+        path: '/_action/paypal/pos/webhook/registration/{salesChannelId}',
         operationId: 'deregisterPosWebhook',
         tags: ['Admin Api', 'SwagPayPalPosWebhook'],
         parameters: [new OA\Parameter(
@@ -87,7 +87,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/pos/webhook/execute/{salesChannelId}',
+        path: '/_action/paypal/pos/webhook/execute/{salesChannelId}',
         operationId: 'executePosWebhook',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(ref: Webhook::class)),
         tags: ['Admin Api', 'SwagPayPalPosWebhook'],

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -1,13 +1,13 @@
 {
     "openapi": "3.0.0",
     "paths": {
-        "/api/_action/paypal/saleschannel-default": {
+        "/_action/paypal/saleschannel-default": {
             "post": {
                 "tags": [
                     "Admin Api",
                     "SwagPayPalPaymentMethod"
                 ],
-                "description": "Sets PayPal as the default payment method for a given Saleschannel, or all.",
+                "description": "Sets PayPal as the default payment method for a given SalesChannel, or all.",
                 "operationId": "setPayPalAsDefault",
                 "requestBody": {
                     "content": {
@@ -15,7 +15,7 @@
                             "schema": {
                                 "properties": {
                                     "salesChannelId": {
-                                        "description": "The id of the Saleschannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel.",
+                                        "description": "The id of the SalesChannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel.",
                                         "type": "string",
                                         "nullable": true
                                     }
@@ -32,7 +32,7 @@
                 }
             }
         },
-        "/api/paypal/dispute": {
+        "/paypal/dispute": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -75,7 +75,7 @@
                 }
             }
         },
-        "/api/paypal/dispute/{disputeId}": {
+        "/paypal/dispute/{disputeId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -119,7 +119,7 @@
                 }
             }
         },
-        "/api/paypal-v2/order/{orderTransactionId}/{paypalOrderId}": {
+        "/paypal-v2/order/{orderTransactionId}/{paypalOrderId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -164,7 +164,7 @@
                 }
             }
         },
-        "/api/paypal-v2/authorization/{orderTransactionId}/{authorizationId}": {
+        "/paypal-v2/authorization/{orderTransactionId}/{authorizationId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -210,7 +210,7 @@
                 }
             }
         },
-        "/api/paypal-v2/capture/{orderTransactionId}/{captureId}": {
+        "/paypal-v2/capture/{orderTransactionId}/{captureId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -255,7 +255,7 @@
                 }
             }
         },
-        "/api/paypal-v2/refund/{orderTransactionId}/{refundId}": {
+        "/paypal-v2/refund/{orderTransactionId}/{refundId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -300,7 +300,7 @@
                 }
             }
         },
-        "/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}": {
+        "/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}": {
             "post": {
                 "tags": [
                     "Admin API",
@@ -386,7 +386,7 @@
                 }
             }
         },
-        "/api/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}": {
+        "/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}": {
             "post": {
                 "tags": [
                     "Admin API",
@@ -466,7 +466,7 @@
                 }
             }
         },
-        "/api/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}": {
+        "/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}": {
             "post": {
                 "tags": [
                     "Admin API",
@@ -519,7 +519,7 @@
                 }
             }
         },
-        "/api/paypal/payment-details/{orderId}/{paymentId}": {
+        "/paypal/payment-details/{orderId}/{paymentId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -562,7 +562,7 @@
                 }
             }
         },
-        "/api/paypal/resource-details/{resourceType}/{resourceId}/{orderId}": {
+        "/paypal/resource-details/{resourceType}/{resourceId}/{orderId}": {
             "get": {
                 "tags": [
                     "Admin API",
@@ -633,7 +633,7 @@
                 }
             }
         },
-        "/api/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}": {
+        "/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -688,7 +688,7 @@
                 }
             }
         },
-        "/api/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}": {
+        "/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -743,7 +743,7 @@
                 }
             }
         },
-        "/api/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}": {
+        "/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -798,7 +798,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/{salesChannelId}/products": {
+        "/_action/paypal/pos/sync/{salesChannelId}/products": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -836,7 +836,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/{salesChannelId}/images": {
+        "/_action/paypal/pos/sync/{salesChannelId}/images": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -874,7 +874,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/{salesChannelId}/inventory": {
+        "/_action/paypal/pos/sync/{salesChannelId}/inventory": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -912,7 +912,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/{salesChannelId}": {
+        "/_action/paypal/pos/sync/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -950,7 +950,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/abort/{runId}": {
+        "/_action/paypal/pos/sync/abort/{runId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -975,7 +975,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/sync/reset/{salesChannelId}": {
+        "/_action/paypal/pos/sync/reset/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1001,7 +1001,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/log/cleanup/{salesChannelId}": {
+        "/_action/paypal/pos/log/cleanup/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1027,7 +1027,7 @@
                 }
             }
         },
-        "/api/paypal/pos/product-log/{salesChannelId}": {
+        "/paypal/pos/product-log/{salesChannelId}": {
             "get": {
                 "tags": [
                     "Admin Api",
@@ -1075,7 +1075,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/validate-api-credentials": {
+        "/_action/paypal/pos/validate-api-credentials": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1119,7 +1119,7 @@
                 }
             }
         },
-        "/api/paypal/pos/fetch-information": {
+        "/paypal/pos/fetch-information": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1154,7 +1154,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/clone-product-visibility": {
+        "/_action/paypal/pos/clone-product-visibility": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1187,7 +1187,7 @@
                 }
             }
         },
-        "/api/paypal/pos/product-count": {
+        "/paypal/pos/product-count": {
             "get": {
                 "tags": [
                     "Admin Api",
@@ -1230,7 +1230,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/webhook/registration/{salesChannelId}": {
+        "/_action/paypal/pos/webhook/registration/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1278,7 +1278,7 @@
                 }
             }
         },
-        "/api/_action/paypal/pos/webhook/execute/{salesChannelId}": {
+        "/_action/paypal/pos/webhook/execute/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1312,7 +1312,7 @@
                 }
             }
         },
-        "/api/_action/paypal/validate-api-credentials": {
+        "/_action/paypal/validate-api-credentials": {
             "get": {
                 "tags": [
                     "Admin Api",
@@ -1368,7 +1368,7 @@
                 }
             }
         },
-        "/api/_action/paypal/test-api-credentials": {
+        "/_action/paypal/test-api-credentials": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1404,7 +1404,7 @@
                 }
             }
         },
-        "/api/_action/paypal/get-api-credentials": {
+        "/_action/paypal/get-api-credentials": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1451,7 +1451,7 @@
                 }
             }
         },
-        "/api/_action/paypal/merchant-information": {
+        "/_action/paypal/merchant-information": {
             "get": {
                 "tags": [
                     "Admin Api",
@@ -1484,7 +1484,7 @@
                 }
             }
         },
-        "/api/_action/paypal/save-settings": {
+        "/_action/paypal/save-settings": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1508,7 +1508,7 @@
                 }
             }
         },
-        "/api/_action/paypal/webhook/status/{salesChannelId}": {
+        "/_action/paypal/webhook/status/{salesChannelId}": {
             "get": {
                 "tags": [
                     "Admin Api",
@@ -1545,7 +1545,7 @@
                 }
             }
         },
-        "/api/_action/paypal/webhook/register/{salesChannelId}": {
+        "/_action/paypal/webhook/register/{salesChannelId}": {
             "post": {
                 "tags": [
                     "Admin Api",
@@ -1582,7 +1582,7 @@
                 }
             }
         },
-        "/api/_action/paypal/webhook/deregister/{salesChannelId}": {
+        "/_action/paypal/webhook/deregister/{salesChannelId}": {
             "delete": {
                 "tags": [
                     "Admin Api",
@@ -1619,7 +1619,7 @@
                 }
             }
         },
-        "/api/_action/paypal/webhook/execute": {
+        "/_action/paypal/webhook/execute": {
             "post": {
                 "tags": [
                     "Admin Api",

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.0",
     "paths": {
-        "/store-api/paypal/express/create-order": {
+        "/paypal/express/create-order": {
             "post": {
                 "tags": [
                     "Store API",
@@ -16,7 +16,7 @@
                 }
             }
         },
-        "/store-api/paypal/express/prepare-checkout": {
+        "/paypal/express/prepare-checkout": {
             "post": {
                 "tags": [
                     "Store API",
@@ -58,7 +58,7 @@
                 }
             }
         },
-        "/store-api/paypal/pui/payment-instructions/{transactionId}": {
+        "/paypal/pui/payment-instructions/{transactionId}": {
             "get": {
                 "tags": [
                     "Store API",
@@ -85,7 +85,7 @@
                 }
             }
         },
-        "/store-api/paypal/vault/clear": {
+        "/paypal/vault/clear": {
             "post": {
                 "tags": [
                     "Store API",
@@ -119,7 +119,7 @@
                 }
             }
         },
-        "/store-api/paypal/create-order": {
+        "/paypal/create-order": {
             "post": {
                 "tags": [
                     "Store API",
@@ -166,7 +166,7 @@
                 }
             }
         },
-        "/store-api/paypal/payment-method-eligibility": {
+        "/paypal/payment-method-eligibility": {
             "post": {
                 "tags": [
                     "Store API",

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -5,131 +5,131 @@
 
 
 export interface paths {
-  "/api/_action/paypal/saleschannel-default": {
-    /** @description Sets PayPal as the default payment method for a given Saleschannel, or all. */
+  "/_action/paypal/saleschannel-default": {
+    /** @description Sets PayPal as the default payment method for a given SalesChannel, or all. */
     post: operations["setPayPalAsDefault"];
   };
-  "/api/paypal/dispute": {
+  "/paypal/dispute": {
     /** @description Loads a list of PayPal disputes */
     get: operations["disputeList"];
   };
-  "/api/paypal/dispute/{disputeId}": {
+  "/paypal/dispute/{disputeId}": {
     /** @description Loads the dispute details of the given PayPal dispute ID */
     get: operations["disputeDetails"];
   };
-  "/api/paypal-v2/order/{orderTransactionId}/{paypalOrderId}": {
+  "/paypal-v2/order/{orderTransactionId}/{paypalOrderId}": {
     /** @description Loads the order details of the given PayPal order ID */
     get: operations["orderDetails"];
   };
-  "/api/paypal-v2/authorization/{orderTransactionId}/{authorizationId}": {
+  "/paypal-v2/authorization/{orderTransactionId}/{authorizationId}": {
     /** @description Loads the authorization details of the given PayPal authorization ID */
     get: operations["authorizationDetails"];
   };
-  "/api/paypal-v2/capture/{orderTransactionId}/{captureId}": {
+  "/paypal-v2/capture/{orderTransactionId}/{captureId}": {
     /** @description Loads the capture details of the given PayPal capture ID */
     get: operations["captureDetails"];
   };
-  "/api/paypal-v2/refund/{orderTransactionId}/{refundId}": {
+  "/paypal-v2/refund/{orderTransactionId}/{refundId}": {
     /** @description Loads the refund details of the given PayPal refund ID */
     get: operations["refundDetails"];
   };
-  "/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}": {
+  "/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}": {
     /** @description Refunds the PayPal capture and sets the state of the Shopware order transaction accordingly */
     post: operations["refundCapture"];
   };
-  "/api/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}": {
+  "/_action/paypal-v2/capture-authorization/{orderTransactionId}/{authorizationId}": {
     /** @description Captures the PayPal authorization and sets the state of the Shopware order transaction accordingly */
     post: operations["captureAuthorization"];
   };
-  "/api/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}": {
+  "/_action/paypal-v2/void-authorization/{orderTransactionId}/{authorizationId}": {
     /** @description Voids the PayPal authorization and sets the state of the Shopware order transaction accordingly */
     post: operations["voidAuthorization"];
   };
-  "/api/paypal/payment-details/{orderId}/{paymentId}": {
+  "/paypal/payment-details/{orderId}/{paymentId}": {
     /** @description Loads the Payment details of the given PayPal ID */
     get: operations["paymentDetails"];
   };
-  "/api/paypal/resource-details/{resourceType}/{resourceId}/{orderId}": {
+  "/paypal/resource-details/{resourceType}/{resourceId}/{orderId}": {
     /** @description Loads the PayPal resource details of the given resource ID */
     get: operations["resourceDetails"];
   };
-  "/api/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}": {
+  "/_action/paypal/refund-payment/{resourceType}/{resourceId}/{orderId}": {
     post: operations["paypalRefundPayment"];
   };
-  "/api/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}": {
+  "/_action/paypal/capture-payment/{resourceType}/{resourceId}/{orderId}": {
     post: operations["paypalCapturePayment"];
   };
-  "/api/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}": {
+  "/_action/paypal/void-payment/{resourceType}/{resourceId}/{orderId}": {
     post: operations["paypalVoidPayment"];
   };
-  "/api/_action/paypal/pos/sync/{salesChannelId}/products": {
+  "/_action/paypal/pos/sync/{salesChannelId}/products": {
     post: operations["posSyncProducts"];
   };
-  "/api/_action/paypal/pos/sync/{salesChannelId}/images": {
+  "/_action/paypal/pos/sync/{salesChannelId}/images": {
     post: operations["posSyncImages"];
   };
-  "/api/_action/paypal/pos/sync/{salesChannelId}/inventory": {
+  "/_action/paypal/pos/sync/{salesChannelId}/inventory": {
     post: operations["posSyncInventory"];
   };
-  "/api/_action/paypal/pos/sync/{salesChannelId}": {
+  "/_action/paypal/pos/sync/{salesChannelId}": {
     post: operations["posSync"];
   };
-  "/api/_action/paypal/pos/sync/abort/{runId}": {
+  "/_action/paypal/pos/sync/abort/{runId}": {
     post: operations["posSyncAbort"];
   };
-  "/api/_action/paypal/pos/sync/reset/{salesChannelId}": {
+  "/_action/paypal/pos/sync/reset/{salesChannelId}": {
     post: operations["posSyncReset"];
   };
-  "/api/_action/paypal/pos/log/cleanup/{salesChannelId}": {
+  "/_action/paypal/pos/log/cleanup/{salesChannelId}": {
     post: operations["posSyncCleanup"];
   };
-  "/api/paypal/pos/product-log/{salesChannelId}": {
+  "/paypal/pos/product-log/{salesChannelId}": {
     get: operations["posProductLog"];
   };
-  "/api/_action/paypal/pos/validate-api-credentials": {
+  "/_action/paypal/pos/validate-api-credentials": {
     post: operations["posValidateApiCredentials"];
   };
-  "/api/paypal/pos/fetch-information": {
+  "/paypal/pos/fetch-information": {
     post: operations["posFetchInformation"];
   };
-  "/api/_action/paypal/pos/clone-product-visibility": {
+  "/_action/paypal/pos/clone-product-visibility": {
     post: operations["posCloneProductVisibility"];
   };
-  "/api/paypal/pos/product-count": {
+  "/paypal/pos/product-count": {
     get: operations["posGetProductCounts"];
   };
-  "/api/_action/paypal/pos/webhook/registration/{salesChannelId}": {
+  "/_action/paypal/pos/webhook/registration/{salesChannelId}": {
     post: operations["registerPosWebhook"];
     delete: operations["deregisterPosWebhook"];
   };
-  "/api/_action/paypal/pos/webhook/execute/{salesChannelId}": {
+  "/_action/paypal/pos/webhook/execute/{salesChannelId}": {
     post: operations["executePosWebhook"];
   };
-  "/api/_action/paypal/validate-api-credentials": {
+  "/_action/paypal/validate-api-credentials": {
     get: operations["validateApiCredentials"];
   };
-  "/api/_action/paypal/test-api-credentials": {
+  "/_action/paypal/test-api-credentials": {
     post: operations["testApiCredentials"];
   };
-  "/api/_action/paypal/get-api-credentials": {
+  "/_action/paypal/get-api-credentials": {
     post: operations["getApiCredentials"];
   };
-  "/api/_action/paypal/merchant-information": {
+  "/_action/paypal/merchant-information": {
     get: operations["getMerchantInformation"];
   };
-  "/api/_action/paypal/save-settings": {
+  "/_action/paypal/save-settings": {
     post: operations["saveSettings"];
   };
-  "/api/_action/paypal/webhook/status/{salesChannelId}": {
+  "/_action/paypal/webhook/status/{salesChannelId}": {
     get: operations["getWebhookStatus"];
   };
-  "/api/_action/paypal/webhook/register/{salesChannelId}": {
+  "/_action/paypal/webhook/register/{salesChannelId}": {
     post: operations["registerWebhook"];
   };
-  "/api/_action/paypal/webhook/deregister/{salesChannelId}": {
+  "/_action/paypal/webhook/deregister/{salesChannelId}": {
     delete: operations["deregisterWebhook"];
   };
-  "/api/_action/paypal/webhook/execute": {
+  "/_action/paypal/webhook/execute": {
     post: operations["executeWebhook"];
   };
 }
@@ -1424,12 +1424,12 @@ export type external = Record<string, never>;
 
 export interface operations {
 
-  /** @description Sets PayPal as the default payment method for a given Saleschannel, or all. */
+  /** @description Sets PayPal as the default payment method for a given SalesChannel, or all. */
   setPayPalAsDefault: {
     requestBody?: {
       content: {
         "application/json": {
-          /** @description The id of the Saleschannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel. */
+          /** @description The id of the SalesChannel where PayPal should be set as the default payment method. Set to null to set PayPal as default for every Saleschannel. */
           salesChannelId?: string | null;
         };
       };

--- a/src/Setting/SettingsController.php
+++ b/src/Setting/SettingsController.php
@@ -42,7 +42,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/_action/paypal/validate-api-credentials',
+        path: '/_action/paypal/validate-api-credentials',
         operationId: 'validateApiCredentials',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -104,7 +104,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/test-api-credentials',
+        path: '/_action/paypal/test-api-credentials',
         operationId: 'testApiCredentials',
         tags: ['Admin Api', 'PayPal'],
         responses: [new OA\Response(
@@ -161,7 +161,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/get-api-credentials',
+        path: '/_action/paypal/get-api-credentials',
         operationId: 'getApiCredentials',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
             new OA\Property(property: 'authCode', type: 'string'),
@@ -190,7 +190,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/_action/paypal/merchant-information',
+        path: '/_action/paypal/merchant-information',
         operationId: 'getMerchantInformation',
         tags: ['Admin Api', 'PayPal'],
         parameters: [
@@ -219,7 +219,7 @@ class SettingsController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/save-settings',
+        path: '/_action/paypal/save-settings',
         operationId: 'saveSettings',
         tags: ['Admin Api', 'PayPal'],
         responses: [new OA\Response(

--- a/src/Webhook/WebhookController.php
+++ b/src/Webhook/WebhookController.php
@@ -42,7 +42,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Get(
-        path: '/api/_action/paypal/webhook/status/{salesChannelId}',
+        path: '/_action/paypal/webhook/status/{salesChannelId}',
         operationId: 'getWebhookStatus',
         tags: ['Admin Api', 'SwagPayPalWebhook'],
         parameters: [new OA\Parameter(
@@ -69,7 +69,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/webhook/register/{salesChannelId}',
+        path: '/_action/paypal/webhook/register/{salesChannelId}',
         operationId: 'registerWebhook',
         tags: ['Admin Api', 'SwagPayPalWebhook'],
         parameters: [new OA\Parameter(
@@ -96,7 +96,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Delete(
-        path: '/api/_action/paypal/webhook/deregister/{salesChannelId}',
+        path: '/_action/paypal/webhook/deregister/{salesChannelId}',
         operationId: 'deregisterWebhook',
         tags: ['Admin Api', 'SwagPayPalWebhook'],
         parameters: [new OA\Parameter(
@@ -123,7 +123,7 @@ class WebhookController extends AbstractController
     }
 
     #[OA\Post(
-        path: '/api/_action/paypal/webhook/execute',
+        path: '/_action/paypal/webhook/execute',
         operationId: 'executeWebhook',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(ref: Webhook::class)),
         tags: ['Admin Api', 'SwagPayPalPosWebhook'],

--- a/tests/OpenAPISchemaTest.php
+++ b/tests/OpenAPISchemaTest.php
@@ -128,6 +128,7 @@ class OpenAPISchemaTest extends TestCase
             $routes = \array_map(fn ($r) => $r->getArguments(), $routeAttributes);
             $routeMethods = \array_unique(\array_merge(...\array_column($routes, 'methods')));
             $routePaths = \array_column($routes, 'path');
+            $routePathsWithoutPrefix = \array_map(fn ($path) => \str_replace(['/api', '/store-api'], '', $path), $routePaths);
 
             if (!\in_array($annotation->method, $routeMethods, true)) {
                 $failures[] = $fqdn . ' was expected to have a method of "' . \implode('" or "', $routeMethods) . '", but found "' . $annotation->method . '" in OpenAPI Schema';
@@ -137,8 +138,8 @@ class OpenAPISchemaTest extends TestCase
                 }
             }
 
-            if (!\in_array($annotation->path, $routePaths, true)) {
-                $failures[] = $fqdn . ' was expected to have a path of "' . \implode('" or "', $routePaths) . '", but found "' . $annotation->path . '" in OpenAPI Schema';
+            if (!\in_array($annotation->path, $routePathsWithoutPrefix, true)) {
+                $failures[] = $fqdn . ' was expected to have a path of "' . \implode('" or "', $routePathsWithoutPrefix) . '", but found "' . $annotation->path . '" in OpenAPI Schema';
             }
         }
 


### PR DESCRIPTION
Schemas in the `Resources/Schema` directories are not expected to have their respective prefix (`/api`/ `/store-api`) as a prefix. This breaks their use in e.g. stoplight.io, swagger or frontends