### PR TITLE
feat: Added payment means to e-invoice 6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 9.7.8
+# 9.8.0
 - Added necessary payment means for e-invoice generation (shopware/SwagPayPal#255)
 
 # 9.7.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.7.8
+- Added necessary payment means for e-invoice generation (shopware/SwagPayPal#255)
+
 # 9.7.7
 - Fixes an issue, where the spacing between Express Checkout button and PayLater banner was too small (shopware/SwagPayPal#245)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 9.7.8
+- Fügt notwenige Zahlungsmittelinformationen zu E-Rechnungen hinzu (shopware/SwagPayPal#255)
+
 # 9.7.7
 - Behebt ein Problem, bei dem der Abstand zwischen Express Checkout Button und "Später bezahlen" Banner zu klein war (shopware/SwagPayPal#245)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,4 @@
-# 9.7.8
+# 9.8.0
 - Fügt notwenige Zahlungsmittelinformationen zu E-Rechnungen hinzu (shopware/SwagPayPal#255)
 
 # 9.7.7

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,6 +146,12 @@ parameters:
 			path: src/Storefront/Data/CheckoutDataSubscriber.php
 
 		-
+			message: "#^Trying to mock an undefined method addDocumentPaymentMean\\(\\) on class horstoeko\\\\zugferd\\\\ZugferdDocumentBuilder\\.$#"
+			count: 1
+			path: tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+
+
+		-
 			message: "#^Mixed variable in a `\\$criteria\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
 			count: 1
 			path: tests/Checkout/PUI/SalesChannel/PUIPaymentInstructionsRouteTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,9 +6,59 @@ parameters:
 			path: src/Checkout/Card/Exception/CardValidationFailedException.php
 
 		-
-			message: "#^Call to deprecated method get\\(\\) of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity:\ntag:v6.7.0 - reason:exception\\-change Thrown exception will change from InternalFieldAccessNotAllowedException to DataAbstractionLayerException$#"
+			message: "#^Access to property \\$config on an unknown class Shopware\\\\Core\\\\Checkout\\\\Document\\\\Zugferd\\\\ZugferdInvoiceGeneratedEvent\\.$#"
 			count: 1
-			path: src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Access to property \\$document on an unknown class Shopware\\\\Core\\\\Checkout\\\\Document\\\\Zugferd\\\\ZugferdInvoiceGeneratedEvent\\.$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Access to property \\$order on an unknown class Shopware\\\\Core\\\\Checkout\\\\Document\\\\Zugferd\\\\ZugferdInvoiceGeneratedEvent\\.$#"
+			count: 2
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Cannot call method getBuilder\\(\\) on class\\-string\\|object\\.$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$event\\-\\>document\\-\\>getBuilder\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$event\\-\\>order\\-\\>getLanguage\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$event\\-\\>order\\-\\>getLanguage\\(\\)\\?\\-\\>getLocale\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$event\\-\\>order\\-\\>getTransactions\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$paymentMethod\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Mixed variable in a `\\$transaction\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			count: 3
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+
+		-
+			message: "#^Parameter \\$event of method Swag\\\\PayPal\\\\Checkout\\\\Document\\\\Zugferd\\\\ZugferdSubscriber\\:\\:generateInvoice\\(\\) has invalid type Shopware\\\\Core\\\\Checkout\\\\Document\\\\Zugferd\\\\ZugferdInvoiceGeneratedEvent\\.$#"
+			count: 1
+			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
 
 		-
 			message: "#^Mixed variable in a `\\$session\\-\\>getFlashBag\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,11 @@ parameters:
 			path: src/Checkout/Document/Zugferd/ZugferdSubscriber.php
 
 		-
+			message: "#^Call to deprecated method get\\(\\) of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity:\ntag:v6.7.0 - reason:exception\\-change Thrown exception will change from InternalFieldAccessNotAllowedException to DataAbstractionLayerException$#"
+			count: 1
+			path: src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+
+		-
 			message: "#^Mixed variable in a `\\$session\\-\\>getFlashBag\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
 			count: 1
 			path: src/Checkout/Payment/Method/PUIHandler.php

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -19,6 +19,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Package('checkout')]
 class ZugferdSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Payment to bank account
+     */
+    private const UNTDID_4461_42 = '42';
+
+    /**
+     * Mutually defined
+     */
+    private const UNTDID_4461_ZZZ = 'ZZZ';
+
     public function __construct(
         private readonly TranslatorInterface $translator
     ) {
@@ -52,7 +62,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
 
         $locale = $event->order->getLanguage()?->getLocale()?->getCode();
         $paymentMeans = [
-            'typeCode' => 'ZZZ',
+            'typeCode' => self::UNTDID_4461_ZZZ,
             'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
         ];
 
@@ -62,7 +72,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
             $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);
 
             $paymentMeans['information'] .= ' | ' . $ratePay;
-            $paymentMeans['typeCode'] = '42';
+            $paymentMeans['typeCode'] = self::UNTDID_4461_42;
             $paymentMeans['payeeIban'] = $values['iban'] ?? null;
             $paymentMeans['payeeAccountName'] = $values['account_holder_name'] ?? null;
             $paymentMeans['payeeBic'] = $values['bic'] ?? null;

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -38,14 +38,14 @@ class ZugferdSubscriber implements EventSubscriberInterface
     public function generateInvoice(ZugferdInvoiceGeneratedEvent $event): void
     {
         // Method added with v6.6.10.6
-        // @phpstan-ignore function.alreadyNarrowedType
+        // @phpstan-ignore-next-line
         if (!method_exists($event->document, 'getBuilder')) {
             return;
         }
 
         $transaction = $event->order->getTransactions()?->last();
         $paymentMethod = $transaction?->getPaymentMethod();
-        // @phpstan-ignore method.deprecated
+        // @phpstan-ignore-next-line
         if ($paymentMethod === null || !str_starts_with($paymentMethod->getTechnicalName() ?? '', 'swag_paypal_')) {
             return;
         }
@@ -56,7 +56,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
             'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
         ];
 
-        // @phpstan-ignore method.deprecated
+        // @phpstan-ignore-next-line
         if ($paymentMethod->getTechnicalName() === 'swag_paypal_pui') {
             $values = $transaction->getTranslatedCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION)['deposit_bank_details'] ?? [];
             $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Checkout\Document\Zugferd;
+
+use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
+use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\SwagPayPal;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class ZugferdSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ZugferdInvoiceGeneratedEvent::class => 'generateInvoice',
+        ];
+    }
+
+    public function generateInvoice(ZugferdInvoiceGeneratedEvent $event): void
+    {
+        // Method added with v6.6.10.6
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        if (!method_exists($event->document, 'getBuilder')) {
+            return;
+        }
+
+        $transaction = $event->order->getTransactions()?->last();
+        $paymentMethod = $transaction?->getPaymentMethod();
+        // @phpstan-ignore method.deprecated
+        if ($paymentMethod === null || !str_starts_with($paymentMethod->getTechnicalName() ?? '', 'swag_paypal_')) {
+            return;
+        }
+
+        $locale = $event->order->getLanguage()?->getLocale()?->getCode();
+        $paymentMeans = [
+            'typeCode' => ZugferdPaymentMeans::UNTDID_4461_ZZZ,
+            'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
+        ];
+
+        // @phpstan-ignore method.deprecated
+        if ($paymentMethod->getTechnicalName() === 'swag_paypal_pui') {
+            $values = $transaction->getTranslatedCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION)['deposit_bank_details'] ?? [];
+            $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);
+
+            $paymentMeans['information'] .= ' | ' . $ratePay;
+            $paymentMeans['typeCode'] = ZugferdPaymentMeans::UNTDID_4461_42;
+            $paymentMeans['payeeIban'] = $values['iban'] ?? null;
+            $paymentMeans['payeeAccountName'] = $values['account_holder_name'] ?? null;
+            $paymentMeans['payeeBic'] = $values['bic'] ?? null;
+        } else {
+            $paymentMeans['information'] .= ' | ' . $this->translator->trans('paypal.e-invoice.orderId', ['%orderId%' => $transaction->getTranslatedCustomFieldsValue('swag_paypal_order_id')], locale: $locale);
+        }
+
+        $event->document->getBuilder()
+            ->addDocumentPaymentMean(...$paymentMeans);
+    }
+}

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -7,7 +7,6 @@
 
 namespace Swag\PayPal\Checkout\Document\Zugferd;
 
