### PR TITLE
fix: onboarding with zoid

### DIFF
--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
@@ -44,6 +44,7 @@ export default Shopware.Component.wrapComponentConfig({
             type: this.mode,
 
             callbackId: Shopware.Utils.createId(),
+            setupFunctionWaits: 0,
 
             isLoading: true,
 
@@ -91,6 +92,11 @@ export default Shopware.Component.wrapComponentConfig({
     watch: {
         mode() {
             this.type = this.mode;
+        },
+        '$route.query'(query: Record<string, unknown>) {
+            if (Object.hasOwn(query, 'ppOnboarding')) {
+                this.completeOnboarding();
+            }
         },
     },
 
@@ -204,29 +210,60 @@ export default Shopware.Component.wrapComponentConfig({
 
             if (window.PAYPAL) {
                 this.isLoading = false;
-                window.PAYPAL.apps.Signup.setup();
+                if (window.PAYPAL.apps.Signup.setup) {
+                    window.PAYPAL.apps.Signup.setup();
+                } else {
+                    window.PAYPAL.apps.Signup.render();
+                }
             } else {
-                el.addEventListener('load', this.renderPayPalButton.bind(this), false);
+                el.addEventListener('load', () => void this.renderPayPalButton(), false);
             }
         },
 
-        renderPayPalButton() {
-            this.isLoading = false;
+        async renderPayPalButton() {
+            this.isLoading = true;
 
-            // The original render function inside the partner.js is overwritten here.
-            // The function gets overwritten again, as soon as PayPals signup.js is loaded.
-            // A loop is created and the render() function is executed until the real render() function is available.
-            // PayPal does originally nearly the same, but only once and not in a loop.
-            // If the signup.js is loaded to slow the button is not rendered.
-            window.PAYPAL!.apps.Signup.render = function proxyPPrender() {
-                if (window.PAYPAL!.apps.Signup.timeout) {
-                    clearTimeout(window.PAYPAL!.apps.Signup.timeout);
+            // maybe another button instance already started loading and rendering
+            if (window.paypalScriptPromise) {
+                Shopware.Utils.debug.warn('[PayPal Onboarding] another button is already loading');
+            } else {
+                window.PAYPAL!.apps.Signup.render = function proxyPPrender() {};
+                window.paypalScriptPromise = this.waitForScriptsLoaded();
+            }
+
+            await window.paypalScriptPromise;
+
+            this.isLoading = false;
+        },
+
+        // The partner.js does not provide a stub `setup` function like the `render` function.
+        // The setup function is overriden as soon as all scripts are loaded properly.
+        // Still, just in case we should stop waiting after 30sec.
+        waitForScriptsLoaded(): Promise<void> {
+            let tries = 0;
+
+            const checkFn = (resolve: (() => void)) => {
+                if (tries > 100) {
+                    Shopware.Utils.debug.warn('[PayPal Onboarding] exceeded tries. paypal script is properly not loaded correctly');
+                    return resolve();
                 }
 
-                window.PAYPAL!.apps.Signup.timeout = setTimeout(window.PAYPAL!.apps.Signup.render, 300);
+                if (window.PAYPAL!.apps.Signup.render.name !== 'proxyPPrender') {
+                    Shopware.Utils.debug.warn('[PayPal Onboarding] found render function');
+                    window.PAYPAL!.apps.Signup.render();
+                    return resolve();
+                }
+
+                if (window.PAYPAL!.apps.Signup.setup) {
+                    Shopware.Utils.debug.warn('[PayPal Onboarding] found setup function');
+                    return resolve();
+                }
+
+                tries += 1;
+                setTimeout(checkFn.bind(this, resolve), 300);
             };
 
-            window.PAYPAL!.apps.Signup.render();
+            return new Promise<void>(checkFn.bind(this));
         },
 
         async fetchCredentials(authCode: string, sharedId: string) {
@@ -272,6 +309,7 @@ export default Shopware.Component.wrapComponentConfig({
 
         completeOnboarding() {
             const { ppOnboarding, merchantIdInPayPal } = this.$route.query;
+
             this.$router.replace({ query: {} });
 
             if (!merchantIdInPayPal || ppOnboarding !== 'sandbox' && ppOnboarding !== 'live') {

--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
@@ -44,7 +44,6 @@ export default Shopware.Component.wrapComponentConfig({
             type: this.mode,
 
             callbackId: Shopware.Utils.createId(),
-            setupFunctionWaits: 0,
 
             isLoading: true,
 

--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/index.ts
@@ -224,9 +224,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.isLoading = true;
 
             // maybe another button instance already started loading and rendering
-            if (window.paypalScriptPromise) {
-                Shopware.Utils.debug.warn('[PayPal Onboarding] another button is already loading');
-            } else {
+            if (!window.paypalScriptPromise) {
                 window.PAYPAL!.apps.Signup.render = function proxyPPrender() {};
                 window.paypalScriptPromise = this.waitForScriptsLoaded();
             }
@@ -244,18 +242,15 @@ export default Shopware.Component.wrapComponentConfig({
 
             const checkFn = (resolve: (() => void)) => {
                 if (tries > 100) {
-                    Shopware.Utils.debug.warn('[PayPal Onboarding] exceeded tries. paypal script is properly not loaded correctly');
                     return resolve();
                 }
 
                 if (window.PAYPAL!.apps.Signup.render.name !== 'proxyPPrender') {
-                    Shopware.Utils.debug.warn('[PayPal Onboarding] found render function');
                     window.PAYPAL!.apps.Signup.render();
                     return resolve();
                 }
 
                 if (window.PAYPAL!.apps.Signup.setup) {
-                    Shopware.Utils.debug.warn('[PayPal Onboarding] found setup function');
                     return resolve();
                 }
 

--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.html.twig
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.html.twig
@@ -1,15 +1,14 @@
 <a
     :href="onboardingUrl"
-    :disabled="isDisabled"
     :class="classes"
     class="swag-paypal-onboarding-button"
     target="_paypal"
     :data-paypal-onboard-complete="callbackName"
     data-paypal-button="true"
 >
-    <sw-loader
+    <mt-loader
         v-if="isLoading"
-        class="sw-button_loader"
+        class="swag-paypal-onboarding-button__loader"
         size="20px"
     />
 

--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.scss
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.scss
@@ -1,6 +1,7 @@
 @import "~scss/variables";
 
 .swag-paypal-onboarding-button {
+    position: relative;
     color: var(--color-text-brand-default);
     font-weight: var(--font-weight-semi-bold);
     font-size: var(--font-size-xs);
@@ -22,6 +23,7 @@
 
     &.is--disabled {
         cursor: not-allowed;
+        pointer-events: none;
         color: var(--color-text-brand-disabled);
         border-color: var(--color-text-brand-disabled);
 

--- a/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.spec.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-onboarding-button/swag-paypal-onboarding-button.spec.ts
@@ -161,6 +161,7 @@ describe('swag-paypal-onboarding-button', () => {
     });
 
     it('should complete onboarding', async () => {
+        global.activeAclRoles = ['swag_paypal.editor'];
         const wrapper = await createWrapper();
 
         const store = Shopware.Store.get('swagPayPalSettings');

--- a/src/Resources/app/administration/src/types/window-paypal.ts
+++ b/src/Resources/app/administration/src/types/window-paypal.ts
@@ -10,7 +10,7 @@ export declare type AppSignup = {
     };
 
     render: () => void;
-    setup: () => void;
+    setup: undefined | (() => void);
     timeout?: NodeJS.Timeout;
 };
 
@@ -28,6 +28,8 @@ export declare type PAYPAL = {
 declare global {
     interface Window {
         PAYPAL?: PAYPAL;
+
+        paypalScriptPromise?: Promise<void>;
 
         [key: `onboardingCallback${string}`]: undefined | ((authCode: string, sharedId: string) => void);
     }


### PR DESCRIPTION
For some time now, PayPal seems to have replaced the old signup-js with zoid. You'll find console.log messages like "Partner must be ramped to zoid, loading new MB script".  
As a result, there is no `render` function and our `proxyPPrender` function is retained and loops indefinitely. But to check if the script is loaded, we can wait for the `setup` function.

Still, the old behaviour is somewhat needed for referral onboardings.