### PR TITLE
chore: min version in job matrices

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@
 /tests export-ignore
 /.php-cs-fixer.dist.php export-ignore
 /ecs.php export-ignore
-/phpstan.neon export-ignore
+/phpstan.dynamic.neon export-ignore
 /phpstan.neon.dist export-ignore
 /phpstan-baseline.neon export-ignore
 /phpunit.xml.dist export-ignore

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   build-zip:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
     steps:
       - name: Build and validate zip
         uses: shopware/github-actions/build-zip@main
@@ -26,13 +29,14 @@ jobs:
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:
           extension-zip: ${{ steps.upload.outputs.artifact-url }}
+          shopware-version: ${{ matrix.PLATFORM_BRANCH }}
 
   phpunit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         MYSQL_IMAGE: ["mysql:8.0", "mariadb:10.11"]
-        PLATFORM_BRANCH: ["trunk"]
+        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
         PHP_VERSION: ["8.2", "8.3"]
         WITH_COMMERCIAL: [true, false]
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,17 +14,29 @@ jobs:
   build-zip:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1 # to avoid artifact conflicts
       matrix:
         PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
     steps:
+      - name: Attempt to download the artifact
+        id: artifact-download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ${{ github.event.repository.name }}
+          path: /tmp/existing-artifact
+
       - name: Build and validate zip
+        if: steps.artifact-download.outcome != 'success'
         uses: shopware/github-actions/build-zip@main
         with:
           extensionName: ${{ github.event.repository.name }}
+
       - name: Checkout SwagPayPal
         uses: actions/checkout@v4
         with:
           path: custom/plugins/${{ github.event.repository.name }}
+
       - name: Test install zip
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 1 # to avoid artifact conflicts
       matrix:
-        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
+        PLATFORM_BRANCH: ["v6.7.0.0", "trunk"]
     steps:
       - name: Attempt to download the artifact
         id: artifact-download
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         MYSQL_IMAGE: ["mysql:8.0", "mariadb:10.11"]
-        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
+        PLATFORM_BRANCH: ["v6.7.0.0", "trunk"]
         PHP_VERSION: ["8.2", "8.3"]
         WITH_COMMERCIAL: [true, false]
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: ${{ github.event.repository.name }}
+          name: ${{ format('{0}.zip', github.event.repository.name) }}
           path: /tmp/existing-artifact
 
       - name: Build and validate zip

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -43,7 +43,7 @@ jobs:
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
       - name: Install dependencies
         if: matrix.PLATFORM_BRANCH == 'v6.7.0.0'
-        run: composer -d custom/plugins/${{ github.event.repository.name }} require --dev phpstan/phpstan-strict-rules
+        run: composer require --dev phpstan/phpstan-strict-rules phpstan/phpstan:2.1.16
       - name: Prepare phpstan
         working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,17 +41,16 @@ jobs:
           install-admin: true
           install-storefront: true
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
+      - name: Install dependencies
+        if: matrix.PLATFORM_BRANCH == 'v6.7.0.0'
+        run: composer require --dev phpstan/phpstan-strict-rules
       - name: Prepare phpstan
         working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCmsExtensions"
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCommercial"
-          jq -e '.["require-dev"] | has("phpstan/phpstan-strict-rules")' composer.json || composer require --dev phpstan/phpstan-strict-rules
           sed -i 's|reportUnmatchedIgnoredErrors: true|reportUnmatchedIgnoredErrors: false|' ./phpstan.neon.dist
-      - run: |
-          composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
-        env:
-          PLATFORM_BRANCH: ${{ matrix.PLATFORM_BRANCH }}
+      - run: composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
 
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -43,7 +43,7 @@ jobs:
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
       - name: Install dependencies
         if: matrix.PLATFORM_BRANCH == 'v6.7.0.0'
-        run: composer require --dev phpstan/phpstan-strict-rules
+        run: composer -d custom/plugins/${{ github.event.repository.name }} require --dev phpstan/phpstan-strict-rules
       - name: Prepare phpstan
         working-directory: custom/plugins/${{ github.event.repository.name }}
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCmsExtensions"
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCommercial"
+          jq -e '.["require-dev"] | has("phpstan/phpstan-strict-rules")' composer.json || composer require --dev phpstan/phpstan-strict-rules
           sed -i 's|reportUnmatchedIgnoredErrors: true|reportUnmatchedIgnoredErrors: false|' ./phpstan.neon.dist
       - run: |
           composer -d custom/plugins/${{ github.event.repository.name }} run phpstan

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCmsExtensions"
           composer dump-autoload --dev -d "${GITHUB_WORKSPACE}/custom/plugins/SwagCommercial"
