### PR TITLE
fix: fixed issue where paylater could incorrectly display

### DIFF
--- a/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
+++ b/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
@@ -34,8 +34,8 @@ use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Shopware\Storefront\Pagelet\Wishlist\GuestWishlistPageletLoadedEvent;
 use Swag\CmsExtensions\Storefront\Pagelet\Quickview\QuickviewPageletLoadedEvent;
 use Swag\PayPal\Checkout\Cart\Service\ExcludedProductValidator;
-use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCheckoutDataServiceInterface;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
+use Swag\PayPal\Checkout\ExpressCheckout\Service\PayPalExpressCheckoutDataService;
 use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
@@ -57,7 +57,7 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
      * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(
-        private readonly ExpressCheckoutDataServiceInterface $expressCheckoutDataService,
+        private readonly PayPalExpressCheckoutDataService $expressCheckoutDataService,
         private readonly SettingsValidationServiceInterface $settingsValidationService,
         private readonly SystemConfigService $systemConfigService,
         private readonly PaymentMethodUtil $paymentMethodUtil,

--- a/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
+++ b/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
@@ -51,6 +51,7 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
 {
     public const PAYPAL_EXPRESS_CHECKOUT_BUTTON_DATA_EXTENSION_ID = 'payPalEcsButtonData';
     public const PAYPAL_PAYLATER_PRODUCT = 'payPaylPayLaterProduct';
+    public const PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME = 'payPalEcsEventName';
 
     /**
      * @param EntityRepository<CustomerCollection> $customerRepository
@@ -109,9 +110,12 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
             );
         }
 
+        $event->getSalesChannelContext()->addExtension(self::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME, new ArrayStruct([$event::class]));
+
         $expressCheckoutButtonData = $this->getExpressCheckoutButtonData($event->getSalesChannelContext(), $event::class, $addProductToCart);
 
         $event->getSalesChannelContext()->removeExtension(self::PAYPAL_PAYLATER_PRODUCT);
+        $event->getSalesChannelContext()->removeExtension(self::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME);
 
         if ($expressCheckoutButtonData === null) {
             return;

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutSubscriber;
-use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCheckoutDataServiceInterface;
+use Swag\PayPal\Checkout\ExpressCheckout\Service\PayPalExpressCheckoutDataService;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Setting\Settings;
@@ -30,7 +30,7 @@ class ExpressCategoryRoute extends AbstractCategoryRoute
      */
     public function __construct(
         private readonly AbstractCategoryRoute $inner,
-        private readonly ExpressCheckoutDataServiceInterface $expressCheckoutDataService,
+        private readonly PayPalExpressCheckoutDataService $expressCheckoutDataService,
         private readonly SettingsValidationServiceInterface $settingsValidationService,
         private readonly SystemConfigService $systemConfigService,
         private readonly PaymentMethodUtil $paymentMethodUtil,

--- a/src/Checkout/ExpressCheckout/Service/ExpressCheckoutDataServiceInterface.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCheckoutDataServiceInterface.php
@@ -11,11 +11,11 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutButtonData;
 
+/**
+ * @deprecated tag:v10.0.0 - reason:removed - Interfaced will be removed with no replacement
+ */
 #[Package('checkout')]
 interface ExpressCheckoutDataServiceInterface
 {
-    /**
-     * @deprecated tag:v10.0.0 - reason:new-optional-parameter - a ShopwareSalesChannelEvent that defaults to null will be added
-     */
     public function buildExpressCheckoutButtonData(SalesChannelContext $salesChannelContext, bool $addProductToCart = false): ?ExpressCheckoutButtonData;
 }

--- a/src/Checkout/ExpressCheckout/Service/ExpressCheckoutDataServiceInterface.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCheckoutDataServiceInterface.php
@@ -15,7 +15,7 @@ use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutButtonData;
 interface ExpressCheckoutDataServiceInterface
 {
     /**
-     * @deprecated tag:v10.0.0 - reason:new-optional-parameter - a SalesChannelProductEntity that defaults to null will be added
+     * @deprecated tag:v10.0.0 - reason:new-optional-parameter - a ShopwareSalesChannelEvent that defaults to null will be added
      */
     public function buildExpressCheckoutButtonData(SalesChannelContext $salesChannelContext, bool $addProductToCart = false): ?ExpressCheckoutButtonData;
 }

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -29,6 +29,9 @@ use Swag\PayPal\Util\LocaleCodeProvider;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\Routing\RouterInterface;
 
+/**
+ * @deprecated tag:v10.0.0 - Class won't implement ExpressCheckoutDataServiceInterface anymore
+ */
 #[Package('checkout')]
 class PayPalExpressCheckoutDataService extends AbstractScriptDataService implements ExpressCheckoutDataServiceInterface
 {

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -11,8 +11,10 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Page\Product\ProductPageLoadedEvent;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutButtonData;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutSubscriber;
@@ -47,7 +49,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
     }
 
     /**
-     * @deprecated tag:v10.0.0 - reason:new-optional-parameter - a SalesChannelProductEntity that defaults to null will be added
+     * @deprecated tag:v10.0.0 - reason:new-optional-parameter - a ShopwareSalesChannelEvent that defaults to null will be added
      */
     public function buildExpressCheckoutButtonData(
         SalesChannelContext $salesChannelContext,
@@ -70,6 +72,10 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
 
         $context = $salesChannelContext->getContext();
         $salesChannelId = $salesChannelContext->getSalesChannelId();
+        $eventName = $salesChannelContext->getExtensionOfType(ExpressCheckoutSubscriber::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME, ArrayStruct::class);
+        if ($eventName === null) {
+            $eventName = new ArrayStruct();
+        }
 
         $fundingSources = ['paypal', 'venmo'];
 
@@ -82,7 +88,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
             $availabilityContext = AvailabilityContextBuilder::buildFromCart($cart, $salesChannelContext);
         }
 
-        if ($this->showPayLater($salesChannelId, $availabilityContext)) {
+        if ($this->showPayLater($salesChannelId, $availabilityContext, $eventName)) {
             array_splice($fundingSources, 1, 0, ['paylater']);
         }
 
@@ -109,7 +115,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
             'addErrorUrl' => $this->router->generate('frontend.paypal.error'),
             'handleErrorUrl' => $this->router->generate('frontend.paypal.handle-error'),
             'cancelRedirectUrl' => $this->router->generate($addProductToCart ? 'frontend.checkout.cart.page' : 'frontend.checkout.register.page'),
-            'showPayLater' => $this->showPayLater($salesChannelId, $availabilityContext),
+            'showPayLater' => $this->showPayLater($salesChannelId, $availabilityContext, $eventName),
             'fundingSources' => $fundingSources,
         ]);
     }
@@ -125,9 +131,13 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
         );
     }
 
