### PR TITLE
[6.5.x] fix: add request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 8.7.7
+- Fixes an issue, requests to PayPal could wait indefinitly. Requests are now limited to 30 seconds (shopware/SwagPayPal#262)
+
 # 8.7.6
 - Fixes an issue, where vaulted payments could not be processed in the after order payment process in certain situations
 - Fixes a problem where the Venmo Express button was not shown

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 8.7.7
+- Behebt ein Problem, bei dem Anfragen an PayPal unendlich lange warten konnten. Die Anfragen sind jetzt auf 30 Sekunden begrenzt (shopware/SwagPayPal#262)
+
 # 8.7.6
 - Behebt ein Problem, bei dem Vaulting-Zahlungen in bestimmten Fällen im Zahlungsprozess nach einer Bestellung nicht ausgeführt werden konnten
 - Behebt ein Problem, bei dem der Venmo Express-Button nicht angezeigt wurde

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "8.7.6",
+    "version": "8.7.7",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/RestApi/Client/CredentialsClient.php
+++ b/src/RestApi/Client/CredentialsClient.php
@@ -19,7 +19,10 @@ class CredentialsClient extends AbstractClient
         string $url,
         LoggerInterface $logger
     ) {
-        $client = new Client(['base_uri' => $url]);
+        $client = new Client([
+            'base_uri' => $url,
+            'timeout' => 30,
+        ]);
 
         parent::__construct($client, $logger);
     }

--- a/src/RestApi/Client/PayPalClient.php
+++ b/src/RestApi/Client/PayPalClient.php
@@ -28,6 +28,7 @@ class PayPalClient extends AbstractClient implements PayPalClientInterface
                 'PayPal-Partner-Attribution-Id' => $partnerAttributionId,
                 ...$credentials,
             ],
+            'timeout' => 30,
         ]);
 
         parent::__construct($client, $logger);

--- a/src/RestApi/Client/TokenClient.php
+++ b/src/RestApi/Client/TokenClient.php
@@ -27,6 +27,7 @@ class TokenClient extends AbstractClient implements TokenClientInterface
                 'PayPal-Partner-Attribution-Id' => PartnerAttributionId::PAYPAL_PPCP,
                 'Authorization' => (string) $credentials,
             ],
+            'timeout' => 30,
         ]);
 
         parent::__construct($client, $logger);


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, request against the PayPal API are allowed to live indefinitely. Upon network issues, this can cause trouble, e.g. by having a non-terminating message in the message queue.

### 2. What does this change do, exactly?
Configure all guzzle clients with a timeout of 30s.

[Related PayPal docs](https://www.paypal.com/us/cshelp/article/how-do-i-resolve-api-timeout-problems-ts1403)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- fixes #262

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