-          sed -i 's|reportUnmatchedIgnoredErrors: true|reportUnmatchedIgnoredErrors: false|' ./phpstan.neon.dist
       - run: composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
 
   php-cs-fixer:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PLATFORM_BRANCH: ["trunk"]
+        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
       fail-fast: false
     steps:
       - name: Checkout SwagPayPal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PLATFORM_BRANCH: ["6.7.0.0", "trunk"]
+        PLATFORM_BRANCH: ["v6.7.0.0", "trunk"]
       fail-fast: false
     steps:
       - name: Checkout SwagPayPal
@@ -49,6 +49,8 @@ jobs:
           sed -i 's|reportUnmatchedIgnoredErrors: true|reportUnmatchedIgnoredErrors: false|' ./phpstan.neon.dist
       - run: |
           composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
+        env:
+          PLATFORM_BRANCH: ${{ matrix.PLATFORM_BRANCH }}
 
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ vendor/
 src/Resources/public/administration/
 src/Resources/public/static/
 src/Resources/app/storefront/dist
-phpstan.neon
+phpstan.dynamic.neon
 var/
 composer.lock
 node_modules

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -43,7 +43,7 @@ $phpstanConfig = [
     ],
 ];
 
-if ($kernel->getContainer()->getParameter('kernel.shopware_version') === '6.7.0.0') {
+if ($_SERVER['PLATFORM_BRANCH'] === 'v6.7.0.0') {
     unset($phpstanConfig['parameters']['featureToggles']);
 }
 

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -46,7 +46,7 @@ echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
 $versionedConfig = \sprintf('%s/phpstan-%s.neon.dist', $pluginRootPath, $shopwareVersion);
 
 $phpstanConfig = [
-    'includes' => \array_merge(#
+    'includes' => \array_merge(
         [$kernel->getProjectDir() . '/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon'],
         \file_exists($versionedConfig) ? [$versionedConfig] : [],
     ),

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -43,7 +43,10 @@ $phpstanConfig = [
     ],
 ];
 
-if ($_SERVER['PLATFORM_BRANCH'] === 'v6.7.0.0') {
+$shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
+echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
+
+if ($shopwareVersion === 'v6.7.0.0') {
     unset($phpstanConfig['parameters']['featureToggles']);
 }
 

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -10,30 +10,24 @@ use Shopware\Core\DevOps\StaticAnalyze\StaticAnalyzeKernel;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Swag\PayPal\SwagPayPal;
-use Symfony\Component\Dotenv\Dotenv;
 
-$projectRoot = dirname(__DIR__, 4);
+$projectRoot = $_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4);
 $pluginRootPath = dirname(__DIR__);
 
 $classLoader = require $projectRoot . '/vendor/autoload.php';
-if (file_exists($projectRoot . '/.env')) {
-    (new Dotenv())->usePutEnv()->bootEnv($projectRoot . '/.env');
-}
 
 /** @var array{'autoload': array{}} $composer */
 $composer = json_decode((string) file_get_contents($pluginRootPath . '/composer.json'), true);
 
-$pluginLoader = new StaticKernelPluginLoader($classLoader, null, [
-    [
-        'name' => 'SwagPayPal',
-        'active' => true,
-        'version' => $composer['version'],
-        'baseClass' => SwagPayPal::class,
-        'managedByComposer' => false,
-        'autoload' => $composer['autoload'],
-        'path' => $pluginRootPath,
-    ],
-]);
+$pluginLoader = new StaticKernelPluginLoader($classLoader, null, [[
+    'name' => 'SwagPayPal',
+    'active' => true,
+    'version' => $composer['version'],
+    'baseClass' => SwagPayPal::class,
+    'managedByComposer' => false,
+    'autoload' => $composer['autoload'],
+    'path' => $pluginRootPath,
+]]);
 
 KernelFactory::$kernelClass = StaticAnalyzeKernel::class;
 
@@ -41,31 +35,16 @@ KernelFactory::$kernelClass = StaticAnalyzeKernel::class;
 $kernel = KernelFactory::create('dev', true, $classLoader, $pluginLoader);
 $kernel->boot();
 
-$phpStanConfigDist = file_get_contents($pluginRootPath . '/phpstan.neon.dist');
-if ($phpStanConfigDist === false) {
-    throw new RuntimeException('phpstan.neon.dist file not found');
+$phpstanConfig = [
+    'includes' => [$kernel->getProjectDir() . '/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon'],
+    'parameters' => [
+        'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
+        'featureToggles' => ['internalTag' => true],
+    ],
+];
+
+if ($kernel->getContainer()->getParameter('kernel.shopware_version') === '6.7.0.0') {
+    unset($phpstanConfig['parameters']['featureToggles']);
 }
 
-// because the cache dir is hashed by Shopware, we need to set the PHPStan config dynamically
-$phpStanConfig = str_replace(
-    [
-        '%ShopwareHashedCacheDir%',
-        '%ShopwareRoot%',
-        '%ShopwareKernelClass%',
-    ],
-    [
-        str_replace($kernel->getProjectDir(), '', $kernel->getCacheDir()),
-        $projectRoot . (is_dir($projectRoot . '/platform') ? '/platform' : ''),
-        str_replace('\\', '_', $kernel::class),
-    ],
-    $phpStanConfigDist
-);
-
-$shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
-if ($shopwareVersion === '6.7.0.0') {
-    $phpStanConfig = str_replace(['featureToggles:', 'internalTag: true'], ['', ''], $phpStanConfig);
-}
-
-file_put_contents(__DIR__ . '/../phpstan.neon', $phpStanConfig);
-
-return $classLoader;
+file_put_contents(__DIR__ . '/../phpstan.dynamic.neon', \json_encode($phpstanConfig, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -61,6 +61,11 @@ $phpStanConfig = str_replace(
     $phpStanConfigDist
 );
 
+$shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
+if ($shopwareVersion === '6.7.0.0') {
+    $phpStanConfig = str_replace(['featureToggles:', 'internalTag: true'], ['', ''], $phpStanConfig);
+}
+
 file_put_contents(__DIR__ . '/../phpstan.neon', $phpStanConfig);
 
 return $classLoader;

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -40,6 +40,7 @@ $phpstanConfig = [
     'parameters' => [
         'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
     ],
+    'featureToggles' => ['internalTag' => true],
 ];
 
 $shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -40,7 +40,6 @@ $phpstanConfig = [
     'parameters' => [
         'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
     ],
-    'featureToggles' => ['internalTag' => true],
 ];
 
 $shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
@@ -49,10 +48,6 @@ echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
 $versionedConfig = \sprintf('%s/phpstan-%s.neon.dist', $pluginRootPath, $shopwareVersion);
 if (\file_exists($versionedConfig)) {
     $phpstanConfig['includes'][] = $versionedConfig;
-}
-
-if ($shopwareVersion === '6.7.0.0') {
-    unset($phpstanConfig['parameters']['featureToggles']);
 }
 
 $encoded = \json_encode($phpstanConfig, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT);

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -46,6 +46,11 @@ $phpstanConfig = [
 $shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
 echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
 
+$versionedConfig = \sprintf('%s/phpstan-%s.neon.dist', $pluginRootPath, $shopwareVersion);
+if (\file_exists($versionedConfig)) {
+    $phpstanConfig['includes'][] = $versionedConfig;
+}
+
 if ($shopwareVersion === '6.7.0.0') {
     unset($phpstanConfig['parameters']['featureToggles']);
 }

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -39,7 +39,6 @@ $phpstanConfig = [
     'includes' => [$kernel->getProjectDir() . '/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon'],
     'parameters' => [
         'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
-        'featureToggles' => ['internalTag' => true],
     ],
 ];
 
@@ -55,4 +54,10 @@ if ($shopwareVersion === '6.7.0.0') {
     unset($phpstanConfig['parameters']['featureToggles']);
 }
 
-file_put_contents(__DIR__ . '/../phpstan.dynamic.neon', \json_encode($phpstanConfig, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));
+$encoded = \json_encode($phpstanConfig, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT);
+
+if ((bool) $_SERVER['CI']) { // Print config for clearity in workflow
+    echo 'Generated config:' . \PHP_EOL . $encoded . \PHP_EOL;
+}
+
+file_put_contents(__DIR__ . '/../phpstan.dynamic.neon', $encoded);

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -11,12 +11,15 @@ use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Swag\PayPal\SwagPayPal;
 
+// SETUP
+
+$_SERVER['CI'] ??= false;
 $projectRoot = $_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4);
 $pluginRootPath = dirname(__DIR__);
 
 $classLoader = require $projectRoot . '/vendor/autoload.php';
 
-/** @var array{'autoload': array{}} $composer */
+/** @var array{autoload: array{}, version: string} $composer */
 $composer = json_decode((string) file_get_contents($pluginRootPath . '/composer.json'), true);
 
 $pluginLoader = new StaticKernelPluginLoader($classLoader, null, [[
@@ -35,25 +38,27 @@ KernelFactory::$kernelClass = StaticAnalyzeKernel::class;
 $kernel = KernelFactory::create('dev', true, $classLoader, $pluginLoader);
 $kernel->boot();
 
-$phpstanConfig = [
-    'includes' => [$kernel->getProjectDir() . '/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon'],
-    'parameters' => [
-        'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
-    ],
-];
+// GENERATE CONFIG
 
 $shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
 echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
 
 $versionedConfig = \sprintf('%s/phpstan-%s.neon.dist', $pluginRootPath, $shopwareVersion);
-if (\file_exists($versionedConfig)) {
-    $phpstanConfig['includes'][] = $versionedConfig;
-}
+
+$phpstanConfig = [
+    'includes' => \array_merge(#
+        [$kernel->getProjectDir() . '/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon'],
+        \file_exists($versionedConfig) ? [$versionedConfig] : [],
+    ),
+    'parameters' => [
+        'symfony' => ['containerXmlPath' => \sprintf('%s/%sDevDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class))],
+        'reportUnmatchedIgnoredErrors' => !((bool) $_SERVER['CI']),
+    ],
+];
 
 $encoded = \json_encode($phpstanConfig, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT);
+file_put_contents(__DIR__ . '/../phpstan.dynamic.neon', $encoded);
 
 if ((bool) $_SERVER['CI']) { // Print config for clearity in workflow
     echo 'Generated config:' . \PHP_EOL . $encoded . \PHP_EOL;
 }
-
-file_put_contents(__DIR__ . '/../phpstan.dynamic.neon', $encoded);

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -24,7 +24,7 @@ $pluginLoader = new StaticKernelPluginLoader($classLoader, null, [[
     'active' => true,
     'version' => $composer['version'],
     'baseClass' => SwagPayPal::class,
-    'managedByComposer' => false,
+    'managedByComposer' => true,
     'autoload' => $composer['autoload'],
     'path' => $pluginRootPath,
 ]]);
@@ -46,7 +46,7 @@ $phpstanConfig = [
 $shopwareVersion = $kernel->getContainer()->getParameter('kernel.shopware_version');
 echo \sprintf('Identified shopware version "%s"' . \PHP_EOL, $shopwareVersion);
 
-if ($shopwareVersion === 'v6.7.0.0') {
+if ($shopwareVersion === '6.7.0.0') {
     unset($phpstanConfig['parameters']['featureToggles']);
 }
 

--- a/phpstan-6.7.0.0.neon.dist
+++ b/phpstan-6.7.0.0.neon.dist
@@ -29,3 +29,6 @@ parameters:
         - message: '#.* method_exists\(\) with Shopware\\Core\\Checkout\\Order\\OrderEntity .*#'
           identifier: function.impossibleType
           path: tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+
+        - identifier: symplify.noDynamicName
+          path: tests/Pos/Mock/MessageBusMock.php

--- a/phpstan-6.7.0.0.neon.dist
+++ b/phpstan-6.7.0.0.neon.dist
@@ -1,9 +1,6 @@
 # Polyfill of trunk's common.neon
 
 parameters:
-    featureToggles:
-        internalTag: false
-
     reportMaybesInMethodSignatures: false
     reportWrongPhpDocTypeInVarTag: false
 

--- a/phpstan-6.7.0.0.neon.dist
+++ b/phpstan-6.7.0.0.neon.dist
@@ -24,3 +24,8 @@ parameters:
         noVariableVariables: false
         strictArrayFilter: false
         illegalConstructorMethodCall: false
+
+    ignoreErrors:
+        - message: '#.* method_exists\(\) with Shopware\\Core\\Checkout\\Order\\OrderEntity .*#'
+          identifier: function.impossibleType
+          path: tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php

--- a/phpstan-6.7.0.0.neon.dist
+++ b/phpstan-6.7.0.0.neon.dist
@@ -1,0 +1,29 @@
+# Polyfill of trunk's common.neon
+
+parameters:
+    featureToggles:
+        internalTag: false
+
+    reportMaybesInMethodSignatures: false
+    reportWrongPhpDocTypeInVarTag: false
+
+    strictRules:
+        disallowedLooseComparison: false
+        booleansInConditions: false
+        booleansInLoopConditions: false
+        uselessCast: false
+        requireParentConstructorCall: false
+        disallowedBacktick: false
+        disallowedEmpty: false
+        disallowedImplicitArrayCreation: false
+        disallowedShortTernary: false
+        overwriteVariablesWithLoop: false
+        closureUsesThis: false
+        matchingInheritedMethodNames: false
+        numericOperandsInArithmeticOperators: false
+        strictFunctionCalls: false
+        dynamicCallOnStaticMethod: false
+        switchConditionsMatchingType: false
+        noVariableVariables: false
+        strictArrayFilter: false
+        illegalConstructorMethodCall: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,9 @@ parameters:
     bootstrapFiles:
         - bin/static-analyze-autoloader.php
 
+    featureToggles:
+        internalTag: true
+
     symfony:
         constantHassers: false
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,9 +17,6 @@ parameters:
     bootstrapFiles:
         - bin/static-analyze-autoloader.php
 
-    featureToggles:
-        internalTag: true
-
     symfony:
         constantHassers: false
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,9 @@
 includes:
     - phpstan-baseline.neon
-    - %ShopwareRoot%/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+    - phpstan.dynamic.neon
 
 parameters:
     tmpDir: var/cache/phpstan
-    featureToggles:
-        internalTag: true
 
     paths:
         - src
@@ -21,8 +19,6 @@ parameters:
 
     symfony:
         constantHassers: false
-        # the placeholder "%ShopwareHashedCacheDir%" will be replaced on execution by bin/phpstan-config-generator.php script
-        containerXmlPath: '../../..%ShopwareHashedCacheDir%/%ShopwareKernelClass%DevDebugContainer.xml'
 
     ignoreErrors:
         # We won't type all arrays/iterables for now

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -38,7 +38,8 @@ class ZugferdSubscriber implements EventSubscriberInterface
         $transaction = $event->order->getTransactions()?->last();
         // Method is not available for version 6.7.0.0
         /** @phpstan-ignore function.alreadyNarrowedType */
-        if (Feature::isActive('v6.8.0.0') && method_exists($event->order, 'getPrimaryOrderTransaction')) {
+        if (Feature::isActive('v6.8.0.0') && \method_exists($event->order, 'getPrimaryOrderTransaction')) {
+            /** @var OrderTransaction|null $transaction - silence 6.7.0.0 type errors */
             $transaction = $event->order->getPrimaryOrderTransaction();
         }
 

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -7,14 +7,14 @@
 
 namespace Swag\PayPal\Checkout\Document\Zugferd;
 
-use Swag\PayPal\SwagPayPal;
-use Shopware\Core\Framework\Feature;
-use Shopware\Core\Framework\Log\Package;
 use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
-use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\SwagPayPal;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal

--- a/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
+++ b/src/Checkout/Document/Zugferd/ZugferdSubscriber.php
@@ -7,13 +7,14 @@
 
 namespace Swag\PayPal\Checkout\Document\Zugferd;
 
-use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
-use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
+use Swag\PayPal\SwagPayPal;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Swag\PayPal\SwagPayPal;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceGeneratedEvent;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 
 /**
  * @internal
@@ -39,7 +40,7 @@ class ZugferdSubscriber implements EventSubscriberInterface
         // Method is not available for version 6.7.0.0
         /** @phpstan-ignore function.alreadyNarrowedType */
         if (Feature::isActive('v6.8.0.0') && \method_exists($event->order, 'getPrimaryOrderTransaction')) {
-            /** @var OrderTransaction|null $transaction - silence 6.7.0.0 type errors */
+            /** @var OrderTransactionEntity|null $transaction - silence 6.7.0.0 type errors */
             $transaction = $event->order->getPrimaryOrderTransaction();
         }
 

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -53,6 +53,7 @@ class ZugferdSubscriberTest extends TestCase
 
         $order = new OrderEntity();
         if ($transaction !== null) {
+            /** @phpstan-ignore function.alreadyNarrowedType */
             if (\method_exists($order, 'setPrimaryOrderTransaction')) {
                 $order->setPrimaryOrderTransaction($transaction);
             }

--- a/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
+++ b/tests/Checkout/Document/Zugferd/ZugferdSubscriberTest.php
@@ -53,7 +53,9 @@ class ZugferdSubscriberTest extends TestCase
 
         $order = new OrderEntity();
         if ($transaction !== null) {
-            $order->setPrimaryOrderTransaction($transaction);
+            if (\method_exists($order, 'setPrimaryOrderTransaction')) {
+                $order->setPrimaryOrderTransaction($transaction);
+            }
             $order->setTransactions(new OrderTransactionCollection([$transaction]));
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Now that 6.7.0.0 has been released, we should include it as our minimum version again in GitHub action jobs.
The PHPStan parameter `featureToggles->internalTag` is not available in version 6.7.0.0, which prompted me to revisit how PHPStan configurations are generated.

### 2. What does this change do, exactly?
Add 6.7.0.0 to matrices `PLATFORM_BRANCH` variable

