### PR TITLE
feat: remove delay message stamp

### DIFF
--- a/src/Pos/DataAbstractionLayer/Entity/PosSalesChannelInventoryEntity.php
+++ b/src/Pos/DataAbstractionLayer/Entity/PosSalesChannelInventoryEntity.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Pos\DataAbstractionLayer\Entity;
 
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\Log\Package;
 
@@ -16,6 +17,8 @@ class PosSalesChannelInventoryEntity extends Entity
     protected string $salesChannelId;
 
     protected string $productId;
+
+    protected ?ProductEntity $product = null;
 
     protected string $productVersionId;
 
@@ -39,6 +42,16 @@ class PosSalesChannelInventoryEntity extends Entity
     public function setProductId(string $productId): void
     {
         $this->productId = $productId;
+    }
+
+    public function getProduct(): ?ProductEntity
+    {
+        return $this->product;
+    }
+
+    public function setProduct(?ProductEntity $product): void
+    {
+        $this->product = $product;
     }
 
     public function getProductVersionId(): string

--- a/src/Pos/DataAbstractionLayer/Entity/PosSalesChannelProductEntity.php
+++ b/src/Pos/DataAbstractionLayer/Entity/PosSalesChannelProductEntity.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Pos\DataAbstractionLayer\Entity;
 
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\Log\Package;
 
@@ -16,6 +17,8 @@ class PosSalesChannelProductEntity extends Entity
     protected string $salesChannelId;
 
     protected string $productId;
+
+    protected ?ProductEntity $product = null;
 
     protected string $productVersionId;
 
@@ -39,6 +42,16 @@ class PosSalesChannelProductEntity extends Entity
     public function setProductId(string $productId): void
     {
         $this->productId = $productId;
+    }
+
+    public function getProduct(): ?ProductEntity
+    {
+        return $this->product;
+    }
+
+    public function setProduct(?ProductEntity $product): void
+    {
+        $this->product = $product;
     }
 
     public function getProductVersionId(): string

--- a/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
+++ b/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
@@ -8,9 +8,9 @@
 namespace Swag\PayPal\Pos\MessageQueue\Handler;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -29,27 +29,15 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 class InventoryUpdateHandler
 {
-    private RunService $runService;
-
-    private EntityRepository $salesChannelRepository;
-
-    private InventorySyncManager $inventorySyncManager;
-
-    private MessageDispatcher $messageBus;
-
     /**
      * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
-        RunService $runService,
-        EntityRepository $salesChannelRepository,
-        InventorySyncManager $inventorySyncManager,
-        MessageDispatcher $messageBus,
+        private readonly RunService $runService,
+        private readonly EntityRepository $salesChannelRepository,
+        private readonly InventorySyncManager $inventorySyncManager,
+        private readonly MessageDispatcher $messageBus,
     ) {
-        $this->runService = $runService;
-        $this->salesChannelRepository = $salesChannelRepository;
-        $this->inventorySyncManager = $inventorySyncManager;
-        $this->messageBus = $messageBus;
     }
 
     public function __invoke(InventoryUpdateMessage $message): void
@@ -70,13 +58,16 @@ class InventoryUpdateHandler
         }
     }
 
-    private function getSalesChannels(Context $context): EntitySearchResult
+    /**
+     * @return SalesChannelCollection
+     */
+    private function getSalesChannels(Context $context): EntityCollection
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('typeId', SwagPayPal::SALES_CHANNEL_TYPE_POS));
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addAssociation(SwagPayPal::SALES_CHANNEL_POS_EXTENSION);
 
-        return $this->salesChannelRepository->search($criteria, $context);
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
 }

--- a/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
+++ b/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
@@ -8,7 +8,6 @@
 namespace Swag\PayPal\Pos\MessageQueue\Handler;
 
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -58,10 +57,7 @@ class InventoryUpdateHandler
         }
     }
 
-    /**
-     * @return SalesChannelCollection
-     */
-    private function getSalesChannels(Context $context): EntityCollection
+    private function getSalesChannels(Context $context): SalesChannelCollection
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('typeId', SwagPayPal::SALES_CHANNEL_TYPE_POS));

--- a/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
+++ b/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
@@ -36,6 +36,9 @@ class InventoryUpdateHandler
 
     private MessageDispatcher $messageBus;
 
