### PR TITLE
fix: paypal refund modal

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-payment/component/swag-paypal-text-field/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/component/swag-paypal-text-field/index.js
@@ -10,6 +10,6 @@ const { Component } = Shopware;
  * @component-example
  * <swag-paypal-text-field label="Name" placeholder="placeholder goes here..."></swag-paypal-text-field>
  */
-Component.extend('swag-paypal-text-field', 'sw-text-field', {
+Component.extend('swag-paypal-text-field', 'sw-text-field-deprecated', {
     template,
 });


### PR DESCRIPTION
The paypal refund modal was not showing text fields as it should.

Before:
![image](https://github.com/user-attachments/assets/10cb6922-f98f-4bd9-b095-9985bb491cc3)

After:
![image](https://github.com/user-attachments/assets/8b7a3645-095e-4a59-912a-318856593d69)
