### PR TITLE
fix: chevron icon size

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-settings/page/swag-paypal-settings/swag-paypal-settings.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/page/swag-paypal-settings/swag-paypal-settings.html.twig
@@ -2,7 +2,7 @@
     <template #smart-bar-header>
         <h2>
             {{ $t('sw-settings.index.title') }}
-            <mt-icon name="regular-chevron-right-xs" size="16px" />
+            <mt-icon name="regular-chevron-right-xs" size="12" />
             {{ $t('swag-paypal-settings.header') }}
         </h2>
     </template>


### PR DESCRIPTION
fixes shopware/shopware#9740

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Icon should be aligned with all other chevron's for sw-pages

### 2. What does this change do, exactly?
change icon size from 16 to 12px;

