### PR TITLE
POC: upgrade to JS SDK v6

### DIFF
--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -19,6 +19,7 @@ use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutButtonData;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutSubscriber;
 use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Storefront\Data\Service\AbstractScriptDataService;
@@ -45,10 +46,11 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
         private readonly PaymentMethodUtil $paymentMethodUtil,
         SystemConfigService $systemConfigService,
         CredentialsUtilInterface $credentialsUtil,
+        TokenResource $tokenResource,
         private readonly CartPriceService $cartPriceService,
         private readonly PayLaterMethodData $payLaterMethodData,
     ) {
-        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil);
+        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil, $tokenResource);
     }
 
     /**

--- a/src/Installment/Banner/Service/BannerDataService.php
+++ b/src/Installment/Banner/Service/BannerDataService.php
@@ -23,6 +23,7 @@ use Shopware\Storefront\Page\Product\ProductPage;
 use Shopware\Storefront\Pagelet\Footer\FooterPagelet;
 use Swag\CmsExtensions\Storefront\Pagelet\Quickview\QuickviewPagelet;
 use Swag\PayPal\Installment\Banner\BannerData;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Storefront\Data\Service\AbstractScriptDataService;
@@ -39,10 +40,11 @@ class BannerDataService extends AbstractScriptDataService implements BannerDataS
         LocaleCodeProvider $localeCodeProvider,
         SystemConfigService $systemConfigService,
         CredentialsUtilInterface $credentialsUtil,
+        TokenResource $tokenResource,
         private readonly PaymentMethodUtil $paymentMethodUtil,
         private readonly EntityRepository $languageRepository,
     ) {
-        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil);
+        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil, $tokenResource);
     }
 
     /**

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
@@ -97,14 +97,17 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
         });
     }
 
-    render(paypal) {
-        const button = paypal.Buttons(this.getButtonConfig(this.getFundingSource(paypal)));
+    async render(paypal) {
+        // const paymentMethods = await paypal.findEligibleMethods();
+        // if (!paymentMethods.isEligible("paypal")) {
+        //     return void this.handleError(this.NOT_ELIGIBLE, true, `Funding for PayPal button is not eligible (${this.getFundingSource(paypal)})`);
+        // }
 
-        if (!button.isEligible()) {
-            return void this.handleError(this.NOT_ELIGIBLE, true, `Funding for PayPal button is not eligible (${this.getFundingSource(paypal)})`);
-        }
+        const session = paypal.createPayPalOneTimePaymentSession(this.getButtonConfig(this.getFundingSource(paypal)));
 
-        button.render(this.el);
+        const button = this.createPayPalButton();
+        button.addEventListener('click', this.onClick.bind(this, session));
+        this.el.append(button);
     }
 
     /**
@@ -116,19 +119,9 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
 
     getButtonConfig(fundingSource) {
         return {
-            fundingSource,
+            commit: this.options.commit,
 
-            style: {
-                size: this.options.buttonSize,
-                shape: this.options.buttonShape,
-                color: this.options.buttonColor,
-                label: 'pay',
-            },
-
-            /**
-             * Will be called if when the payment process starts
-             */
-            createOrder: this.createOrder.bind(this, this.constructor.product),
+            orderId: this.options.orderId || undefined,
 
             /**
              * Will be called if the payment process is approved by paypal
@@ -139,11 +132,6 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
              * Remove loading spinner when user comes back
              */
             onCancel: this.onCancel.bind(this),
-
-            /**
-             * Check form validity & show loading spinner on confirm click
-             */
-            onClick: this.onClick.bind(this),
 
             /**
              * Will be called if an error occurs during the payment process.
@@ -208,11 +196,15 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
      * @param {{reject: Function, resolve: Function}} actions
      * @returns {*}
      */
-    onClick(_, actions) {
+    async onClick(session, event) {
         if (!this.confirmOrderForm.checkValidity()) {
-            return actions.reject();
+            event.preventDefault();
+            return;
         }
 
-        return actions.resolve();
+        await session.start(
+            { presentationMode: 'auto' },
+            this.createOrder(this.constructor.product).then((orderId) => ({ orderId })),
+        );
     }
 }

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -1,6 +1,6 @@
 import HttpClient from 'src/service/http-client.service';
 import DomAccess from 'src/helper/dom-access.helper';