+    /**
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     */
     public function __construct(
         RunService $runService,
         EntityRepository $salesChannelRepository,
@@ -73,9 +76,6 @@ class InventoryUpdateHandler
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addAssociation(SwagPayPal::SALES_CHANNEL_POS_EXTENSION);
 
-        /** @var SalesChannelCollection $salesChannels */
-        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
-
-        return $salesChannels;
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
 }

--- a/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
+++ b/src/Pos/MessageQueue/Handler/InventoryUpdateHandler.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Pos\MessageQueue\Handler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -69,13 +70,13 @@ class InventoryUpdateHandler
         }
     }
 
-    private function getSalesChannels(Context $context): SalesChannelCollection
+    private function getSalesChannels(Context $context): EntitySearchResult
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('typeId', SwagPayPal::SALES_CHANNEL_TYPE_POS));
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addAssociation(SwagPayPal::SALES_CHANNEL_POS_EXTENSION);
 
-        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
+        return $this->salesChannelRepository->search($criteria, $context);
     }
 }

--- a/src/Pos/MessageQueue/Manager/InventorySyncManager.php
+++ b/src/Pos/MessageQueue/Manager/InventorySyncManager.php
@@ -76,20 +76,19 @@ class InventorySyncManager extends AbstractSyncManager
             $accumulatedIds[] = $id;
 
             if (\count($accumulatedIds) >= self::CHUNK_SIZE) {
-                $messages[] = $this->createMessage($context, $inventoryContext, $salesChannel, $runId, $accumulatedIds, $parentIds);
+                $messages[] = $this->createMessage($inventoryContext, $salesChannel, $runId, $accumulatedIds, $parentIds);
                 $accumulatedIds = [];
             }
         }
 
         if (\count($accumulatedIds) > 0) {
-            $messages[] = $this->createMessage($context, $inventoryContext, $salesChannel, $runId, $accumulatedIds, $parentIds);
+            $messages[] = $this->createMessage($inventoryContext, $salesChannel, $runId, $accumulatedIds, $parentIds);
         }
 
         return $messages;
     }
 
     private function createMessage(
-        Context $context,
         InventoryContext $inventoryContext,
         SalesChannelEntity $salesChannel,
         string $runId,

--- a/src/Pos/MessageQueue/Message/InventoryUpdateMessage.php
+++ b/src/Pos/MessageQueue/Message/InventoryUpdateMessage.php
@@ -22,7 +22,7 @@ class InventoryUpdateMessage implements AsyncMessageInterface, \JsonSerializable
     /**
      * @var string[]
      */
-    private array $ids;
+    private array $ids = [];
 
     private ?Context $context = null;
 

--- a/src/Pos/Sync/Inventory/StockSubscriber.php
+++ b/src/Pos/Sync/Inventory/StockSubscriber.php
@@ -7,28 +7,17 @@
 
 namespace Swag\PayPal\Pos\Sync\Inventory;
 
-use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
-use Shopware\Core\Checkout\Cart\LineItem\LineItem;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
-use Shopware\Core\Checkout\Order\OrderDefinition;
-use Shopware\Core\Checkout\Order\OrderEvents;
-use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Content\Product\Events\ProductStockAlteredEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
 use Swag\PayPal\Pos\MessageQueue\Message\InventoryUpdateMessage;
 use Swag\PayPal\SwagPayPal;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * @internal
@@ -36,25 +25,10 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 #[Package('checkout')]
 class StockSubscriber implements EventSubscriberInterface
 {
-    /**
-     * Needed for letting the StockUpdater first recalculate availableStock
-     */
-    private const DELAY = 10000;
-
-    private EntityRepository $orderLineItemRepository;
-
-    private MessageBusInterface $messageBus;
-
-    private EntityRepository $salesChannelRepository;
-
     public function __construct(
-        EntityRepository $orderLineItemRepository,
-        MessageBusInterface $messageBus,
-        EntityRepository $salesChannelRepository,
+        private readonly MessageBusInterface $messageBus,
+        private readonly EntityRepository    $salesChannelRepository,
     ) {
-        $this->orderLineItemRepository = $orderLineItemRepository;
-        $this->messageBus = $messageBus;
-        $this->salesChannelRepository = $salesChannelRepository;
     }
 
     /**
@@ -63,106 +37,13 @@ class StockSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CheckoutOrderPlacedEvent::class => 'orderPlaced',
-            StateMachineTransitionEvent::class => 'stateChanged',
-            OrderEvents::ORDER_LINE_ITEM_WRITTEN_EVENT => 'lineItemWritten',
-            OrderEvents::ORDER_LINE_ITEM_DELETED_EVENT => 'lineItemWritten',
+            ProductStockAlteredEvent::class => 'updateInventory',
         ];
     }
 
-    /**
-     * If the product of an order item changed, the stocks of the old product and the new product must be updated.
-     */
-    public function lineItemWritten(EntityWrittenEvent $event): void
+    public function updateInventory(ProductStockAlteredEvent $event): void
     {
-        $ids = [];
-
-        foreach ($event->getWriteResults() as $result) {
-            if ($result->hasPayload('referencedId') && $result->getProperty('type') === LineItem::PRODUCT_LINE_ITEM_TYPE) {
-                $ids[] = $result->getProperty('referencedId');
-            }
-
-            if ($result->getOperation() === EntityWriteResult::OPERATION_INSERT) {
-                continue;
-            }
-
-            $changeSet = $result->getChangeSet();
-            if (!$changeSet) {
-                continue;
-            }
-
-            $type = $changeSet->getBefore('type');
-
-            if ($type !== LineItem::PRODUCT_LINE_ITEM_TYPE) {
-                continue;
-            }
-
-            if (!$changeSet->hasChanged('referenced_id') && !$changeSet->hasChanged('quantity')) {
-                continue;
-            }
-
-            $ids[] = $changeSet->getBefore('referenced_id');
-            $ids[] = $changeSet->getAfter('referenced_id');
-        }
-
-        $this->startSync(\array_unique(\array_filter($ids)), $event->getContext());
-    }
-
-    public function stateChanged(StateMachineTransitionEvent $event): void
-    {
-        $context = $event->getContext();
-        if ($context->getVersionId() !== Defaults::LIVE_VERSION) {
-            return;
-        }
-
-        if ($event->getEntityName() !== OrderDefinition::ENTITY_NAME) {
-            return;
-        }
-
-        $to = $event->getToPlace()->getTechnicalName();
-        $from = $event->getFromPlace()->getTechnicalName();
-
-        if ($to !== OrderStates::STATE_COMPLETED && $from !== OrderStates::STATE_COMPLETED
-         && $to !== OrderStates::STATE_CANCELLED && $from !== OrderStates::STATE_CANCELLED) {
-            return;
-        }
-
-        if ($this->posSalesChannelDoesNotExist($context)) {
-            return;
-        }
-
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('orderId', $event->getEntityId()));
-        $criteria->addFilter(new EqualsFilter('type', LineItem::PRODUCT_LINE_ITEM_TYPE));
-
-        /** @var OrderLineItemCollection $lineItems */
-        $lineItems = $this->orderLineItemRepository->search($criteria, $context)->getEntities();
-
-        $ids = [];
-        foreach ($lineItems as $lineItem) {
-            /* @var OrderLineItemEntity $lineItem */
-            $ids[] = $lineItem->getReferencedId();
-        }
-
-        $this->startSync($ids, $context);
-    }
-
-    public function orderPlaced(CheckoutOrderPlacedEvent $event): void
-    {
-        $ids = [];
-        $lineItems = $event->getOrder()->getLineItems();
-        if ($lineItems === null) {
-            return;
-        }
-
-        foreach ($lineItems as $lineItem) {
-            if ($lineItem->getType() !== LineItem::PRODUCT_LINE_ITEM_TYPE) {
-                continue;
-            }
-            $ids[] = $lineItem->getReferencedId();
-        }
-
-        $this->startSync($ids, $event->getContext());
+        $this->startSync($event->getIds(), $event->getContext());
     }
 
     private function posSalesChannelDoesNotExist(Context $context): bool
@@ -170,6 +51,7 @@ class StockSubscriber implements EventSubscriberInterface
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('typeId', SwagPayPal::SALES_CHANNEL_TYPE_POS));
         $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->setLimit(1);
 
         return $this->salesChannelRepository->searchIds($criteria, $context)->getTotal() === 0;
     }
