### PR TITLE
fix: system config webhook check

### DIFF
--- a/src/Webhook/Registration/WebhookSubscriber.php
+++ b/src/Webhook/Registration/WebhookSubscriber.php
@@ -62,33 +62,41 @@ class WebhookSubscriber implements EventSubscriberInterface
 
     /**
      * system-config should be written by {@see SettingsSaver} only, which checks the webhook on its own.
-     * Just in case new/changed credentials will be saved via the normal system config save route.
+     * Just in case new/changed credentials will be saved via the normal system config.
      */
     public function checkWebhookBefore(BeforeSystemConfigMultipleChangedEvent $event): void
     {
         $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
 
-        if (!\str_contains($routeName, 'api.action.core.save.system-config')) {
+        if (\str_contains($routeName, 'api.action.paypal.settings.save')) {
             return;
         }
 
-        /** @var array<string, array<string, mixed>> $config */
+        /** @var array<string, mixed> $config */
         $config = $event->getConfig();
-        $this->webhookSystemConfigHelper->checkWebhookBefore($config);
+
+        if ($this->webhookSystemConfigHelper->needsCheck($config)) {
+            $this->webhookSystemConfigHelper->checkWebhookBefore([$event->getSalesChannelId() => $config]);
+        }
     }
 
     /**
      * system-config should be written by {@see SettingsSaver} only, which checks the webhook on its own.
-     * Just in case new/changed credentials will be saved via the normal system config save route.
+     * Just in case new/changed credentials will be saved via the normal system config.
      */
     public function checkWebhookAfter(SystemConfigMultipleChangedEvent $event): void
     {
         $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
 
-        if (!\str_contains($routeName, 'api.action.core.save.system-config')) {
+        if (\str_contains($routeName, 'api.action.paypal.settings.save')) {
             return;
         }
 
-        $this->webhookSystemConfigHelper->checkWebhookAfter(\array_keys($event->getConfig()));
+        /** @var array<string, mixed> $config */
+        $config = $event->getConfig();
+
+        if ($this->webhookSystemConfigHelper->needsCheck($config)) {
+            $this->webhookSystemConfigHelper->checkWebhookAfter([$event->getSalesChannelId()]);
+        }
     }
 }

--- a/src/Webhook/Registration/WebhookSubscriber.php
+++ b/src/Webhook/Registration/WebhookSubscriber.php
@@ -66,16 +66,7 @@ class WebhookSubscriber implements EventSubscriberInterface
      */
     public function checkWebhookBefore(BeforeSystemConfigMultipleChangedEvent $event): void
     {
-        $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
-
-        if (\str_contains($routeName, 'api.action.paypal.settings.save')) {
-            return;
-        }
-
-        /** @var array<string, mixed> $config */
-        $config = $event->getConfig();
-
-        if ($this->webhookSystemConfigHelper->needsCheck($config)) {
+        if ($config = $this->getConfigToCheck($event)) {
             $this->webhookSystemConfigHelper->checkWebhookBefore([$event->getSalesChannelId() => $config]);
         }
     }
@@ -86,17 +77,24 @@ class WebhookSubscriber implements EventSubscriberInterface
      */
     public function checkWebhookAfter(SystemConfigMultipleChangedEvent $event): void
     {
-        $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
-
-        if (\str_contains($routeName, 'api.action.paypal.settings.save')) {
-            return;
-        }
-
-        /** @var array<string, mixed> $config */
-        $config = $event->getConfig();
-
-        if ($this->webhookSystemConfigHelper->needsCheck($config)) {
+        if ($this->getConfigToCheck($event)) {
             $this->webhookSystemConfigHelper->checkWebhookAfter([$event->getSalesChannelId()]);
         }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getConfigToCheck(BeforeSystemConfigMultipleChangedEvent|SystemConfigMultipleChangedEvent $event): ?array
+    {
+        /** @var array<string, mixed> $config */
+        $config = $event->getConfig();
+        $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
+
+        if (!$this->webhookSystemConfigHelper->needsCheck($config) || \str_contains($routeName, 'api.action.paypal.settings.save')) {
+            return null;
+        }
+
+        return $config;
     }
 }

--- a/src/Webhook/Registration/WebhookSubscriber.php
+++ b/src/Webhook/Registration/WebhookSubscriber.php
@@ -91,7 +91,7 @@ class WebhookSubscriber implements EventSubscriberInterface
         $config = $event->getConfig();
         $routeName = (string) $this->requestStack->getMainRequest()?->attributes->getString('_route');
 
-        if (!$this->webhookSystemConfigHelper->needsCheck($config) || \str_contains($routeName, 'api.action.paypal.settings.save')) {
+        if (\str_contains($routeName, 'api.action.paypal.settings.save') || !$this->webhookSystemConfigHelper->needsCheck($config)) {
             return null;
         }
 

--- a/src/Webhook/Registration/WebhookSystemConfigHelper.php
+++ b/src/Webhook/Registration/WebhookSystemConfigHelper.php
@@ -59,7 +59,7 @@ class WebhookSystemConfigHelper
         $errors = [];
 
         foreach ($newData as $salesChannelId => $newSettings) {
-            if ($salesChannelId === 'null') {
+            if (!$salesChannelId || $salesChannelId === 'null') {
                 $salesChannelId = null;
             }
 
@@ -102,7 +102,7 @@ class WebhookSystemConfigHelper
         $errors = [];
 
         foreach ($salesChannelIds as $salesChannelId) {
-            if ($salesChannelId === 'null') {
+            if (!$salesChannelId || $salesChannelId === 'null') {
                 $salesChannelId = null;
             }
 
@@ -127,6 +127,14 @@ class WebhookSystemConfigHelper
         }
 
         return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function needsCheck(array $config): bool
+    {
+        return !empty($this->filterSettings($config));
     }
 
     private function fetchSettings(?string $salesChannelId, bool $inherit = false): array

--- a/tests/Webhook/Registration/WebhookSubscriberTest.php
+++ b/tests/Webhook/Registration/WebhookSubscriberTest.php
@@ -29,6 +29,7 @@ use Swag\PayPal\Webhook\Registration\WebhookSubscriber;
 use Swag\PayPal\Webhook\Registration\WebhookSystemConfigHelper;
 use Swag\PayPal\Webhook\WebhookRegistry;
 use Swag\PayPal\Webhook\WebhookService;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -44,9 +45,15 @@ class WebhookSubscriberTest extends TestCase
 
     private SystemConfigService $systemConfigService;
 
+    private WebhookSystemConfigHelper $webhookSystemConfigHelper;
+
+    private RequestStack $requestStack;
+
     protected function setUp(): void
     {
         $this->systemConfigService = SystemConfigServiceMock::createWithCredentials();
+        $this->webhookSystemConfigHelper = $this->createMock(WebhookSystemConfigHelper::class);
+        $this->requestStack = new RequestStack();
     }
 
     public function testRemoveWebhookWithInheritedConfiguration(): void
@@ -71,6 +78,157 @@ class WebhookSubscriberTest extends TestCase
             ->removeSalesChannelWebhookConfiguration($this->createEvent());
 
         static::assertEmpty($this->systemConfigService->getString(Settings::WEBHOOK_ID, TestDefaults::SALES_CHANNEL));
+    }
+
+    public function testCheckWebhookBefore(): void
+    {
+        $event = new BeforeSystemConfigMultipleChangedEvent(['some-key' => 'some-value'], null);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('checkWebhookBefore')
+            ->with(['' => ['some-key' => 'some-value']]);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(true);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookBefore($event);
+    }
+
+    public function testCheckWebhookBeforeWithSalesChannelId(): void
+    {
+        $event = new BeforeSystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('checkWebhookBefore')
+            ->with(['some-sales-channel-id' => ['some-key' => 'some-value']]);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(true);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookBefore($event);
+    }
+
+    public function testCheckWebhookBeforeWithSaveRoute(): void
+    {
+        $request = new Request(attributes: ['_route' => 'api.action.paypal.settings.save']);
+        $this->requestStack->push($request);
+
+        $event = new BeforeSystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::never())
+            ->method('checkWebhookBefore');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::never())
+            ->method('needsCheck');
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookBefore($event);
+    }
+
+    public function testCheckWebhookBeforeWithNoCheckNeeded(): void
+    {
+        $event = new BeforeSystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::never())
+            ->method('checkWebhookBefore');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(false);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookBefore($event);
+    }
+
+    public function testCheckWebhookAfter(): void
+    {
+        $event = new SystemConfigMultipleChangedEvent(['some-key' => 'some-value'], null);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('checkWebhookAfter')
+            ->with(['']);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(true);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookAfter($event);
+    }
+
+    public function testCheckWebhookAfterWithSalesChannelId(): void
+    {
+        $event = new SystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('checkWebhookAfter')
+            ->with(['some-sales-channel-id']);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(true);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookAfter($event);
+    }
+
+    public function testCheckWebhookAfterWithSaveRoute(): void
+    {
+        $request = new Request(attributes: ['_route' => 'api.action.paypal.settings.save']);
+        $this->requestStack->push($request);
+
+        $event = new SystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('checkWebhookAfter')
+            ->with(['some-sales-channel-id']);
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::never())
+            ->method('needsCheck');
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookAfter($event);
+    }
+
+    public function testCheckWebhookAfterWithNoCheckNeeded(): void
+    {
+        $event = new SystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::never())
+            ->method('checkWebhookAfter');
+
+        $this->webhookSystemConfigHelper
+            ->expects(static::once())
+            ->method('needsCheck')
+            ->with(['some-key' => 'some-value'])
+            ->willReturn(false);
+
+        $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
+            ->checkWebhookBefore($event);
     }
 
     public function testSubscribedEvents(): void
@@ -105,8 +263,8 @@ class WebhookSubscriberTest extends TestCase
             new NullLogger(),
             $this->systemConfigService,
             $webhookService,
-            $this->createMock(WebhookSystemConfigHelper::class),
-            new RequestStack(),
+            $this->webhookSystemConfigHelper,
+            $this->requestStack,
         );
     }
 

