### PR TITLE
[6.6.x] feat: change logging behaviour of storefront errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 9.7.0
 - PPI-1000 - Fixes an issue, where PayLater is shown in cases where it should not be available
 - PPI-1044 - Improved compatibility of Vaulting with Store API usage and Headless setups
+- PPI-1073 - Changed logging behaviour of errors happening during checkout
 - PPI-1076 - Improved information passing in Express Checkout API calls
 - PPI-1077 - Improved the availability for Google Pay and Apple Pay
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # 9.7.0
 - PPI-1000 - Behebt ein Problem, bei dem 'Später Bezahlen' in Fällen angezeigt wird, in denen es nicht verfügbar sein sollte
 - PPI-1044 - Verbesserte Kompatibilität von Vaulting mit der Store-API und Headless
+- PPI-1073 - Verändert die Protokollierung von Fehlern während des Bestellvorganges
 - PPI-1076 - Verbesserte Informationsweitergabe in Express Checkout-API-Aufrufen
 - PPI-1077 - Verbesserte Verfügbarkeit von Google Pay und Apple Pay
 

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
@@ -4,6 +4,7 @@ import HttpClient from 'src/service/http-client.service';
 import PageLoadingIndicatorUtil from 'src/utility/loading-indicator/page-loading-indicator.util';
 import SwagPaypalAbstractButtons from '../swag-paypal.abstract-buttons';
 import SwagPayPalScriptLoading from '../swag-paypal.script-loading';