@@ -190,9 +72,7 @@ class StockSubscriber implements EventSubscriberInterface
 
         $message = new InventoryUpdateMessage();
         $message->setIds($productIds);
-        $envelope = new Envelope($message, [
-            new DelayStamp(self::DELAY), // @phpstan-ignore-line shopware.noDelayStamp
-        ]);
-        $this->messageBus->dispatch($envelope);
+
+        $this->messageBus->dispatch($message);
     }
 }

--- a/src/Pos/Sync/Inventory/StockSubscriber.php
+++ b/src/Pos/Sync/Inventory/StockSubscriber.php
@@ -27,7 +27,7 @@ class StockSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
-        private readonly EntityRepository    $salesChannelRepository,
+        private readonly EntityRepository $salesChannelRepository,
     ) {
     }
 

--- a/src/Resources/app/administration/.gitignore
+++ b/src/Resources/app/administration/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.tmp

--- a/src/Resources/config/services/pos/sync.xml
+++ b/src/Resources/config/services/pos/sync.xml
@@ -57,7 +57,6 @@
         </service>
 
         <service id="Swag\PayPal\Pos\Sync\Inventory\StockSubscriber">
-            <argument type="service" id="order_line_item.repository"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="sales_channel.repository"/>
             <tag name="kernel.event_subscriber"/>