-use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\SwagPayPal;
@@ -27,6 +26,10 @@ class ZugferdSubscriber implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
+        if (!class_exists(ZugferdInvoiceGeneratedEvent::class)) {
+            return [];
+        }
+
         return [
             ZugferdInvoiceGeneratedEvent::class => 'generateInvoice',
         ];
@@ -49,7 +52,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
 
         $locale = $event->order->getLanguage()?->getLocale()?->getCode();
         $paymentMeans = [
-            'typeCode' => ZugferdPaymentMeans::UNTDID_4461_ZZZ,
+            'typeCode' => 'ZZZ',
             'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
         ];
 
@@ -59,7 +62,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
             $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);
 
             $paymentMeans['information'] .= ' | ' . $ratePay;
-            $paymentMeans['typeCode'] = ZugferdPaymentMeans::UNTDID_4461_42;
+            $paymentMeans['typeCode'] = '42';
             $paymentMeans['payeeIban'] = $values['iban'] ?? null;
             $paymentMeans['payeeAccountName'] = $values['account_holder_name'] ?? null;
             $paymentMeans['payeeBic'] = $values['bic'] ?? null;

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -38,14 +38,14 @@ class ZugferdSubscriber implements EventSubscriberInterface
     public function generateInvoice(ZugferdInvoiceGeneratedEvent $event): void
     {
         // Method added with v6.6.10.6
-        // @phpstan-ignore-next-line function.alreadyNarrowedType
+        // @phpstan-ignore function.alreadyNarrowedType
         if (!method_exists($event->document, 'getBuilder')) {
             return;
         }
 
         $transaction = $event->order->getTransactions()?->last();
         $paymentMethod = $transaction?->getPaymentMethod();
-        // @phpstan-ignore-next-line method.deprecated
+        // @phpstan-ignore method.deprecated
         if ($paymentMethod === null || !str_starts_with($paymentMethod->getTechnicalName() ?? '', 'swag_paypal_')) {
             return;
         }
@@ -56,7 +56,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
             'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
         ];
 