-import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
+import PageLoadingIndicatorUtil from 'src/utility/loading-indicator/page-loading-indicator.util';
 import SwagPaypalAbstractButtons from '../swag-paypal.abstract-buttons';
 import SwagPayPalScriptLoading from '../swag-paypal.script-loading';
 
@@ -93,6 +93,7 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
          * Streamline options for listing pages, overriding the ones
          * from swag-paypal.script-loading.js
          */
+        pageType: 'checkout',
         useAlternativePaymentMethods: true,
         commit: false,
         scriptAwaitVisibility: true,
@@ -118,14 +119,24 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
     }
 
     renderButton(paypal) {
-        this.options.fundingSources.forEach((fundingSource) => {
-            const button = paypal.Buttons(this.getButtonConfig(fundingSource));
+        // const paymentMethods = await paypal.findEligibleMethods();
+        // if (!paymentMethods.isEligible("paypal")) {
+        //     return void this.handleError(this.NOT_ELIGIBLE, true, `Funding for PayPal button is not eligible (${this.getFundingSource(paypal)})`);
+        // }
 
-            if (button.isEligible()) {
-                button.render(this.el);
-            }
-        });
+        const session = paypal.createPayPalOneTimePaymentSession(this.getButtonConfig('paypal'));
 
+        const button = this.createPayPalButton();
+        button.setAttribute('type', 'checkout');
+        button.addEventListener('click', this.onClick.bind(this, session));
+        this.el.append(button);
+    }
+
+    async onClick(session, event) {
+        await session.start(
+            { presentationMode: 'auto' },
+            this.createOrder().then((orderId) => ({ orderId })),
+        );
     }
 
     getBuyButtonState() {
@@ -166,58 +177,7 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
     }
 
     getButtonConfig(fundingSource = 'paypal') {
-        const renderElement = this.el;
-        const { element: buyButton, disabled: isBuyButtonDisabled } = this.getBuyButtonState();
-
         return {
-            fundingSource,
-
-            onInit: (data, actions) => {
-                if (!this.options.addProductToCart) {
-                    return;
-                }
-
-                /**
-                 * Helper method which enables the paypal button
-                 * @returns void
-                 */
-                const enableButton = () => {
-                    actions.enable();
-                    renderElement.classList.remove(this.options.disabledClass);
-                };
-
-                /**
-                 * Helper method which disables the paypal button
-                 * @returns void
-                 */
-                const disableButton = () => {
-                    actions.disable();
-                    renderElement.classList.add(this.options.disabledClass);
-                };
-
-                this.observeBuyButton(buyButton, enableButton, disableButton);
-
-                // Set the initial state of the button
-                if (isBuyButtonDisabled) {
-                    disableButton();
-                    return;
-                }
-                enableButton();
-            },
-            style: {
-                size: this.options.buttonSize,
-                shape: this.options.buttonShape,
-                color: this.options.buttonColor,
-                tagline: this.options.tagline,
-                layout: 'vertical',
-                label: 'checkout',
-                height: 40,
-            },
-
-            /**
-             * Will be called if the express button is clicked
-             */
-            createOrder: this.createOrder.bind(this),
 
             /**
              * Will be called if the payment process is approved by paypal
@@ -307,21 +267,24 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
         });
     }
 
-    onApprove(data, actions) {
+    onApprove(data) {
         const requestPayload = {
-            token: data.orderID,
+            token: data.orderId,
         };
 
         // Add a loading indicator to the body to prevent the user breaking the checkout process
-        ElementLoadingIndicatorUtil.create(document.body);
+        PageLoadingIndicatorUtil.create();
 
         this._client.post(
             this.options.prepareCheckoutUrl,
             JSON.stringify(requestPayload),
             (response, request) => {
                 if (request.status < 400) {
-                    return actions.redirect(this.options.checkoutConfirmUrl);
+                    window.location.href = this.options.checkoutConfirmUrl;
+                    return;
                 }
+
+                PageLoadingIndicatorUtil.remove();
 
                 return this.onError();
             },

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,3 +1,11 @@
 @import 'components/express';
 @import 'components/google-pay';
 @import 'components/pui';
+
+.swag-paypal-button {
+    width: 100%;
+
+    &.shape-sharp {
+        --paypal-button-border-radius: 0px;
+    }
+}

--- a/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
+++ b/src/Resources/app/storefront/src/swag-paypal.abstract-buttons.js
@@ -56,6 +56,22 @@ export default class SwagPaypalAbstractButtons extends SwagPayPalScriptBase {
     SCRIPT_ERROR = 'SWAG_PAYPAL__SCRIPT_ERROR';
     SCRIPT_NOT_LOADED = 'SWAG_PAYPAL__SCRIPT_NOT_LOADED';
 
+    createPayPalButton() {
+        const button = document.createElement('paypal-button');
+        button.classList.add('swag-paypal-button');
+        button.setAttribute('type', 'pay');
+
+        if (this.options.buttonShape) {
+            button.classList.add(`shape-${this.options.buttonShape}`);
+        }
+
+        if (this.options.buttonColor) {
+            button.classList.add(`paypal-${this.options.buttonColor}`);
+        }
+
+        return button;
+    }
+
     /**
      * @param {String} code - The error code. Will be replaced by an extracted error code from {@link error} if available
      * @param {Boolean} [fatal=false] - A fatal error will not allow a rerender of the PayPal buttons

--- a/src/Resources/app/storefront/src/swag-paypal.script-base.js
+++ b/src/Resources/app/storefront/src/swag-paypal.script-base.js
@@ -108,36 +108,22 @@ export default class SwagPayPalScriptBase extends Plugin {
         userIdToken: null,
 
         /**
+         * @type string
+         */
+        pageType: 'checkout',
+
+        /**
          * This option will await the visibility of the element before continue loading the script.
          * Useful for listing pages to not load all express buttons at once.
          *
          * @type boolean
          */
         scriptAwaitVisibility: false,
-
-        /**
-         * This option toggles when the script should be loaded.
-         * If false, the script will be loaded on 'load' instead of 'DOMContentLoaded' event.
-         * See 'DOMContentLoaded' and 'load' event for more information.
-         *
-         * @type boolean
-         */
-        partOfDomContentLoading: true,
     };
 
     static scriptPromises = {};
 
     static paypal = {};
-
-    _init() {
-        if (this.options.partOfDomContentLoading || document.readyState === 'complete') {
-            super._init();
-        } else {
-            window.addEventListener('load', () => {
-                super._init();
-            });
-        }
-    }
 
     get scriptOptionsHash() {
         return JSON.stringify(this.getScriptOptions());
@@ -173,13 +159,17 @@ export default class SwagPayPalScriptBase extends Plugin {
     }
 
     async _loadScript() {
-        SwagPayPalScriptBase.paypal[this.scriptOptionsHash] = await loadScript(this.getScriptOptions());
+        const scriptTag = document.getElementById('paypal-sdk-v6');
 
-        // overwriting an existing `window.paypal` object would remove previously rendered elements
-        // therefore we remove it so other scripts can load it on their own
-        delete window.paypal;
+        if (!scriptTag) {
+            throw new Error('PayPal script is not present');
+        }
 
-        return SwagPayPalScriptBase.paypal[this.scriptOptionsHash];
+        if (!window.paypal) {
+            await new Promise((resolve) => scriptTag.addEventListener('load', resolve));
+        }
+
+        return await window.paypal.createInstance(this.getScriptOptions());
     }
 
     /**
@@ -188,43 +178,39 @@ export default class SwagPayPalScriptBase extends Plugin {
      * mess up the `scriptOptionsHash` and therefore affects script caching.
      */
     getScriptOptions() {
-        const config = {
-            components: 'buttons,messages,card-fields,funding-eligibility,applepay,googlepay',
-            'client-id': this.options.clientId,
-            commit: !!this.options.commit,
+        return {
+            clientToken: this.options.clientToken,
+            components: ['paypal-payments'],
             locale: this.options.languageIso,
-            currency: this.options.currency,
-            intent: this.options.intent,
-            'enable-funding': 'paylater,venmo',
+
+            pageType: this.options.pageType,
         };
 
-        if (this.options.disablePayLater || this.options.showPayLater === false) {
-            config['enable-funding'] = 'venmo';
-        }
+        // if (this.options.disablePayLater || this.options.showPayLater === false) {
+        //     config['enable-funding'] = 'venmo';
+        // }
 
-        if (this.options.useAlternativePaymentMethods === false) {
-            config['disable-funding'] = availableAPMs.join(',');
-        } else if (this.options.disabledAlternativePaymentMethods.length > 0) {
-            config['disable-funding'] = this.options.disabledAlternativePaymentMethods.join(',');
-        }
+        // if (this.options.useAlternativePaymentMethods === false) {
+        //     config['disable-funding'] = availableAPMs.join(',');
+        // } else if (this.options.disabledAlternativePaymentMethods.length > 0) {
+        //     config['disable-funding'] = this.options.disabledAlternativePaymentMethods.join(',');
+        // }
 
-        if (this.options.merchantPayerId) {
-            config['merchant-id'] = this.options.merchantPayerId;
-        }
+        // if (this.options.merchantPayerId) {
+        //     config['merchant-id'] = this.options.merchantPayerId;
+        // }
 
-        if (this.options.clientToken) {
-            config['data-client-token'] = this.options.clientToken;
-        }
+        // if (this.options.clientToken) {
+        //     config['data-client-token'] = this.options.clientToken;
+        // }
 
-        if (this.options.userIdToken) {
-            config['data-user-id-token'] = this.options.userIdToken;
-        }
+        // if (this.options.userIdToken) {
+        //     config['data-user-id-token'] = this.options.userIdToken;
+        // }
 
-        if (this.options.partnerAttributionId) {
-            config['data-partner-attribution-id'] = this.options.partnerAttributionId;
-        }
-
-        return config;
+        // if (this.options.partnerAttributionId) {
+        //     config['data-partner-attribution-id'] = this.options.partnerAttributionId;
+        // }
     }
 
     /**

--- a/src/Resources/config/services/express_checkout.xml
+++ b/src/Resources/config/services/express_checkout.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Swag\PayPal\Setting\Service\CredentialsUtil"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\TokenResource" />
             <argument type="service" id="Swag\PayPal\Checkout\Cart\Service\CartPriceService"/>
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PayLaterMethodData"/>
         </service>

--- a/src/Resources/config/services/installment.xml
+++ b/src/Resources/config/services/installment.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="Swag\PayPal\Util\LocaleCodeProvider"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Swag\PayPal\Setting\Service\CredentialsUtil"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\TokenResource" />
             <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <argument type="service" id="language.repository"/>
         </service>

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -53,6 +53,7 @@
             <argument type="service" id="Swag\PayPal\Setting\Service\CredentialsUtil"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Swag\PayPal\Util\LocaleCodeProvider"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\TokenResource" />
             <argument type="service" id="router"/>
             <argument type="service" id="request_stack"/>
         </service>
@@ -69,6 +70,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Swag\PayPal\Setting\Service\CredentialsUtil"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\TokenResource" />
         </service>
 
         <service id="Swag\PayPal\Storefront\Data\Service\ACDCCheckoutDataService" public="true" parent="Swag\PayPal\Storefront\Data\Service\AbstractCheckoutDataService"/>

--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -3,6 +3,8 @@
 {% block layout_head_javascript_hmr_mode %}
     {{ parent() }}
 
+    <script id="paypal-sdk-v6" src="https://www.sandbox.paypal.com/web-sdk/v6/core"></script>
+
     {% if page.extensions[constant('Swag\\PayPal\\Checkout\\Plus\\PlusSubscriber::PAYPAL_PLUS_DATA_EXTENSION_ID')] %}
         <script src="https://www.paypalobjects.com/webstatic/ppplus/ppplus.min.js"></script>
     {% endif %}

--- a/src/RestApi/V1/Resource/TokenResource.php
+++ b/src/RestApi/V1/Resource/TokenResource.php
@@ -30,6 +30,17 @@ class TokenResource implements TokenResourceInterface
     ) {
     }
 
+    public function getClientToken(?string $salesChannelId): Token
+    {
+        $credentials = $this->credentialProvider->createCredentialsObject($salesChannelId);
+
+        $tokenClient = $this->tokenClientFactory->createTokenClient($credentials);
+
+        return (new Token())->assign($tokenClient->getToken([
+            'response_type' => 'client_token',
+        ]));
+    }
+
     public function getToken(?string $salesChannelId): Token
     {
         $credentials = $this->credentialProvider->createCredentialsObject($salesChannelId);

--- a/src/Storefront/Data/Service/AbstractCheckoutDataService.php
+++ b/src/Storefront/Data/Service/AbstractCheckoutDataService.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Storefront\Data\Struct\AbstractCheckoutData;
@@ -38,8 +39,9 @@ abstract class AbstractCheckoutDataService extends AbstractScriptDataService
         private readonly RouterInterface $router,
         SystemConfigService $systemConfigService,
         CredentialsUtilInterface $credentialsUtil,
+        TokenResource $tokenResource,
     ) {
-        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil);
+        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil, $tokenResource);
         $this->methodData = $this->paymentMethodDataRegistry->getPaymentMethod($this->getMethodDataClass());
     }
 

--- a/src/Storefront/Data/Service/AbstractScriptDataService.php
+++ b/src/Storefront/Data/Service/AbstractScriptDataService.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\RestApi\PartnerAttributionId;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\LocaleCodeProvider;
@@ -26,6 +27,7 @@ abstract class AbstractScriptDataService
         protected readonly LocaleCodeProvider $localeCodeProvider,
         protected readonly SystemConfigService $systemConfigService,
         protected readonly CredentialsUtilInterface $credentialsUtil,
+        protected readonly TokenResource $tokenResource,
     ) {
     }
 
@@ -36,6 +38,7 @@ abstract class AbstractScriptDataService
 
         return [
             'clientId' => $this->credentialsUtil->getClientId($salesChannelId),
+            'clientToken' => $this->tokenResource->getClientToken($salesChannelId)->getAccessToken(),
             'merchantPayerId' => $merchantPayerId,
             'languageIso' => $this->getButtonLanguage($context),
             'currency' => $context->getCurrency()->getIsoCode(),

--- a/src/Storefront/Data/Service/FundingEligibilityDataService.php
+++ b/src/Storefront/Data/Service/FundingEligibilityDataService.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData;
 use Swag\PayPal\Util\LocaleCodeProvider;
@@ -27,10 +28,11 @@ class FundingEligibilityDataService extends AbstractScriptDataService
         CredentialsUtilInterface $credentialsUtil,
         SystemConfigService $systemConfigService,
         LocaleCodeProvider $localeCodeProvider,
+        TokenResource $tokenResource,
         private readonly RouterInterface $router,
         private readonly RequestStack $requestStack,
     ) {
-        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil);
+        parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil, $tokenResource);
     }
 
     public function buildData(SalesChannelContext $context): ?FundingEligibilityData

--- a/src/Storefront/Data/Service/SPBCheckoutDataService.php
+++ b/src/Storefront/Data/Service/SPBCheckoutDataService.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute;
 use Swag\PayPal\Checkout\SPBCheckout\SPBCheckoutButtonData;
+use Swag\PayPal\RestApi\V1\Resource\TokenResource;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
@@ -38,9 +39,10 @@ class SPBCheckoutDataService extends AbstractCheckoutDataService
         RouterInterface $router,
         SystemConfigService $systemConfigService,
         CredentialsUtilInterface $credentialsUtil,
+        TokenResource $tokenResource,
         private readonly CustomerVaultTokenRoute $customerVaultTokenRoute,
     ) {
-        parent::__construct($paymentMethodDataRegistry, $localeCodeProvider, $router, $systemConfigService, $credentialsUtil);
+        parent::__construct($paymentMethodDataRegistry, $localeCodeProvider, $router, $systemConfigService, $credentialsUtil, $tokenResource);
     }
 
     public function buildCheckoutData(

--- a/src/Util/LocaleCodeProvider.php
+++ b/src/Util/LocaleCodeProvider.php
@@ -21,7 +21,7 @@ class LocaleCodeProvider implements ResetInterface
 {
     private const SUPPORTED_LOCALE_CODE_LENGTH = 5;
 
-    private const DEFAULT_LOCALE_CODE = 'en_GB';
+    private const DEFAULT_LOCALE_CODE = 'en-GB';
 
     private EntityRepository $languageRepository;
 
@@ -79,7 +79,7 @@ class LocaleCodeProvider implements ResetInterface
             return self::DEFAULT_LOCALE_CODE;
         }
 
-        return $canonicalizedCode;
+        return \str_replace('_', '-', $canonicalizedCode);
     }
 
     public function reset(): void


### PR DESCRIPTION
At the PayPal Developer Days hackathon, we modernized the PayPal integration for Shopware 6—a flexible, open-source, self-hosted eCommerce platform—by upgrading from the old JavaScript SDK (v5) to the beta PayPal JS SDK (v6). This improves performance, maintainability, and aligns with PayPal’s latest standards. A key benefit is significantly faster button rendering, especially when multiple buttons appear on one page. All Shopware merchants will benefit from these improvements soon after a simple plugin update.
Since Shopware 6 isn’t quick to set up, we created a demo shop with sample products: https://ppdevdays-mbade.eu-core-1.shopdev.de