--- a/tests/Pos/MessageQueue/Handler/InventoryUpdateHandlerTest.php
+++ b/tests/Pos/MessageQueue/Handler/InventoryUpdateHandlerTest.php
@@ -55,7 +55,7 @@ class InventoryUpdateHandlerTest extends TestCase
         $mockResult = [
             'random',
             'AbstractSyncMessage',
-            'values'
+            'values',
         ];
 
         $inventorySyncMock = $this->createMock(InventorySyncManager::class);

--- a/tests/Pos/MessageQueue/Handler/InventoryUpdateHandlerTest.php
+++ b/tests/Pos/MessageQueue/Handler/InventoryUpdateHandlerTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Pos\MessageQueue\Handler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Swag\PayPal\Pos\MessageQueue\Handler\InventoryUpdateHandler;
+use Swag\PayPal\Pos\MessageQueue\Manager\InventorySyncManager;
+use Swag\PayPal\Pos\MessageQueue\Message\InventoryUpdateMessage;
+use Swag\PayPal\Pos\MessageQueue\MessageDispatcher;
+use Swag\PayPal\Pos\Run\RunService;
+use Swag\PayPal\Test\Pos\Helper\SalesChannelTrait;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(InventoryUpdateHandler::class)]
+class InventoryUpdateHandlerTest extends TestCase
+{
+    use KernelTestBehaviour;
+    use SalesChannelTrait;
+
+    public function testTest(): void
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $repositoryMock = $this->createMock(EntityRepository::class);
+        $repositoryMock
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                new SalesChannelCollection([$salesChannel]),
+                null,
+                new Criteria(),
+                Context::createDefaultContext()
+            ));
+
+        $mockResult = [
+            'random',
+            'AbstractSyncMessage',
+            'values'
+        ];
+
+        $inventorySyncMock = $this->createMock(InventorySyncManager::class);
+        $inventorySyncMock
+            ->method('createMessages')
+            ->willReturn($mockResult);
+
+        $dispatcherMock = $this->createMock(MessageDispatcher::class);
+        $dispatcherMock
+            ->method('bulkDispatch')
+            ->with($mockResult);
+
+        (new InventoryUpdateHandler(
+            $this->createMock(RunService::class),
+            $repositoryMock,
+            $inventorySyncMock,
+            $dispatcherMock,
+        ))(new InventoryUpdateMessage());
+    }
+}

--- a/tests/Pos/Sync/Inventory/StockSubscriberTest.php
+++ b/tests/Pos/Sync/Inventory/StockSubscriberTest.php
@@ -7,225 +7,110 @@
 
 namespace Swag\PayPal\Test\Pos\Sync\Inventory;
 