-        // @phpstan-ignore-next-line method.deprecated
+        // @phpstan-ignore method.deprecated
         if ($paymentMethod->getTechnicalName() === 'swag_paypal_pui') {
             $values = $transaction->getTranslatedCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION)['deposit_bank_details'] ?? [];
             $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -26,7 +26,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        if (!class_exists(ZugferdInvoiceGeneratedEvent::class)) {
+        if (!\class_exists(ZugferdInvoiceGeneratedEvent::class)) {
             return [];
         }
 
@@ -38,14 +38,14 @@ class ZugferdSubscriber implements EventSubscriberInterface
     public function generateInvoice(ZugferdInvoiceGeneratedEvent $event): void
     {
         // Method added with v6.6.10.6
-        /** @phpstan-ignore function.alreadyNarrowedType */
+        // @phpstan-ignore-next-line function.alreadyNarrowedType
         if (!method_exists($event->document, 'getBuilder')) {
             return;
         }
 
         $transaction = $event->order->getTransactions()?->last();
         $paymentMethod = $transaction?->getPaymentMethod();
-        // @phpstan-ignore method.deprecated
+        // @phpstan-ignore-next-line method.deprecated
         if ($paymentMethod === null || !str_starts_with($paymentMethod->getTechnicalName() ?? '', 'swag_paypal_')) {
             return;
         }
@@ -56,7 +56,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
             'information' => $this->translator->trans('paypal.e-invoice.paymentMethod', ['%paymentMethod%' => $paymentMethod->getTranslation('name')], locale: $locale),
         ];
 
-        // @phpstan-ignore method.deprecated
+        // @phpstan-ignore-next-line method.deprecated
         if ($paymentMethod->getTechnicalName() === 'swag_paypal_pui') {
             $values = $transaction->getTranslatedCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION)['deposit_bank_details'] ?? [];
             $ratePay = $this->translator->trans('paypal.payUponInvoice.document.paymentNoteRatepay', ['%companyName%' => $event->config->getCompanyName()], locale: $locale);

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -19,6 +19,7 @@ return static function (ContainerBuilder $container): void {
     $loader->load('dal.xml');
     $loader->load('dev_ops.xml');
     $loader->load('dispute.xml');
+    $loader->load('document.xml');
     $loader->load('express_checkout.xml');
     $loader->load('installment.xml');
     $loader->load('orders_api.xml');

--- a/src/Resources/config/services/document.xml
+++ b/src/Resources/config/services/document.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Swag\PayPal\Checkout\Document\Zugferd\ZugferdSubscriber">
+            <argument type="service" id="translator"/>
+
+            <tag name="kernel.event_subscriber" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/snippet/storefront/paypal.de-DE.json
+++ b/src/Resources/snippet/storefront/paypal.de-DE.json
@@ -83,6 +83,10 @@
             "clear": "Karte entfernen",
             "create": "Karte für zukünftige Käufe speichern"
           }
+        },
+        "e-invoice":{
+          "paymentMethod": "Zahlungsart: \"%paymentMethod%\"",
+          "orderId": "Auftragsnummer: %orderId%"
         }
     }
 }