--- a/tests/Webhook/Registration/WebhookSubscriberTest.php
+++ b/tests/Webhook/Registration/WebhookSubscriberTest.php
@@ -228,7 +228,7 @@ class WebhookSubscriberTest extends TestCase
             ->willReturn(false);
 
         $this->createWebhookSubscriber(['' => null, TestDefaults::SALES_CHANNEL => null])
-            ->checkWebhookBefore($event);
+            ->checkWebhookAfter($event);
     }
 
     public function testSubscribedEvents(): void

--- a/tests/Webhook/Registration/WebhookSubscriberTest.php
+++ b/tests/Webhook/Registration/WebhookSubscriberTest.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Test\Webhook\Registration;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\Context;
@@ -45,7 +46,7 @@ class WebhookSubscriberTest extends TestCase
 
     private SystemConfigService $systemConfigService;
 
-    private WebhookSystemConfigHelper $webhookSystemConfigHelper;
+    private WebhookSystemConfigHelper&MockObject $webhookSystemConfigHelper;
 
     private RequestStack $requestStack;
 
@@ -201,9 +202,8 @@ class WebhookSubscriberTest extends TestCase
         $event = new SystemConfigMultipleChangedEvent(['some-key' => 'some-value'], 'some-sales-channel-id');
 
         $this->webhookSystemConfigHelper
