### PR TITLE
fix: onboarding button wording with ppcp check

### DIFF
--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
@@ -137,7 +137,7 @@ export default Shopware.Component.wrapComponentConfig({
                 return this.$t(`swag-paypal-onboarding-button.${this.type}.title`);
             }
 
-            if (!this.merchantInformationStore.canPPCP) {
+            if (this.settingsStore.isSandbox === this.isSandbox && !this.merchantInformationStore.canPPCP) {
                 return this.$t(`swag-paypal-onboarding-button.${this.type}.onboardingTitle`);
             }
 


### PR DESCRIPTION
The onboarding button component can do live & sandbox, but merchant information is only loaded based on the sandbox toggle. So if you only have sandbox credentials, but the sandbox is set to live, the merchant information for live will of course be loaded - i.e. `canPPCP` will be set to false. If you now create a sandbox button for the payment method card, it will not say 'Change sandbox account' but 'Start new onboarding', even though validate credentials are stored.  
**=>** the button should only check `canPPCP` if merchant information is loaded for the correct type.