-use Doctrine\DBAL\Connection;
-use Monolog\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
-use Shopware\Core\Checkout\Cart\LineItem\LineItem;
-use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
-use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
-use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
-use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
-use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
-use Shopware\Core\Checkout\Order\OrderDefinition;
-use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Checkout\Order\OrderStates;
-use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
-use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
-use Shopware\Core\Defaults;
+use Shopware\Core\Content\Product\Events\ProductStockAlteredEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\ChangeSet;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
-use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
-use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\Generator;
-use Shopware\Core\Test\TestDefaults;
-use Swag\PayPal\Pos\Api\Service\Converter\UuidConverter;
-use Swag\PayPal\Pos\MessageQueue\Handler\InventoryUpdateHandler;
-use Swag\PayPal\Pos\MessageQueue\Manager\InventorySyncManager;
-use Swag\PayPal\Pos\MessageQueue\Message\Sync\InventorySyncMessage;
-use Swag\PayPal\Pos\MessageQueue\MessageDispatcher;
-use Swag\PayPal\Pos\Resource\InventoryResource;
-use Swag\PayPal\Pos\Sync\Context\InventoryContextFactory;
+use Swag\PayPal\Pos\MessageQueue\Message\InventoryUpdateMessage;
 use Swag\PayPal\Pos\Sync\Inventory\StockSubscriber;
-use Swag\PayPal\Pos\Sync\ProductSelection;
 use Swag\PayPal\Test\Pos\ConstantsForTesting;
 use Swag\PayPal\Test\Pos\Helper\SalesChannelTrait;
-use Swag\PayPal\Test\Pos\Mock\Client\PosClientFactoryMock;
 use Swag\PayPal\Test\Pos\Mock\MessageBusMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\OrderLineItemRepoMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\PosInventoryRepoMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\ProductRepoMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\RunLogRepoMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
-use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelProductRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
-use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
-use Symfony\Component\Messenger\MessageBus;
 
 /**
  * @internal
  */
 #[Package('checkout')]
+#[CoversClass(StockSubscriber::class)]
 class StockSubscriberTest extends TestCase
 {
-    use BasicTestDataBehaviour;
     use KernelTestBehaviour;
     use SalesChannelTrait;
 
-    public function testStateChanged(): void
-    {
-        $this->process(function (StockSubscriber $stockSubscriber, OrderEntity $order, SalesChannelContext $context): void {
-            $event = $this->createStateMachineTransitionEvent($order->getId(), $context->getContext());
+    private MockObject&EntityRepository $repositoryMock;
 
-            $stockSubscriber->stateChanged($event);
+    public function testAddInventoryMessage(): void
+    {
+        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+            $event = new ProductStockAlteredEvent([
+                ConstantsForTesting::PRODUCT_A_ID,
+                ConstantsForTesting::PRODUCT_B_ID,
+                ConstantsForTesting::PRODUCT_C_ID,
+            ], $context->getContext());
+
+            $stockSubscriber->updateInventory($event);
         });
     }
 
-    public function testStateChangedWithoutPosSalesChannel(): void
+    public function testEmptyProductIds(): void
     {
-        $event = $this->createStateMachineTransitionEvent(Uuid::randomHex(), Context::createDefaultContext());
-
-        $orderLineItemRepo = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
-        $orderLineItemRepo->expects(static::never())->method('search');
-        $salesChannelRepository = $this->getContainer()->get('sales_channel.repository');
-
-        $stockSubscriber = new StockSubscriber(
-            $orderLineItemRepo,
-            new MessageBusMock(),
-            $salesChannelRepository
-        );
-
-        $stockSubscriber->stateChanged($event);
+        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+            $stockSubscriber->updateInventory(new ProductStockAlteredEvent([], $context->getContext()));
+        }, false);
     }
 
-    public function testLineItemWritten(): void
+    public function testNoPosSalesChannel(): void
     {
-        $this->process(function (StockSubscriber $stockSubscriber, OrderEntity $order, SalesChannelContext $context): void {
-            $event = $this->createEntityWrittenEvent($order, $context->getContext());
+        $this->repositoryMock = $this->createMock(EntityRepository::class);
+        $this->repositoryMock
+            ->method('searchIds')
+            ->willReturn(new IdSearchResult(0, [], new Criteria(), Context::createDefaultContext()));
 
-            $stockSubscriber->lineItemWritten($event);
-        });
+        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+            $event = new ProductStockAlteredEvent([
+                ConstantsForTesting::PRODUCT_A_ID,
+                ConstantsForTesting::PRODUCT_B_ID,
+                ConstantsForTesting::PRODUCT_C_ID,
+            ], $context->getContext());
+
+            $stockSubscriber->updateInventory($event);
+        }, false);
     }
 
