### PR TITLE
chore: fix phpstan plugin update

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -96,4 +96,3 @@ rules:
     # naming rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Symplify\NoReturnSetterMethodWithFluentSettersRule
     - Symplify\PHPStanRules\Rules\UppercaseConstantRule
-    - Symplify\PHPStanRules\Rules\CheckClassNamespaceFollowPsr4Rule


### PR DESCRIPTION
Minor update of symplify/phpstan-rules removed this rule, plugin was updated in platform trunk