--- a/src/Resources/snippet/storefront/paypal.en-GB.json
+++ b/src/Resources/snippet/storefront/paypal.en-GB.json
@@ -83,6 +83,10 @@
             "clear": "Remove card",
             "create": "Remember card for future purchases"
           }
+        },
+        "e-invoice":{
+          "paymentMethod": "Payment method: \"%paymentMethod%\"",
+          "orderId": "Order ID: %orderId%"
         }
     }
 }

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -36,7 +36,7 @@ class ZugferdSubscriberTest extends TestCase
         if (
             !\class_exists(ZugferdInvoiceGeneratedEvent::class)
             || !\class_exists(ZugferdDocumentBuilder::class)
-            || !\method_exists(ZugferdDocument::class, 'getBuilder') // @phpstan-ignore function.alreadyNarrowedType
+            || !\method_exists(ZugferdDocument::class, 'getBuilder') // @phpstan-ignore-line
         ) {
             static::markTestSkipped('Class and method will be available for >=v6.6.10.6');
         }
@@ -65,7 +65,7 @@ class ZugferdSubscriberTest extends TestCase
         }
 
         $event = new ZugferdInvoiceGeneratedEvent(
-            new ZugferdDocument($builderMock),
+            new ZugferdDocument($builderMock), // @phpstan-ignore-line
             $order,
             new DocumentConfiguration(),
             Context::createDefaultContext()

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -41,7 +41,7 @@ class ZugferdSubscriberTest extends TestCase
 
         $builderMock = $this->createMock(ZugferdDocumentBuilder::class);
         $builderMock
-            ->expects(empty($expected) ? $this->never() : $this->once())
+            ->expects(empty($expected) ? static::never() : static::once())
             ->method('addDocumentPaymentMean')
             ->willReturnCallback(static function (...$arguments) use ($expected, $builderMock): ZugferdDocumentBuilder {
                 foreach ($expected as $value) {

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -33,6 +33,10 @@ class ZugferdSubscriberTest extends TestCase
     #[DataProvider('dataProviderTransaction')]
     public function testTest(?OrderTransactionEntity $transaction, array $expected): void
     {
+        if (!\class_exists(ZugferdInvoiceGeneratedEvent::class) || !\method_exists(ZugferdDocument::class, 'getBuilder')) {
+            static::markTestSkipped('Class and method will be available for >=v6.6.10.6');
+        }
+
         // return last snippet path
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -33,7 +33,11 @@ class ZugferdSubscriberTest extends TestCase
     #[DataProvider('dataProviderTransaction')]
     public function testTest(?OrderTransactionEntity $transaction, array $expected): void
     {
-        if (!\class_exists(ZugferdInvoiceGeneratedEvent::class) || !\method_exists(ZugferdDocument::class, 'getBuilder')) {
+        if (
+            !\class_exists(ZugferdInvoiceGeneratedEvent::class)
+            || !\class_exists(ZugferdDocumentBuilder::class)
+            || !\method_exists(ZugferdDocument::class, 'getBuilder') // @phpstan-ignore function.alreadyNarrowedType
+        ) {
             static::markTestSkipped('Class and method will be available for >=v6.6.10.6');
         }
 
@@ -47,7 +51,7 @@ class ZugferdSubscriberTest extends TestCase
         $builderMock
             ->expects(empty($expected) ? static::never() : static::once())
             ->method('addDocumentPaymentMean')
-            ->willReturnCallback(static function (...$arguments) use ($expected, $builderMock): ZugferdDocumentBuilder {
+            ->willReturnCallback(static function (...$arguments) use ($expected, $builderMock) {
                 foreach ($expected as $value) {
                     static::assertContains($value, $arguments);
                 }
@@ -57,7 +61,6 @@ class ZugferdSubscriberTest extends TestCase
 
         $order = new OrderEntity();
         if ($transaction !== null) {
-            $order->setPrimaryOrderTransaction($transaction);
             $order->setTransactions(new OrderTransactionCollection([$transaction]));
         }
 

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\Document\Zugferd;
+
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentConfiguration;
+use Shopware\Core\Checkout\Document\Zugferd\ZugferdDocument;
+use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Swag\PayPal\Checkout\Document\Zugferd\ZugferdSubscriber;
+use Swag\PayPal\SwagPayPal;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class ZugferdSubscriberTest extends TestCase
+{
+    #[DataProvider('dataProviderTransaction')]
+    public function testTest(?OrderTransactionEntity $transaction, array $expected): void
+    {
+        // return last snippet path
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->method('trans')
+            ->willReturnCallback(static fn (string $message): string => substr($message, strrpos($message, '.') + 1));
+
+        $builderMock = $this->createMock(ZugferdDocumentBuilder::class);
+        $builderMock
+            ->expects(empty($expected) ? $this->never() : $this->once())
+            ->method('addDocumentPaymentMean')
+            ->willReturnCallback(static function (...$arguments) use ($expected, $builderMock): ZugferdDocumentBuilder {
+                foreach ($expected as $value) {
+                    static::assertContains($value, $arguments);
+                }
+
+                return $builderMock;
+            });
+
+        $order = new OrderEntity();
+        if ($transaction !== null) {
+            $order->setPrimaryOrderTransaction($transaction);
+            $order->setTransactions(new OrderTransactionCollection([$transaction]));
+        }
+
+        $event = new ZugferdInvoiceGeneratedEvent(
+            new ZugferdDocument($builderMock),
+            $order,
+            new DocumentConfiguration(),
+            Context::createDefaultContext()
+        );
+
+        (new ZugferdSubscriber($translator))->generateInvoice($event);
+    }
+
+    public static function dataProviderTransaction(): array
+    {
+        return [
+            'no transaction' => [null, []],
+            'no payment method' => [self::createTransaction(), []],
+            'default' => [self::createTransaction('test'),
+                [
+                    'typeCode' => 'ZZZ',
+                    'information' => 'paymentMethod | orderId',
+                ],
+            ],
+            'pui' => [self::createTransaction('pui'),
+                [
+                    'typeCode' => '42',
+                    'information' => 'paymentMethod | paymentNoteRatepay',
+                    'payeeIban' => 'SomeIban',
+                    'payeeAccountName' => 'SomeAccountHolderName',
+                    'payeeBic' => 'SomeBic',
+                ],
+            ],
+        ];
+    }
+
+    private static function createTransaction(string $paymentMethod = ''): OrderTransactionEntity
+    {
+        $bankDetails = ['deposit_bank_details' => [
+            'iban' => 'SomeIban',
+            'account_holder_name' => 'SomeAccountHolderName',
+            'bic' => 'SomeBic',
+        ]];
+
+        $transaction = new OrderTransactionEntity();
+        $transaction->setId(Uuid::randomHex());
+        $transaction->setTranslated(['customFields' => [SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION => $bankDetails]]);
+
+        if ($paymentMethod !== '') {
+            $transaction->setPaymentMethod(self::createPaymentMethod($paymentMethod));
+        }
+
+        return $transaction;
+    }
+
+    private static function createPaymentMethod(string $technicalName): PaymentMethodEntity
+    {
+        $paymentMethod = new PaymentMethodEntity();
+        $paymentMethod->setId(Uuid::randomHex());
+        $paymentMethod->setTechnicalName('swag_paypal_' . $technicalName);
+        $paymentMethod->setTranslated(['name' => 'Swag Paypal Payment']);
+
+        return $paymentMethod;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Payment means for e-invoices are necessary

### 2. What does this change do, exactly?
Listen to an event and adds a payment mean to the e-invoice document

### 3. Describe each step to reproduce the issue or behaviour.
Create an e-invoice with a SwagPayPal payment method

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/SwagPayPal/issues/255