### PR TITLE
refactor: simplify workflow naming

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,4 +1,3 @@
-name: Admin
 on:
   push:
     branches:
@@ -20,10 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
           install-admin: true
+
       - name: Run ESLint
         env:
           ADMIN_PATH: ${{ github.workspace }}/src/Administration/Resources/app/administration
@@ -31,7 +32,16 @@ jobs:
         run: composer run lint:admin:ci
 
   jest:
-    uses: shopware/github-actions/.github/workflows/admin-jest.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-      uploadCoverage: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SwagPayPal
+        uses: actions/checkout@v4
+        with:
+          path: custom/plugins/${{ github.event.repository.name }}
+
+      - name: Setup SwagPayPal
+        uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
+        with:
+          install-admin: true
+
+      - uses: shopware/github-actions/admin-jest@main

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,3 +1,5 @@
+name: admin
+
 on:
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,3 +1,5 @@
+name: integration
+
 on:
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,3 @@
-name: Integration
 on:
   push:
     branches:
@@ -18,10 +17,12 @@ jobs:
         uses: shopware/github-actions/build-zip@main
         with:
           extensionName: ${{ github.event.repository.name }}
+
       - name: Checkout SwagPayPal
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Test install zip
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
@@ -47,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
@@ -56,6 +58,7 @@ jobs:
           mysql-version: ${{ matrix.MYSQL_IMAGE }}
           php-version: ${{ matrix.PHP_VERSION }}
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
+
       - name: Run PHPUnit
         working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,3 +1,5 @@
+name: php
+
 on:
   push:
     branches:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,3 @@
-name: PHP checks
-
 on:
   push:
     branches:
@@ -33,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
@@ -40,13 +39,16 @@ jobs:
           install-admin: true
           install-storefront: true
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
+
       - name: Prepare phpstan
         working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCmsExtensions"
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCommercial"
           sed -i 's|reportUnmatchedIgnoredErrors: true|reportUnmatchedIgnoredErrors: false|' ./phpstan.neon.dist
-      - run: |
+
+      - name: Run phpstan
+        run: |
           composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
 
   php-cs-fixer:
@@ -56,8 +58,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
+
       - name: Run php-cs-fixer
         run: |
           composer -d custom/plugins/${{ github.event.repository.name }} run ecs
@@ -69,16 +73,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
           install-admin: true
           install-storefront: true
-      - working-directory: custom/plugins/${{ github.event.repository.name }}
+
+      - name: Generate openapi schema
+        working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |
           composer install
           composer init:admin
           composer openapi:generate
+
+      - name: Check openapi schema
+        working-directory: custom/plugins/${{ github.event.repository.name }}
+        run: |
           git update-index --refresh || printf ''
           git diff --exit-code src/Resources/app/administration/src/types/openapi.d.ts || (echo "Please run 'composer openapi:generate' to update openapi.d.ts" && exit 1)
           git diff --exit-code src/Resources/Schema || (echo "Please run 'composer openapi:generate' to update Resources/Schema files" && exit 1)

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,6 +1,6 @@
-name: Release to Store
 on:
   workflow_dispatch:
+
 jobs:
   build:
     uses: shopware/github-actions/.github/workflows/store-release.yml@main

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,3 +1,5 @@
+name: store-release
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -1,4 +1,3 @@
-name: Storefront
 on:
   push:
     branches:
@@ -20,11 +19,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
           install-commercial: true
           install-storefront: true
+
       - name: Run ESLint
         env:
           STOREFRONT_PATH: ${{ github.workspace }}/src/Storefront/Resources/app/storefront

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -1,3 +1,5 @@
+name: storefront
+
 on:
   push:
     branches:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,5 +1,3 @@
-name: Weekly
-
 on:
   schedule:
     - cron: '0 0 * * 1'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,3 +1,5 @@
+name: weekly
+
 on:
   schedule:
     - cron: '0 0 * * 1'


### PR DESCRIPTION
### 1. Why is this change necessary?
- Workflow names including spaces and equal the file names anyway
- admin jest workflow still references old workflow instead of the composable

### 2. What does this change do, exactly?
- ~~remove workflow names. The default are file names~~ _path names_, not really pleased to look at
- Use admin jest composable