### PR TITLE
fix: first-run-wizard styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 10.0.3
 - Fixes an issue, where the spacing between Express Checkout button and PayLater banner was too small (shopware/SwagPayPal#245)
+- Fixes an issue, where the First Run Wizard was not shown correctly
 
 # 10.0.2
 - Fixes an issue, where some admin settings are not saved correctly

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # 10.0.3
 - Behebt ein Problem, bei dem der Abstand zwischen Express Checkout Button und "Später bezahlen" Banner zu klein war (shopware/SwagPayPal#245)
+- Behebt ein Problem, bei dem der Ersteinrichtungs-Assistent nicht korrekt dargestellt wurde
 
 # 10.0.2
 - Behebt ein Problem, bei dem einige Admin-Einstellungen nicht korrekt gespeichert wurden

--- a/src/Resources/app/administration/src/module/extension/sw-first-run-wizard/sw-first-run-wizard-paypal-credentials/sw-first-run-wizard-paypal-credentials.scss
+++ b/src/Resources/app/administration/src/module/extension/sw-first-run-wizard/sw-first-run-wizard-paypal-credentials/sw-first-run-wizard-paypal-credentials.scss
@@ -2,6 +2,7 @@
 
 .sw-first-run-wizard-paypal-credentials {
     width: 100%;
+    height: 100%;
 
     display: flex;
     flex-direction: column;
@@ -16,13 +17,11 @@
         margin: 0;
     }
 
-    .sw-field.sw-block-field, .sw-field--switch {
-        margin: 0;
-    }
-
-    .sw-field--switch .sw-field__label label {
-        padding-top: 0;
-        padding-bottom: 0;
+    & .mt-field,
+    & .mt-switch,
+    & .swag-paypal-setting.is--boolean {
+       margin-top: 0;
+       margin-bottom: 0;
     }
 
     .swag-paypal-onboarding-button {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The margin of meteor components expanded the first run wizard page into oblivion, making text and toggles inaccessable:

![image](https://github.com/user-attachments/assets/44b02469-7420-43c3-a084-572eab365098)

### 2. What does this change do, exactly?
- Add a height to the component, making it scrollable, in case that happens again.
- Remove the margin from all components

![image](https://github.com/user-attachments/assets/ccb2d844-c830-48a5-9cb4-5d493a8bc241)

### 3. Describe each step to reproduce the issue or behaviour.
- Open the first run wizard
- Step through to the PayPal config page

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
