### PR TITLE
fix: vaulting enabled without userId token

### DIFF
--- a/src/Storefront/Data/Service/SPBCheckoutDataService.php
+++ b/src/Storefront/Data/Service/SPBCheckoutDataService.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Checkout\Exception\MissingCustomerVaultTokenException;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute;
 use Swag\PayPal\Checkout\SPBCheckout\SPBCheckoutButtonData;
@@ -71,7 +72,10 @@ class SPBCheckoutDataService extends AbstractCheckoutDataService
 
         $userIdToken = null;
         if ($this->methodData->isVaultable($context)) {
-            $userIdToken = $this->customerVaultTokenRoute->getVaultToken($context)->getToken();
+            try {
+                $userIdToken = $this->customerVaultTokenRoute->getVaultToken($context)->getToken();
+            } catch (MissingCustomerVaultTokenException) {
+            }
         }
 
         return (new SPBCheckoutButtonData())->assign(\array_merge($data, [

--- a/src/Storefront/Data/Service/VenmoCheckoutDataService.php
+++ b/src/Storefront/Data/Service/VenmoCheckoutDataService.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Checkout\Exception\MissingCustomerVaultTokenException;
 use Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Storefront\Data\Struct\VenmoCheckoutData;
@@ -43,7 +44,10 @@ class VenmoCheckoutDataService extends AbstractCheckoutDataService
 
         $userIdToken = null;
         if ($this->methodData->isVaultable($context)) {
-            $userIdToken = $this->customerVaultTokenRoute->getVaultToken($context)->getToken();
+            try {
+                $userIdToken = $this->customerVaultTokenRoute->getVaultToken($context)->getToken();
+            } catch (MissingCustomerVaultTokenException) {
+            }
         }
 
         return (new VenmoCheckoutData())->assign(\array_merge($data, [


### PR DESCRIPTION
If you don't have a userId token yet on the confirm checkout page, you get a token missing exception.