### PR TITLE
[6.6.x] fix: build admin in production

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,6 @@
 /rector.php export-ignore
 
 ; admin
-/src/Resources/app/administration/internal-rules export-ignore
 /src/Resources/app/administration/*.js export-ignore
 /src/Resources/app/administration/*.mjs export-ignore
 *.spec.ts export-ignore


### PR DESCRIPTION
`internal-rules` is listed as a dependency in package.json. Without including it in the production build, customers will not be able to build the administration because npm will not find it as a dependency.