### PR TITLE
fix: express checkout event access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.7.6
+- Fixes an issue, where the Express Checkout was not displayed correctly on certain pages (shopware/SwagPayPal#234)
+
 # 9.7.5
 - Fixes an issue, where the PayLater button is not displayed on a product Page when the cart is empty (shopware/shopware#8356)
 - Fixes an issue, where vaulted payments could not be processed in the after order payment process in certain situations

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 9.7.6
+- Behebt ein Problem, bei dem der Express Checkout auf bestimmten Seiten nicht korrekt angezeigt wurde (shopware/SwagPayPal#234)
+
 # 9.7.5
 - Behebt ein Problem, bei dem der PayLater Button auf einer Produktseite nicht angezeigt wird, wenn der Warenkorb leer ist (shopware/shopware#8356)
 - Behebt ein Problem, bei dem Vaulting-Zahlungen in bestimmten Fällen im Zahlungsprozess nach einer Bestellung nicht ausgeführt werden konnten

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -76,9 +76,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
         $context = $salesChannelContext->getContext();
         $salesChannelId = $salesChannelContext->getSalesChannelId();
         $eventName = $salesChannelContext->getExtensionOfType(ExpressCheckoutSubscriber::PAYPAL_EXPRESS_CHECKOUT_EVENT_NAME, ArrayStruct::class);
-        if ($eventName === null) {
-            $eventName = new ArrayStruct();
-        }
+        $eventName ??= new ArrayStruct();
 
         $fundingSources = ['paypal', 'venmo'];
 
@@ -139,7 +137,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
      */
     private function showPayLater(string $salesChannelId, AvailabilityContext $availabilityContext, ArrayStruct $eventName): bool
     {
-        return $eventName->all()[0] === ProductPageLoadedEvent::class
+        return $eventName->get(0) === ProductPageLoadedEvent::class
             && $this->systemConfigService->getBool(Settings::ECS_SHOW_PAY_LATER, $salesChannelId)
             && $this->payLaterMethodData->isAvailable($availabilityContext);
     }

--- a/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
@@ -266,6 +266,49 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
         static::assertSame($payLaterAvailable && $showPayLaterSetting, $expressCheckoutButtonData->isShowPayLater());
     }
 
+    public function testGetExpressCheckoutButtonDataWithoutEventNameExtension(): void
+    {
+        $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $this->systemConfigService->set(Settings::ECS_SHOW_PAY_LATER, true, $salesChannelContext->getSalesChannelId());
+
+        $context = Context::createDefaultContext();
+        $taxId = $this->createTaxId($context);
+        $productId = $this->getProductId($context, $taxId);
+        $product = new SalesChannelProductEntity();
+        $product->setId($productId);
+        $product->setPrice(new PriceCollection([
+            new Price(Defaults::CURRENCY, 2, 5, false),
+        ]));
+        $product->setCalculatedPrice(new CalculatedPrice(
+            2,
+            2,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection()
+        ));
+
+        $salesChannelContext->addExtension(ExpressCheckoutSubscriber::PAYPAL_PAYLATER_PRODUCT, $product);
+
+        $payLaterMethodData = $this->createMock(PayLaterMethodData::class);
+        $payLaterMethodData->method('isAvailable')
+            ->willReturn(true);
+
+        $payPalExpressCheckoutDataService = new PayPalExpressCheckoutDataService(
+            $this->getContainer()->get(CartService::class),
+            $this->getContainer()->get(LocaleCodeProvider::class),
+            $this->getContainer()->get('router'),
+            $this->paymentMethodUtil,
+            $this->systemConfigService,
+            new CredentialsUtil($this->systemConfigService),
+            $this->getContainer()->get(CartPriceService::class),
+            $payLaterMethodData
+        );
+
+        $expressCheckoutButtonData = $payPalExpressCheckoutDataService->buildExpressCheckoutButtonData($salesChannelContext, true);
+
+        static::assertNotNull($expressCheckoutButtonData);
+    }
+
     public static function dataProviderTestFundingSourcesWithPayLater(): array
     {
         return [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The SalesChannelContext extension, which contains the event name, is not always present. The default is an empty ArrayStruct, which results in an 'undefined array key' error further down the code.

### 2. What does this change do, exactly?
Replace the array key access with a proper method call, which returns `null` on an undefined array key instead.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- fixes #234

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
