### PR TITLE
[6.6.x] fix: Storefront plugin error for ACDC in After Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.7.3
+- Fixes an issue, where card fields were not displayed in the after order payment process (shopware/shopware#7643)
+
 # 9.7.2
 - Fixes an issue, where guest checkout was not possible (shopware/SwagPayPal#165)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 9.7.3
+- Behebt ein Problem, bei dem Kartenfelder im Zahlungsprozess nach einer Bestellung nicht angezeigt wurden (shopware/shopware#7643)
+
 # 9.7.2
 - Behebt ein Problem, bei dem der Checkout als Gast nicht möglich war (shopware/SwagPayPal#165)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "9.7.2",
+    "version": "9.7.3",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
@@ -90,10 +90,10 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
             // catch sync and async errors - `.catch()` or similar aren't able to do so
             try {
                 await this.render(paypal);
-                ElementLoadingIndicatorUtil.remove(this.el);
             } catch (error) {
                 this.handleError(this.SCRIPT_ERROR, true, error);
             }
+            ElementLoadingIndicatorUtil.remove(this.el);
         });
     }
 

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.acdc-fields.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.acdc-fields.js
@@ -172,7 +172,10 @@ export default class SwagPaypalAcdcFields extends SwagPaypalAbstractStandalone {
         this.confirmOrderForm.addEventListener('submit', this.onFieldSubmit.bind(this, cardFields));
 
         // remove history listener, it messes up errors
-        window.PluginManager.getPluginInstanceFromElement(this.confirmOrderForm, 'FormAddHistory').options.entries = [];
+        const formAddHistoryPlugin = window.PluginManager.getPluginInstanceFromElement(this.confirmOrderForm, 'FormAddHistory');
+        if (formAddHistoryPlugin) {
+            formAddHistoryPlugin.options.entries = [];
+        }
     }
 
     onFieldSubmit(cardFields, event) {


### PR DESCRIPTION
fixes shopware/shopware#7643

In the after order payment process, the FormAddHistory does not exist. This created a simple console error previously in case of rendering card fields.
With the new Storefront error handling, this error was interpreted as a hard error and disabled rendering afterwards.
I therefore also made sure to remove all non-existential code statements out of that error handling.