### PR TITLE
fix: plugin update

### DIFF
--- a/src/Resources/config/services/util.xml
+++ b/src/Resources/config/services/util.xml
@@ -50,7 +50,7 @@
         </service>
 
         <service id="Swag\PayPal\Util\Lifecycle\PluginLifecycleSubscriber">
-            <argument type="string">%kernel.project_dir%</argument>
+            <argument type="service" id="Swag\PayPal\SwagPayPal"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/config/services/util.xml
+++ b/src/Resources/config/services/util.xml
@@ -49,6 +49,11 @@
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\State\PosStateService"/>
         </service>
 
+        <service id="Swag\PayPal\Util\Lifecycle\PluginLifecycleSubscriber">
+            <argument type="string">%kernel.project_dir%</argument>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Swag\PayPal\Util\Lifecycle\State\PaymentMethodStateService" public="true">
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
             <argument type="service" id="payment_method.repository"/>

--- a/src/SwagPayPal.php
+++ b/src/SwagPayPal.php
@@ -112,8 +112,7 @@ class SwagPayPal extends Plugin
 
     public function update(UpdateContext $updateContext): void
     {
-        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
-        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
+        $this->patchAutoloader();
 
         /** @var WebhookService|null $webhookService */
         $webhookService = $this->container->get(WebhookService::class, ContainerInterface::NULL_ON_INVALID_REFERENCE);
@@ -166,8 +165,7 @@ class SwagPayPal extends Plugin
 
     public function activate(ActivateContext $activateContext): void
     {
-        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
-        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
+        $this->patchAutoloader();
 
         $this->activateDeactivate->activate($activateContext->getContext());
 
@@ -176,8 +174,7 @@ class SwagPayPal extends Plugin
 
     public function deactivate(DeactivateContext $deactivateContext): void
     {
-        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
-        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
+        $this->patchAutoloader();
 
         $this->activateDeactivate->deactivate($deactivateContext->getContext());
 
@@ -233,9 +230,15 @@ class SwagPayPal extends Plugin
 
     /**
      * @internal
+     *
+     * @phpstan-assert ContainerInterface $this->container
      */
-    public static function patchAutoloader(string $projectDir): void
+    public function patchAutoloader(): void
     {
+        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
+
+        $projectDir = $this->container->getParameter('kernel.project_dir');
+
         if (!\file_exists($projectDir . '/vendor/autoload.php')) {
             return;
         }
@@ -263,8 +266,7 @@ class SwagPayPal extends Plugin
 
     private function getInstaller(): InstallUninstall
     {
-        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
-        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
+        $this->patchAutoloader();
 
         return new InstallUninstall(
             new PaymentMethodInstaller(

--- a/src/SwagPayPal.php
+++ b/src/SwagPayPal.php
@@ -112,7 +112,8 @@ class SwagPayPal extends Plugin
 
     public function update(UpdateContext $updateContext): void
     {
-        $this->patchAutoloader();
+        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
+        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
 
         /** @var WebhookService|null $webhookService */
         $webhookService = $this->container->get(WebhookService::class, ContainerInterface::NULL_ON_INVALID_REFERENCE);
@@ -165,7 +166,8 @@ class SwagPayPal extends Plugin
 
     public function activate(ActivateContext $activateContext): void
     {
-        $this->patchAutoloader();
+        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
+        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
 
         $this->activateDeactivate->activate($activateContext->getContext());
 
@@ -174,7 +176,8 @@ class SwagPayPal extends Plugin
 
     public function deactivate(DeactivateContext $deactivateContext): void
     {
-        $this->patchAutoloader();
+        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
+        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
 
         $this->activateDeactivate->deactivate($deactivateContext->getContext());
 
@@ -228,9 +231,40 @@ class SwagPayPal extends Plugin
         $configLoader->load($confDir . '/{packages}/*.yaml', 'glob');
     }
 
+    /**
+     * @internal
+     */
+    public static function patchAutoloader(string $projectDir): void
+    {
+        if (!\file_exists($projectDir . '/vendor/autoload.php')) {
+            return;
+        }
+
+        $classLoader = require $projectDir . '/vendor/autoload.php';
+
+        if (!$classLoader instanceof ClassLoader) {
+            return;
+        }
+
+        if (!\in_array('Shopware\\PayPalSDK\\', $classLoader->getPrefixesPsr4(), true)) {
+            $classLoader->addPsr4('Shopware\\PayPalSDK\\', [
+                $projectDir . '/vendor/shopware/paypal-sdk/src',
+                __DIR__ . '/../vendor/shopware/paypal-sdk/src',
+            ]);
+        }
+
+        if (!\in_array('Http\\Discovery\\', $classLoader->getPrefixesPsr4(), true)) {
+            $classLoader->addPsr4('Http\\Discovery\\', [
+                $projectDir . '/vendor/php-http/discovery/src',
+                __DIR__ . '/../vendor/php-http/discovery/src',
+            ]);
+        }
+    }
+
     private function getInstaller(): InstallUninstall
     {
-        $this->patchAutoloader();
+        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
+        $this->patchAutoloader($this->container->getParameter('kernel.project_dir'));
 
         return new InstallUninstall(
             new PaymentMethodInstaller(
@@ -265,39 +299,5 @@ class SwagPayPal extends Plugin
         }
 
         return $repository;
-    }
-
-    /**
-     * @phpstan-assert ContainerInterface $this->container
-     */
-    private function patchAutoloader(): void
-    {
-        \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `platform/Core/Kernel.php:186`.');
-
-        $projectDir = $this->container->getParameter('kernel.project_dir');
-
-        if (!\file_exists($projectDir . '/vendor/autoload.php')) {
-            return;
-        }
-
-        $classLoader = require $projectDir . '/vendor/autoload.php';
-
-        if (!$classLoader instanceof ClassLoader) {
-            return;
-        }
-
-        if (!\in_array('Shopware\\PayPalSDK\\', $classLoader->getPrefixesPsr4(), true)) {
-            $classLoader->addPsr4('Shopware\\PayPalSDK\\', [
-                $projectDir . '/vendor/shopware/paypal-sdk/src',
-                __DIR__ . '/../vendor/shopware/paypal-sdk/src',
-            ]);
-        }
-
-        if (!\in_array('Http\\Discovery\\', $classLoader->getPrefixesPsr4(), true)) {
-            $classLoader->addPsr4('Http\\Discovery\\', [
-                $projectDir . '/vendor/php-http/discovery/src',
-                __DIR__ . '/../vendor/php-http/discovery/src',
-            ]);
-        }
     }
 }

--- a/src/Util/Lifecycle/PluginLifecycleSubscriber.php
+++ b/src/Util/Lifecycle/PluginLifecycleSubscriber.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class PluginLifecycleSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly string $projectDir,
+        private readonly SwagPayPal $plugin,
     ) {
     }
 
@@ -33,7 +33,7 @@ class PluginLifecycleSubscriber implements EventSubscriberInterface
     public function pluginUpdate(PluginPreUpdateEvent $event): void
     {
         if ($event->getPlugin()->getName() === 'SwagPayPal') {
-            SwagPayPal::patchAutoloader($this->projectDir);
+            $this->plugin->patchAutoloader();
         }
     }
 }

--- a/src/Util/Lifecycle/PluginLifecycleSubscriber.php
+++ b/src/Util/Lifecycle/PluginLifecycleSubscriber.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Util\Lifecycle;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Event\PluginPreUpdateEvent;
+use Swag\PayPal\SwagPayPal;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PluginLifecycleSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            PluginPreUpdateEvent::class => ['pluginUpdate',  \PHP_INT_MAX],
+        ];
+    }
+
+    public function pluginUpdate(PluginPreUpdateEvent $event): void
+    {
+        if ($event->getPlugin()->getName() === 'SwagPayPal') {
+            SwagPayPal::patchAutoloader($this->projectDir);
+        }
+    }
+}


### PR DESCRIPTION
During the update of the plugin we need to additionally patch the autoloader as the `PluginPreUpdateEvent` will fail otherwise