### PR TITLE
fix: skeleton bar margin override

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-method/view/swag-paypal-method-card/swag-paypal-method-card.scss
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/view/swag-paypal-method-card/swag-paypal-method-card.scss
@@ -64,5 +64,9 @@
     & .sw-skeleton-bar {
         height: 24px;
         margin: 0;
+
+        &:not(:last-child) {
+        	margin: 0;
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because the default styling for `sw-skeleton-bar` has prio:

![image](https://github.com/user-attachments/assets/56a00d8b-8d77-453f-8f97-1ef277aefe8a)


### 2. What does this change do, exactly?
Override the specific rule

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