-    public function testLineItemWrittenWithoutPosSalesChannel(): void
+    public function testNotLiveContext(): void
     {
-        $context = Context::createDefaultContext();
-        $order = $this->createOrder($context);
-        $event = $this->createEntityWrittenEvent($order, $context);
+        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+            $event = new ProductStockAlteredEvent([
+                ConstantsForTesting::PRODUCT_A_ID,
+                ConstantsForTesting::PRODUCT_B_ID,
+                ConstantsForTesting::PRODUCT_C_ID,
+            ], $context->getContext()->createWithVersionId(Uuid::randomHex()));
 
-        $this->createStockSubscriber()->lineItemWritten($event);
-    }
-
-    public function testOrderPlaced(): void
-    {
-        $this->process(function (StockSubscriber $stockSubscriber, OrderEntity $order, SalesChannelContext $context): void {
-            $event = $this->createCheckoutOrderPlacedEvent($context, $order);
-
-            $stockSubscriber->orderPlaced($event);
-        });
-    }
-
-    public function testOrderPlacedWithoutPosSalesChannel(): void
-    {
-        $salesChannelContext = Generator::generateSalesChannelContext();
-        $order = $this->createOrder($salesChannelContext->getContext());
-        $event = $this->createCheckoutOrderPlacedEvent($salesChannelContext, $order);
-
-        $this->createStockSubscriber()->orderPlaced($event);
+            $stockSubscriber->updateInventory($event);
+        }, false);
     }
 
     private function process(callable $callback, bool $shouldWork = true): void
     {
         $salesChannelContext = Generator::generateSalesChannelContext();
 
-        $inventoryResource = new InventoryResource(new PosClientFactoryMock());
-        $inventoryRepository = new PosInventoryRepoMock();
-        $productRepository = new ProductRepoMock();
-        $salesChannelProductRepository = new SalesChannelProductRepoMock();
-        $salesChannel = $this->getSalesChannel($salesChannelContext->getContext());
-        $salesChannelRepository = new SalesChannelRepoMock();
-        $salesChannelRepository->getCollection()->clear();
-        $salesChannelRepository->addMockEntity($salesChannel);
+        if (!isset($this->repositoryMock)) {
+            $salesChannel = $this->getSalesChannel($salesChannelContext->getContext());
 
-        $inventoryContextFactory = new InventoryContextFactory(
-            $inventoryResource,
-            new UuidConverter(),
-            $inventoryRepository
-        );
+            $salesChannelRepository = new SalesChannelRepoMock();
+            $salesChannelRepository->getCollection()->clear();
+            $salesChannelRepository->addMockEntity($salesChannel);
+        } else {
+            $salesChannelRepository = $this->repositoryMock;
+        }
 
         $messageBus = new MessageBusMock();
-        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class));
-
-        $inventorySyncManager = new InventorySyncManager(
-            $messageDispatcher,
-            new ProductSelection(
-                $salesChannelProductRepository,
-                $this->createMock(ProductStreamBuilder::class),
-                $this->getContainer()->get(SalesChannelContextFactory::class),
-            ),
-            $salesChannelProductRepository,
-            $inventoryContextFactory,
-            true,
-        );
-
-        $runService = new RunServiceMock(
-            new RunRepoMock(),
-            new RunLogRepoMock(),
-            $this->createMock(Connection::class),
-            new Logger('test')
-        );
-
-        $inventoryUpdateHandler = new InventoryUpdateHandler(
-            $runService,
-            $salesChannelRepository,
-            $inventorySyncManager,
-            $messageDispatcher
-        );
-
-        $orderLineItemRepository = new OrderLineItemRepoMock();
-
-        $stockSubscriber = new StockSubscriber(
-            $orderLineItemRepository,
-            $messageBus,
-            $salesChannelRepository
-        );
-
-        /*
-         * A - unchanged
-         * B - increased stock
-         * C - decreased stock
-         */
-        $productA = $productRepository->createMockEntity('productA', 2, 1, ConstantsForTesting::PRODUCT_A_ID);
-        $productA = SalesChannelProductEntity::createFrom($productA);
-        $salesChannelProductRepository->addMockEntity($productA);
-        $productB = $productRepository->createMockEntity('productB', 2, 2, ConstantsForTesting::PRODUCT_B_ID);
-        $productB = SalesChannelProductEntity::createFrom($productB);
-        $salesChannelProductRepository->addMockEntity($productB);
-        $productC = $productRepository->createMockEntity('productC', 2, 0, ConstantsForTesting::PRODUCT_C_ID);
-        $productC = SalesChannelProductEntity::createFrom($productC);
-        $salesChannelProductRepository->addMockEntity($productC);
-
-        $inventoryRepository->createMockEntity($productA, TestDefaults::SALES_CHANNEL, 1);
-        $inventoryRepository->createMockEntity($productB, TestDefaults::SALES_CHANNEL, 1);
-        $inventoryRepository->createMockEntity($productC, TestDefaults::SALES_CHANNEL, 1);
-
-        $order = $this->createOrder($salesChannelContext->getContext());
-        $lineItems = $order->getLineItems();
-        static::assertNotNull($lineItems);
-
-        $repoCollection = $orderLineItemRepository->getCollection();
-        $repoCollection->merge($lineItems);
-
-        $callback($stockSubscriber, $order, $salesChannelContext);
-        $messageBus->execute([$inventoryUpdateHandler]);
+        $callback(new StockSubscriber($messageBus, $salesChannelRepository), $salesChannelContext);
 
         $inventoryMessageCreated = false;
         foreach ($messageBus->getEnvelopes() as $envelope) {
             $message = $envelope->getMessage();
-            if ($message instanceof InventorySyncMessage) {
+            if ($message instanceof InventoryUpdateMessage) {
                 $inventoryMessageCreated = true;
                 static::assertEqualsCanonicalizing(
                     [
@@ -233,146 +118,11 @@ class StockSubscriberTest extends TestCase
                         ConstantsForTesting::PRODUCT_B_ID,
                         ConstantsForTesting::PRODUCT_C_ID,
                     ],
-                    $message->getInventoryContext()->getProductIds()
+                    $message->getIds()
                 );
             }
         }
 
         static::assertSame($shouldWork, $inventoryMessageCreated);
-    }
-
-    private function createStockSubscriber(): StockSubscriber
-    {
-        $messageBus = $this->getMockBuilder(MessageBus::class)->disableOriginalConstructor()->getMock();
-        $messageBus->expects(static::never())->method('dispatch');
-        $salesChannelRepository = $this->getContainer()->get('sales_channel.repository');
-
-        return new StockSubscriber(
-            new OrderLineItemRepoMock(),
-            $messageBus,
-            $salesChannelRepository
-        );
-    }
-
-    private function createEntityWrittenEvent(OrderEntity $order, Context $context): EntityWrittenEvent
-    {
-        return new EntityWrittenEvent(OrderLineItemDefinition::ENTITY_NAME, [
-            new EntityWriteResult(
-                Uuid::randomHex(),
-                [
-                    'orderId' => $order->getId(),
-                    'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                    'referencedId' => ConstantsForTesting::PRODUCT_A_ID,
-                    'quantity' => 1,
-                ],
-                OrderLineItemDefinition::ENTITY_NAME,
-                EntityWriteResult::OPERATION_INSERT
-            ),
-            new EntityWriteResult(
-                Uuid::randomHex(),
-                [],
-                OrderLineItemDefinition::ENTITY_NAME,
-                EntityWriteResult::OPERATION_UPDATE,
-                null,
-                new ChangeSet(
-                    [
-                        'order_id' => $order->getId(),
-                        'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                        'referenced_id' => ConstantsForTesting::PRODUCT_C_ID,
-                        'quantity' => 2,
-                    ],
-                    [
-                        'order_id' => $order->getId(),
-                        'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                        'referenced_id' => ConstantsForTesting::PRODUCT_C_ID,
-                        'quantity' => 1,
-                    ],
-                    false
-                )
-            ),
-            new EntityWriteResult(
-                Uuid::randomHex(),
-                [],
-                OrderLineItemDefinition::ENTITY_NAME,
-                EntityWriteResult::OPERATION_UPDATE,
-                null,
-                new ChangeSet(
-                    [
-                        'order_id' => $order->getId(),
-                        'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                        'referenced_id' => ConstantsForTesting::PRODUCT_B_ID,
-                    ],
-                    [
-                        'order_id' => $order->getId(),
-                        'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                        'referenced_id' => ConstantsForTesting::PRODUCT_C_ID,
-                    ],
-                    false
-                )
-            ),
-        ], $context);
-    }
-
-    private function createOrder(Context $context): OrderEntity
-    {
-        $order = new OrderEntity();
-        $order->assign([
-            'id' => Uuid::randomHex(),
-            'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
-            'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
-            'stateId' => $this->getContainer()->get(InitialStateIdLoader::class)->get(OrderStates::STATE_MACHINE),
-            'paymentMethodId' => $this->getValidPaymentMethodId(),
-            'currencyId' => Defaults::CURRENCY,
-            'currencyFactor' => 1,
-            'salesChannelId' => TestDefaults::SALES_CHANNEL,
-            'orderDateTime' => '2019-04-01 08:36:43.267',
-        ]);
-
-        $productIds = [
-            ConstantsForTesting::PRODUCT_A_ID,
-            ConstantsForTesting::PRODUCT_B_ID,
-            ConstantsForTesting::PRODUCT_C_ID,
-        ];
-
-        $lineItems = new OrderLineItemCollection();
-        foreach ($productIds as $productId) {
-            $lineItem = new OrderLineItemEntity();
-            $lineItem->assign([
-                'id' => Uuid::randomHex(),
-                'versionId' => Uuid::randomHex(),
-                'identifier' => 'test',
-                'quantity' => 1,
-                'type' => LineItem::PRODUCT_LINE_ITEM_TYPE,
-                'label' => 'test',
-                'price' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
-                'priceDefinition' => new QuantityPriceDefinition(10, new TaxRuleCollection(), 2),
-                'priority' => 100,
-                'good' => true,
-                'referencedId' => $productId,
-            ]);
-            $lineItems->add($lineItem);
-        }
-
-        $order->setLineItems($lineItems);
-
-        return $order;
-    }
-
-    private function createStateMachineTransitionEvent(string $orderId, Context $context): StateMachineTransitionEvent
-    {
-        $from = new StateMachineStateEntity();
-        $from->setTechnicalName(OrderStates::STATE_OPEN);
-        $to = new StateMachineStateEntity();
-        $to->setTechnicalName(OrderStates::STATE_CANCELLED);
-
-        return new StateMachineTransitionEvent(OrderDefinition::ENTITY_NAME, $orderId, $from, $to, $context);
-    }
-
-    private function createCheckoutOrderPlacedEvent(SalesChannelContext $context, OrderEntity $order): CheckoutOrderPlacedEvent
-    {
-        return new CheckoutOrderPlacedEvent(
-            $context,
-            $order,
-        );
     }
 }

