### PR TITLE
fix: add configurable http client with timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 10.0.3
-- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 2 minutes (shopware/SwagPayPal#262)
+- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 30 seconds (shopware/SwagPayPal#262)
 - Fixes an issue, where the spacing between Express Checkout button and PayLater banner was too small (shopware/SwagPayPal#245)
 
 # 10.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.0.3
+- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 2 minutes
+
 # 10.0.2
 - Fixes an issue, where some admin settings are not saved correctly
 - Fixes an issue, where partial captures within the admin were not working

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,5 @@
 # 10.0.3
-- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 2 Minuten begrenzt (shopware/SwagPayPal#262)
+- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 30 Sekunden begrenzt (shopware/SwagPayPal#262)
 - Behebt ein Problem, bei dem der Abstand zwischen Express Checkout Button und "Später bezahlen" Banner zu klein war (shopware/SwagPayPal#245)
 
 # 10.0.2

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.0.3
+- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 2 Minuten begrenzt
+
 # 10.0.2
 - Behebt ein Problem, bei dem einige Admin-Einstellungen nicht korrekt gespeichert wurden
 - Behebt ein Problem, bei dem teilweise Zahlungseinzüge im Admin nicht funktionierten

--- a/src/Resources/config/packages/framework.yaml
+++ b/src/Resources/config/packages/framework.yaml
@@ -17,4 +17,4 @@ framework:
     scoped_clients:
       paypal.base-client:
         scope: https\://api\-m\.(sandbox\.)?paypal\.com/
-        max_duration: 120
+        max_duration: 30

--- a/src/Resources/config/packages/framework.yaml
+++ b/src/Resources/config/packages/framework.yaml
@@ -12,3 +12,9 @@ framework:
       log_level: notice
     Swag\PayPal\Dispute\Exception\NotAuthorizedException:
       log_level: notice
+
+  http_client:
+    scoped_clients:
+      paypal.base-client:
+        scope: https\://api\-m\.(sandbox\.)?paypal\.com/
+        max_duration: 120

--- a/src/Resources/config/services/paypal_sdk.xml
+++ b/src/Resources/config/services/paypal_sdk.xml
@@ -13,6 +13,7 @@
         <!-- HTTP CLIENT -->
         <service id="paypal-sdk.client" class="Swag\PayPal\RestApi\Client\Client">
             <argument type="service" id="monolog.logger.paypal"/>
+            <argument type="service" id="psr18.paypal.base-client"/>
         </service>
 
         <!-- CONTEXT FACTORY -->


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, request against the PayPal API are allowed to live indefinitely. Upon network issues, this can cause trouble, e.g. by having a non-terminating message in the message queue.

### 2. What does this change do, exactly?
Add a configuration for a symfony http client with a timeout of 30s, which is now used as default for all PayPal API calls.

[Related PayPal docs](https://www.paypal.com/us/cshelp/article/how-do-i-resolve-api-timeout-problems-ts1403)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- fixes #262

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
