### PR TITLE
[6.6.x] fix: add request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.7.7
+- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 2 minutes
+
 # 9.7.6
 - Fixes an issue, where the Express Checkout was not displayed correctly on certain pages (shopware/SwagPayPal#234)
 
@@ -31,7 +34,7 @@
 
 # 9.6.5
 - PPI-1025 - Improves the performance of the installment banner in the Storefront
-- PPI-1043 - Fixes an issue, where a payment method is toggled twice in the Administration 
+- PPI-1043 - Fixes an issue, where a payment method is toggled twice in the Administration
 - PPI-1045 - Fixes an issue, where a payment was not refundable in some cases
 
 # 9.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 9.7.7
-- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 2 minutes (shopware/SwagPayPal#262)
+- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 30 seconds (shopware/SwagPayPal#262)
 - Fixes an issue, where the spacing between Express Checkout button and PayLater banner was too small (shopware/SwagPayPal#245)
 
 # 9.7.6

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,5 @@
 # 9.7.7
-- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 2 Minuten begrenzt (shopware/SwagPayPal#262)
+- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 30 Sekunden begrenzt (shopware/SwagPayPal#262)
 - Behebt ein Problem, bei dem der Abstand zwischen Express Checkout Button und "Später bezahlen" Banner zu klein war (shopware/SwagPayPal#245)
 
 # 9.7.6

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 9.7.7
+- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 2 Minuten begrenzt
+
 # 9.7.6
 - Behebt ein Problem, bei dem der Express Checkout auf bestimmten Seiten nicht korrekt angezeigt wurde (shopware/SwagPayPal#234)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "9.7.6",
+    "version": "9.7.7",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/RestApi/Client/CredentialsClient.php
+++ b/src/RestApi/Client/CredentialsClient.php
@@ -21,7 +21,7 @@ class CredentialsClient extends AbstractClient
     ) {
         $client = new Client([
             'base_uri' => $url,
-            'timeout' => 120,
+            'timeout' => 30,
         ]);
 
         parent::__construct($client, $logger);

--- a/src/RestApi/Client/CredentialsClient.php
+++ b/src/RestApi/Client/CredentialsClient.php
@@ -19,7 +19,10 @@ class CredentialsClient extends AbstractClient
         string $url,
         LoggerInterface $logger,
     ) {
-        $client = new Client(['base_uri' => $url]);
+        $client = new Client([
+            'base_uri' => $url,
+            'timeout' => 120,
+        ]);
 
         parent::__construct($client, $logger);
     }

--- a/src/RestApi/Client/PayPalClient.php
+++ b/src/RestApi/Client/PayPalClient.php
@@ -28,7 +28,7 @@ class PayPalClient extends AbstractClient implements PayPalClientInterface
                 'PayPal-Partner-Attribution-Id' => $partnerAttributionId,
                 ...$credentials,
             ],
-            'timeout' => 120,
+            'timeout' => 30,
         ]);
 
         parent::__construct($client, $logger);

--- a/src/RestApi/Client/PayPalClient.php
+++ b/src/RestApi/Client/PayPalClient.php
@@ -28,6 +28,7 @@ class PayPalClient extends AbstractClient implements PayPalClientInterface
                 'PayPal-Partner-Attribution-Id' => $partnerAttributionId,
                 ...$credentials,
             ],
+            'timeout' => 120,
         ]);
 
         parent::__construct($client, $logger);

--- a/src/RestApi/Client/TokenClient.php
+++ b/src/RestApi/Client/TokenClient.php
@@ -27,7 +27,7 @@ class TokenClient extends AbstractClient implements TokenClientInterface
                 'PayPal-Partner-Attribution-Id' => PartnerAttributionId::PAYPAL_PPCP,
                 'Authorization' => (string) $credentials,
             ],
-            'timeout' => 120,
+            'timeout' => 30,
         ]);
 
         parent::__construct($client, $logger);

--- a/src/RestApi/Client/TokenClient.php
+++ b/src/RestApi/Client/TokenClient.php
@@ -27,6 +27,7 @@ class TokenClient extends AbstractClient implements TokenClientInterface
                 'PayPal-Partner-Attribution-Id' => PartnerAttributionId::PAYPAL_PPCP,
                 'Authorization' => (string) $credentials,
             ],
+            'timeout' => 120,
         ]);
 
         parent::__construct($client, $logger);


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, request against the PayPal API are allowed to live indefinitely. Upon network issues, this can cause trouble, e.g. by having a non-terminating message in the message queue.

### 2. What does this change do, exactly?
Configure all guzzle clients with a timeout of 30s.

[Related PayPal docs](https://www.paypal.com/us/cshelp/article/how-do-i-resolve-api-timeout-problems-ts1403)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- fixes #262

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