-            ->expects(static::once())
-            ->method('checkWebhookAfter')
-            ->with(['some-sales-channel-id']);
+            ->expects(static::never())
+            ->method('checkWebhookAfter');
 
         $this->webhookSystemConfigHelper
             ->expects(static::never())

--- a/tests/Webhook/Registration/WebhookSystemConfigHelperTest.php
+++ b/tests/Webhook/Registration/WebhookSystemConfigHelperTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Webhook\Registration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
+use Swag\PayPal\Setting\Settings;
+use Swag\PayPal\Webhook\Registration\WebhookSystemConfigHelper;
+use Swag\PayPal\Webhook\WebhookServiceInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(WebhookSystemConfigHelper::class)]
+class WebhookSystemConfigHelperTest extends TestCase
+{
+    private const WEBHOOK_KEYS = [
+        Settings::CLIENT_ID,
+        Settings::CLIENT_SECRET,
+        Settings::CLIENT_ID_SANDBOX,
+        Settings::CLIENT_SECRET_SANDBOX,
+        Settings::SANDBOX,
+        Settings::WEBHOOK_ID,
+    ];
+
+    private WebhookSystemConfigHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new WebhookSystemConfigHelper(
+            new NullLogger(),
+            $this->createMock(WebhookServiceInterface::class),
+            $this->createMock(SystemConfigService::class),
+            $this->createMock(SettingsValidationServiceInterface::class),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    #[DataProvider('providerNeedsCheck')]
+    public function testNeedsCheck(bool $expected, array $config): void
+    {
+        static::assertSame($expected, $this->helper->needsCheck($config));
+    }
+
+    public static function providerNeedsCheck(): \Generator
+    {
+        foreach (self::WEBHOOK_KEYS as $key) {
+            yield \sprintf('needs check for "%s"', $key) => [
+                true,
+                [$key => 'some-value'],
+            ];
+
+            yield \sprintf('needs check for "%s" with null value', $key) => [
+                true,
+                [$key => null],
+            ];
+        }
+
+        foreach (Settings::DEFAULT_VALUES as $key => $value) {
+            if (\in_array($key, self::WEBHOOK_KEYS, true)) {
+                continue;
+            }
+
+            yield \sprintf('no check for "%s"', $key) => [
+                false,
+                [$key => $value],
+            ];
+        }
+    }
+}


### PR DESCRIPTION
The `WebhookSystemConfigHelper` was fed with a wrongly structured config array. A correctly structured array is now used, in addition to:
- Check webhook only if a config value will change
- Check for all route expect our route which already handled it, catching also cases where the system config is written via commands or yaml

fixes shopware/shopware#7537