+import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
 
 export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButtons {
     /**
@@ -77,14 +78,22 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
             DomAccess.querySelector(this.confirmOrderForm, this.options.confirmOrderButtonSelector).disabled = 'disabled';
 
             return;
+        } else {
+            ElementLoadingIndicatorUtil.create(this.el);
         }
 
         DomAccess.querySelector(this.confirmOrderForm, this.options.confirmOrderButtonSelector).classList.add('d-none');
 
         this._client = new HttpClient();
 
-        this.createScript((paypal) => {
-            this.render(paypal);
+        this.createScript(async (paypal) => {
+            // catch sync and async errors - `.catch()` or similar aren't able to do so
+            try {
+                await this.render(paypal);
+                ElementLoadingIndicatorUtil.remove(this.el);
+            } catch (error) {
+                this.handleError(this.SCRIPT_ERROR, true, error);
+            }
         });
     }
 

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.apple-pay.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.apple-pay.js
@@ -22,15 +22,18 @@ export default class SwagPaypalApplePay extends SwagPaypalAbstractStandalone {
 
     async render(paypal) {
         if (!window.ApplePaySession?.supportsVersion(4) || !window.ApplePaySession?.canMakePayments()) {
-            this.handleError(this.BROWSER_UNSUPPORTED, true, 'Browser does not support Apple Pay');
-            return;
+            return void this.handleError(this.BROWSER_UNSUPPORTED, true, 'Browser does not support Apple Pay');
         }
 
-        this.renderButton(paypal).catch(this.onFatalError.bind(this));
+        await this.renderButton(paypal);
     }
 
     async renderButton(paypal) {
         const config = await paypal.Applepay().config();
+
+        if (!config.isEligible) {
+            return void this.handleError(this.NOT_ELIGIBLE, true, 'Funding for Apple Pay is not eligible');
+        }
 
         const button = document.createElement('apple-pay-button');
         button.setAttribute('buttonStyle', 'black');
@@ -42,10 +45,6 @@ export default class SwagPaypalApplePay extends SwagPaypalAbstractStandalone {
                     .catch(this.onError.bind(this));
             }
         });
-
-        if (!config.isEligible) {
-            return void this.handleError(this.NOT_ELIGIBLE, true, 'Funding for Apple Pay is not eligible');
-        }
 
         this.el.appendChild(button);
     }

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.google-pay.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.google-pay.js
@@ -30,15 +30,12 @@ export default class SwagPaypalGooglePay extends SwagPaypalAbstractStandalone {
     }
 
     async render(paypal) {
-        await this.renderGooglePay(paypal)
-            .catch(this.onFatalError.bind(this));
-
-        ElementLoadingIndicatorUtil.remove(this.el);
+        await this.renderGooglePay(paypal);
     }
 
     async renderGooglePay(paypal) {
         if (!window?.google?.payments?.api?.PaymentsClient) {
-            throw new Error('Google Pay script wasn\'t load');
+            return void this.handleError(this.SCRIPT_NOT_LOADED, true, 'Google Pay script wasn\'t load');
         }
 
         const {

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -109,7 +109,11 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
 
     createButton() {
         this.createScript((paypal) => {
-            this.renderButton(paypal);
+            try {
+                this.renderButton(paypal);
+            } catch (error) {
+                this.handleError(this.SCRIPT_ERROR, true, error);
+            }
         });
     }
 

--- a/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
+++ b/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
@@ -53,8 +53,8 @@ export default class SwagPaypalAbstractButtons extends SwagPayPalScriptBase {
     NOT_ELIGIBLE = 'SWAG_PAYPAL__NOT_ELIGIBLE';
     USER_CANCELLED = 'SWAG_PAYPAL__USER_CANCELLED';
     BROWSER_UNSUPPORTED = 'SWAG_PAYPAL__BROWSER_UNSUPPORTED';
-
-
+    SCRIPT_ERROR = 'SWAG_PAYPAL__SCRIPT_ERROR';
+    SCRIPT_NOT_LOADED = 'SWAG_PAYPAL__SCRIPT_NOT_LOADED';
 
     /**
      * @param {String} code - The error code. Will be replaced by an extracted error code from {@link error} if available

--- a/src/Storefront/Controller/PayPalController.php
+++ b/src/Storefront/Controller/PayPalController.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Storefront\Controller;
 
+use Monolog\Level;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
@@ -201,13 +202,17 @@ class PayPalController extends StorefrontController
             $request->getSession()->set(self::PAYMENT_METHOD_FATAL_ERROR, $context->getPaymentMethod()->getId());
         }
 
-        $this->logger->warning('Storefront checkout error', [
-            'error' => $request->request->get('error'),
-            'code' => $code,
-            'fatal' => $fatal,
-            'paymentMethodId' => $context->getPaymentMethod()->getId(),
-            'paymentMethodName' => $context->getPaymentMethod()->getName(),
-        ]);
+        $this->logger->log(
+            \in_array($code, ['SWAG_PAYPAL__SCRIPT_ERROR', 'SWAG_PAYPAL__SCRIPT_NOT_LOADED'], true) ? Level::Error : Level::Warning,
+            'Storefront checkout error',
+            [
+                'error' => $request->request->get('error'),
+                'code' => $code,
+                'fatal' => $fatal,
+                'paymentMethodId' => $context->getPaymentMethod()->getId(),
+                'paymentMethodName' => $context->getPaymentMethod()->getName(),
+            ],
+        );
 
         return new NoContentResponse();
     }

--- a/tests/Storefront/Controller/PayPalControllerTest.php
+++ b/tests/Storefront/Controller/PayPalControllerTest.php
@@ -7,14 +7,16 @@
 
 namespace Swag\PayPal\Test\Storefront\Controller;
 
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Test\TestSessionStorage;
 use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
@@ -28,6 +30,7 @@ use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\Storefront\Controller\PayPalController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * @internal
@@ -38,11 +41,14 @@ class PayPalControllerTest extends TestCase
 {
     private AbstractCreateOrderRoute&MockObject $createOrderRoute;
 
+    private TestHandler $logHandler;
+
     private PayPalController&MockObject $controller;
 
     protected function setUp(): void
     {
         $this->createOrderRoute = $this->createMock(AbstractCreateOrderRoute::class);
+        $this->logHandler = new TestHandler();
 
         $this->controller = $this->getMockBuilder(PayPalController::class)
             ->onlyMethods(['trans', 'addFlash'])
@@ -55,7 +61,7 @@ class PayPalControllerTest extends TestCase
                 $this->createMock(AbstractContextSwitchRoute::class),
                 $this->createMock(AbstractCartDeleteRoute::class),
                 $this->createMock(AbstractClearVaultRoute::class),
-                $this->createMock(LoggerInterface::class),
+                new Logger('test', [$this->logHandler]),
             ])
             ->getMock();
     }
@@ -103,12 +109,12 @@ class PayPalControllerTest extends TestCase
             ->method('addFlash')
             ->with('danger', 'Translated error message');
 
-        $paymentMethod = (new PaymentMethodEntity())->assign([
-            'id' => 'test',
-            'formattedHandlerIdentifier' => 'test_handler',
-        ]);
+        $this->controller->onHandleError($request, $this->generateSalesChannelContext());
 
-        $this->controller->onHandleError($request, Generator::createSalesChannelContext(paymentMethod: $paymentMethod));
+        $this->assertLogRecord(Level::Warning, [
+            'code' => 'SWAG_PAYPAL__TRANSLATABLE_ERROR_CODE',
+            'fatal' => false,
+        ]);
     }
 
     public function testOnHandleErrorWithNonTranslatableErrorCode(): void
@@ -126,47 +132,49 @@ class PayPalControllerTest extends TestCase
             ->with('danger', 'paypal.error.SWAG_PAYPAL__GENERIC_ERROR');
 
         $this->controller->onHandleError($request, $this->generateSalesChannelContext());
+
+        $this->assertLogRecord(Level::Warning, [
+            'code' => 'SWAG_PAYPAL__NON_TRANSLATABLE_ERROR_CODE',
+            'fatal' => false,
+        ]);
     }
 
-    public function testOnHandleErrorWithNonFatalError(): void
+    #[DataProvider('onHandleErrorDataProvider')]
+    public function testOnHandleError(string $code, bool $fatal, Level $level): void
     {
-        $request = $this->getMockBuilder(Request::class)
-            ->onlyMethods(['getSession'])
-            ->setConstructorArgs([
-                'request' => ['code' => 'SWAG_PAYPAL__TRANSLATABLE_ERROR_CODE'],
-            ])
-            ->getMock();
+        $salesChannelContext = $this->generateSalesChannelContext();
+        $request = new Request(request: [
+            'code' => $code,
+            'fatal' => $fatal,
+        ]);
 
-        $request->expects(static::never())->method('getSession');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
 
-        $this->controller->onHandleError($request, $this->generateSalesChannelContext());
-    }
-
-    public function testOnHandleErrorWithFatalError(): void
-    {
-        $request = $this->getMockBuilder(Request::class)
-            ->onlyMethods(['getSession'])
-            ->setConstructorArgs([
-                'request' => [
-                    'code' => 'SWAG_PAYPAL__TRANSLATABLE_ERROR_CODE',
-                    'fatal' => true,
-                ],
-            ])
-            ->getMock();
-
-        $session = new Session(new TestSessionStorage());
-
-        $request
-            ->expects(static::once())
-            ->method('getSession')
-            ->willReturn($session);
-
-        $this->controller->onHandleError($request, $this->generateSalesChannelContext());
+        $this->controller->onHandleError($request, $salesChannelContext);
 
         static::assertSame(
+            $fatal ? $salesChannelContext->getPaymentMethod()->getId() : null,
             $session->get(PayPalController::PAYMENT_METHOD_FATAL_ERROR),
-            $this->generateSalesChannelContext()->getPaymentMethod()->getId()
         );
+
+        $this->assertLogRecord($level, [
+            'code' => $code,
+            'fatal' => $fatal,
+        ]);
+    }
+
+    public static function onHandleErrorDataProvider(): \Generator
+    {
+        yield 'fatal script error' => ['SWAG_PAYPAL__SCRIPT_ERROR', true, Level::Error];
+        yield 'fatal script not loaded' => ['SWAG_PAYPAL__SCRIPT_NOT_LOADED', true, Level::Error];
+        yield 'fatal generic error' => ['SWAG_PAYPAL__GENERIC_ERROR', true, Level::Warning];
+        yield 'fatal eligible error' => ['SWAG_PAYPAL__NOT_ELIGIBLE', true, Level::Warning];
+
+        yield 'script error' => ['SWAG_PAYPAL__SCRIPT_ERROR', false, Level::Error];
+        yield 'script not loaded' => ['SWAG_PAYPAL__SCRIPT_NOT_LOADED', false, Level::Error];
+        yield 'generic error' => ['SWAG_PAYPAL__GENERIC_ERROR', false, Level::Warning];
+        yield 'eligible error' => ['SWAG_PAYPAL__NOT_ELIGIBLE', false, Level::Warning];
     }
 
     private function generateSalesChannelContext(): SalesChannelContext
@@ -179,5 +187,18 @@ class PayPalControllerTest extends TestCase
         ]);
 
         return Generator::createSalesChannelContext(paymentMethod: $paymentMethod);
+    }
+
+    private function assertLogRecord(Level $level, array $context): void
+    {
+        $records = $this->logHandler->getRecords();
+        static::assertCount(1, $records);
+        static::assertSame($level, $records[0]->level);
+        static::assertEquals([
+            'paymentMethodId' => 'test',
+            'paymentMethodName' => 'Generated Payment',
+            'error' => null,
+            ...$context,
+        ], $records[0]->context);
     }
 }


### PR DESCRIPTION
Many merchants have a log level of error configured, which automatically excludes logging storefront errors. While a `warning` log level is appropriate for user cancellations, we should log (fatal) errors with an `error` log level.
This should help us and support with some support cases where a lower log level is needed to help the merchant with their problem.

For reference: `PayPalController::onHandleError`