--- a/tests/Pos/Sync/Inventory/StockSubscriberTest.php
+++ b/tests/Pos/Sync/Inventory/StockSubscriberTest.php
@@ -41,7 +41,7 @@ class StockSubscriberTest extends TestCase
 
     public function testAddInventoryMessage(): void
     {
-        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+        $this->process(function (StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
             $event = new ProductStockAlteredEvent([
                 ConstantsForTesting::PRODUCT_A_ID,
                 ConstantsForTesting::PRODUCT_B_ID,
@@ -54,7 +54,7 @@ class StockSubscriberTest extends TestCase
 
     public function testEmptyProductIds(): void
     {
-        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+        $this->process(function (StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
             $stockSubscriber->updateInventory(new ProductStockAlteredEvent([], $context->getContext()));
         }, false);
     }
@@ -66,7 +66,7 @@ class StockSubscriberTest extends TestCase
             ->method('searchIds')
             ->willReturn(new IdSearchResult(0, [], new Criteria(), Context::createDefaultContext()));
 
-        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+        $this->process(function (StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
             $event = new ProductStockAlteredEvent([
                 ConstantsForTesting::PRODUCT_A_ID,
                 ConstantsForTesting::PRODUCT_B_ID,
@@ -79,7 +79,7 @@ class StockSubscriberTest extends TestCase
 
     public function testNotLiveContext(): void
     {
-        $this->process(function(StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
+        $this->process(function (StockSubscriber $stockSubscriber, SalesChannelContext $context): void {
             $event = new ProductStockAlteredEvent([
                 ConstantsForTesting::PRODUCT_A_ID,
                 ConstantsForTesting::PRODUCT_B_ID,


### PR DESCRIPTION
### 1. Why is this change necessary?
The Delay Stamp is used in PayPal, which is not support by all queue types

### 2. What does this change do, exactly?
Remove the delay stamp. Will listen to a single event, `ProductStockAlteredEvent`. This event will be dispatched, after the new stock values are written into the DB, therefore no delay is needed.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/shopware/issues/8626

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
