### PR TITLE
fix: not defaulting to undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 10.0.2
-- Fixed an issue, where some admin settings are not saved correctly
+- Fixes an issue, where some admin settings are not saved correctly
 
 # 10.0.1
 - Enhanced compatibility with Shopware 6.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.0.2
+- Fixed an issue, where some admin settings are not saved correctly
+
 # 10.0.1
 - Enhanced compatibility with Shopware 6.7
 
@@ -36,7 +39,7 @@
 
 # 9.6.5
 - PPI-1025 - Improves the performance of the installment banner in the Storefront
-- PPI-1043 - Fixes an issue, where a payment method is toggled twice in the Administration 
+- PPI-1043 - Fixes an issue, where a payment method is toggled twice in the Administration
 - PPI-1045 - Fixes an issue, where a payment was not refundable in some cases
 
 # 9.6.4

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.0.2
+- Behebt ein Problem, bei dem einige Admin-Einstellungen nicht korrekt gespeichert wurden
+
 # 10.0.1
 - Verbesserte Kompatibilität mit Shopware 6.7
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.0.1",
+    "version": "10.0.2",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Resources/app/administration/src/app/component/swag-paypal-setting/index.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-setting/index.ts
@@ -142,7 +142,7 @@ export default Shopware.Component.wrapComponentConfig({
         setValue(value: PayPal.SystemConfig[keyof PayPal.SystemConfig]) {
             if (value !== this.value) {
                 this.settingsStore.set(this.path, value);
-                this.$emit('update:value', value ?? undefined);
+                this.$emit('update:value', value);
             }
         },
     },

--- a/src/Resources/app/administration/src/app/component/swag-paypal-setting/swag-paypal-setting.spec.ts
+++ b/src/Resources/app/administration/src/app/component/swag-paypal-setting/swag-paypal-setting.spec.ts
@@ -271,7 +271,7 @@ describe('swag-paypal-setting', () => {
         await icon.trigger('click');
 
         expect(inheritSwitch.vm.isInherited).toBe(true);
-        expect(wrapper.vm.value).toBeUndefined();
+        expect(wrapper.vm.value).toBeNull();
         expect(wrapper.vm.inheritedValue).toBe('some-client-id');
         expect(input.attributes().disabled).toBe('');
         expect(input.attributes().value).toBe('some-client-id');
@@ -325,7 +325,7 @@ describe('swag-paypal-setting', () => {
         await icon.trigger('click');
 
         expect(inheritSwitch.vm.isInherited).toBe(true);
-        expect(wrapper.vm.value).toBeUndefined();
+        expect(wrapper.vm.value).toBeNull();
         expect(wrapper.vm.inheritedValue).toBe('CAPTURE');
         expect(field.vm.$attrs.disabled).toBe(true);
         expect(field.vm.value).toBe('CAPTURE');
@@ -372,7 +372,7 @@ describe('swag-paypal-setting', () => {
         await icon.trigger('click');
 
         expect(inheritSwitch.vm.isInherited).toBe(true);
-        expect(wrapper.vm.value).toBeUndefined();
+        expect(wrapper.vm.value).toBeNull();
         expect(wrapper.vm.inheritedValue).toBe(false);
         expect(input.attributes().disabled).toBe('');
         expect(input.attributes().checked).toBeUndefined();

--- a/src/Resources/app/administration/src/app/store/swag-paypal-settings.store.spec.ts
+++ b/src/Resources/app/administration/src/app/store/swag-paypal-settings.store.spec.ts
@@ -76,10 +76,10 @@ describe('swag-paypal-settings.store', () => {
         expect(store.getRoot(key)).toBe('CAPTURE');
         expect(store.getActual(key)).toBeUndefined();
 
-        store.set(key, 'AUTORIZE');
-        expect(store.get(key)).toBe('AUTORIZE');
+        store.set(key, 'AUTHORIZE');
+        expect(store.get(key)).toBe('AUTHORIZE');
         expect(store.getRoot(key)).toBe('CAPTURE');
-        expect(store.getActual(key)).toBe('AUTORIZE');
+        expect(store.getActual(key)).toBe('AUTHORIZE');
     });
 
     it('should have inherit correctly without root value', () => {
@@ -106,13 +106,13 @@ describe('swag-paypal-settings.store', () => {
 
         const key = 'SwagPayPal.settings.crossBorderBuyerCountry';
 
-        expect(store.get(key)).toBeUndefined();
-        expect(store.getRoot(key)).toBeUndefined();
+        expect(store.get(key)).toBeNull();
+        expect(store.getRoot(key)).toBeNull();
         expect(store.getActual(key)).toBeUndefined();
 
         store.set(key, 'de-DE');
         expect(store.get(key)).toBe('de-DE');
-        expect(store.getRoot(key)).toBeUndefined();
+        expect(store.getRoot(key)).toBeNull();
         expect(store.getActual(key)).toBe('de-DE');
     });
 });

--- a/src/Resources/app/administration/src/app/store/swag-paypal-settings.store.ts
+++ b/src/Resources/app/administration/src/app/store/swag-paypal-settings.store.ts
@@ -24,19 +24,19 @@ const store = Shopware.Store.register({
         },
 
         set<K extends keyof PayPal.SystemConfig>(key: K, value: PayPal.SystemConfig[K]) {
-            this.allConfigs[String(this.salesChannel)][key] = value ?? undefined;
+            this.allConfigs[String(this.salesChannel)][key] = value;
         },
 
         get<K extends keyof PayPal.SystemConfig>(key: K): PayPal.SystemConfig[K] {
-            return this.actual[key] ?? this.root[key] ?? undefined;
+            return this.actual[key] ?? this.root[key];
         },
 
         getRoot<K extends keyof PayPal.SystemConfig>(key: K): PayPal.SystemConfig[K] {
-            return this.root[key] ?? undefined;
+            return this.root[key];
         },
 
         getActual<K extends keyof PayPal.SystemConfig>(key: K): PayPal.SystemConfig[K] {
-            return this.actual[key] ?? undefined;
+            return this.actual[key];
         },
     },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Any system config with a value of `undefined` will not be sent to the backend, not updating / removing the value like intended.

### 2. What does this change do, exactly?
Remove automatic replacement of `null` with `undefined`

### 3. Describe each step to reproduce the issue or behaviour.
- Set a system config key to `undefined`
- Save

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
