### PR TITLE
fix: stringification of error objects

### DIFF
--- a/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
+++ b/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
@@ -53,6 +53,10 @@ export default class SwagPaypalAbstractButtons extends SwagPayPalScriptBase {
      * @param {*} [error=undefined] - The error. Can be any type, but will be converted to a string
      */
     handleError(code, fatal = false, error = undefined) {
+        if (error instanceof Error) {
+            error = String(error);
+        }
+
         if (error && typeof error !== 'string') {
             error = JSON.stringify(error);
         }


### PR DESCRIPTION
When an error object is stringified, e.g. when the paypal sdk throws one, only the stack trace is converted to a string, not the message. The other way round is much more useful