-    private function showPayLater(string $salesChannelId, AvailabilityContext $availabilityContext): bool
+    /**
+     * @param ArrayStruct<int, string> $eventName
+     */
+    private function showPayLater(string $salesChannelId, AvailabilityContext $availabilityContext, ArrayStruct $eventName): bool
     {
-        return $this->systemConfigService->getBool(Settings::ECS_SHOW_PAY_LATER, $salesChannelId)
+        return $eventName->all()[0] === ProductPageLoadedEvent::class
+            && $this->systemConfigService->getBool(Settings::ECS_SHOW_PAY_LATER, $salesChannelId)
             && $this->payLaterMethodData->isAvailable($availabilityContext);
     }
 }

--- a/src/Pos/Sync/Inventory/StockSubscriber.php
+++ b/src/Pos/Sync/Inventory/StockSubscriber.php
@@ -191,7 +191,7 @@ class StockSubscriber implements EventSubscriberInterface
         $message = new InventoryUpdateMessage();
         $message->setIds($productIds);
         $envelope = new Envelope($message, [
-            new DelayStamp(self::DELAY),
+            new DelayStamp(self::DELAY), // @phpstan-ignore-line shopware.noDelayStamp
         ]);
         $this->messageBus->dispatch($envelope);
     }

--- a/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
@@ -38,7 +38,6 @@ use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Page\Product\ProductPageLoadedEvent;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutSubscriber;
-use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCheckoutDataServiceInterface;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\PayPalExpressCheckoutDataService;
 use Swag\PayPal\RestApi\V2\PaymentIntentV2;
 use Swag\PayPal\Setting\Service\CredentialsUtil;
@@ -61,7 +60,7 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
 
     private const CLIENT_ID = 'someClientId';
 
-    private ExpressCheckoutDataServiceInterface $expressCheckoutDataService;
+    private PayPalExpressCheckoutDataService $expressCheckoutDataService;
 
     private AbstractSalesChannelContextFactory $salesChannelContextFactory;
 

--- a/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryEntity;
@@ -34,6 +35,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\Tax\TaxDefinition;
 use Shopware\Core\Test\TestDefaults;
+use Shopware\Storefront\Page\Product\ProductPageLoadedEvent;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutSubscriber;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCheckoutDataServiceInterface;
@@ -170,6 +172,7 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
     {
         $taxId = $this->createTaxId(Context::createDefaultContext());
         $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+        $salesChannelContext->addExtension(ExpressCheckoutSubscriber::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME, new ArrayStruct([ProductPageLoadedEvent::class]));
         $productId = $this->getProductId($salesChannelContext->getContext(), $taxId);
         $lineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE, $productId);
 
@@ -221,6 +224,7 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
     public function testFundingSourcesWithPayLater(bool $showPayLaterSetting, bool $payLaterAvailable, array $expectedFundingSources): void
     {
         $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+        $salesChannelContext->addExtension(ExpressCheckoutSubscriber::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME, new ArrayStruct([ProductPageLoadedEvent::class]));
 
         $this->systemConfigService->set(Settings::ECS_SHOW_PAY_LATER, $showPayLaterSetting, $salesChannelContext->getSalesChannelId());
 

--- a/tests/Pos/Converter/ProductConverterTest.php
+++ b/tests/Pos/Converter/ProductConverterTest.php
@@ -242,10 +242,10 @@ class ProductConverterTest extends TestCase
 
     private function createProductConverter(): ProductConverter
     {
-        $variantConverter = $this->createStub(VariantConverter::class);
+        $variantConverter = static::createStub(VariantConverter::class);
         $variantConverter->method('convert')->willReturn(new Variant());
 
-        $categoryConverter = $this->createStub(CategoryConverter::class);
+        $categoryConverter = static::createStub(CategoryConverter::class);
         $categoryConverter->method('convert')->willReturn(new Category());
 
         return new ProductConverter(

--- a/tests/Pos/Sync/Inventory/InventorySyncerTest.php
+++ b/tests/Pos/Sync/Inventory/InventorySyncerTest.php
@@ -62,7 +62,7 @@ class InventorySyncerTest extends TestCase
         $this->inventoryContext->setSalesChannel($salesChannel);
 
         $this->inventorySyncer = new InventorySyncer(
-            $this->createStub(InventoryContextFactory::class),
+            static::createStub(InventoryContextFactory::class),
             $this->localUpdater,
             $this->remoteUpdater,
             $this->inventoryRepository


### PR DESCRIPTION
Fix an issue where pay later will display on pages where it shouldn't when the cart has a qualifying item in it.