### PR TITLE
fix: missing payment details empty state

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-payment/page/swag-paypal-payment-detail/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/page/swag-paypal-payment-detail/index.js
@@ -46,7 +46,7 @@ Component.register('swag-paypal-payment-detail', {
         },
 
         stateFailedCancelled() {
-            return this.orderTransaction.stateMachineState.technicalName in ['cancelled', 'failed'];
+            return ['cancelled', 'failed'].includes(this.orderTransaction.stateMachineState.technicalName);
         },
 
         hasPayPalDetails() {

--- a/src/Resources/app/administration/src/module/swag-paypal-payment/page/swag-paypal-payment-detail/swag-paypal-payment-detail.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/page/swag-paypal-payment-detail/swag-paypal-payment-detail.html.twig
@@ -13,6 +13,7 @@
             v-if="stateFailedCancelled"
             :title="$t('swag-paypal-payment.errorPage.title')"
             :subline="$t('swag-paypal-payment.errorPage.canceledPaymentContent')"
+            :absolute="false"
             icon="regular-shopping-bag"
             color="#A092F0"
         />
@@ -23,6 +24,7 @@
             v-else
             :title="$t('swag-paypal-payment.errorPage.title')"
             :subline="$t('swag-paypal-payment.errorPage.other')"
+            :absolute="false"
             icon="regular-shopping-bag"
             color="#A092F0"
         />

--- a/src/Resources/app/administration/src/module/swag-paypal-payment/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/snippet/de-DE.json
@@ -138,8 +138,8 @@
         },
         "errorPage": {
             "title": "Zahlungsdetails nicht verfügbar",
-            "canceledPaymentContent": "Beim Abrufen der Zahlungsdaten von PayPal ist ein Fehler aufgetreten. Wenn du diese Nachricht siehst, handelt es sich vermutlich um eine Zahlung, die vom Kunden abgebrochen wurde. Abgebrochene Zahlungen werden nach einiger Zeit von PayPal gelöscht und sind dann nicht länger abrufbar.",
-            "other": "Die Zahlungsdaten konnten nicht von PayPal abgerufen werden. Es ist wahrscheinlich, dass die Zahlung vom Kunden nicht abgeschlossen oder mit aktivierter Sandbox erstellt und jetzt mit Live-Daten angefordert wurde. Die Details für nicht abgeschlossene Zahlungen sind auf der PayPal-Seite nur für etwa 6 Stunden verfügbar."
+            "canceledPaymentContent": "Wenn du diese Nachricht siehst, handelt es sich vermutlich um eine Zahlung, die vom Kunden abgebrochen wurde. Abgebrochene Zahlungen werden nach einiger Zeit von PayPal gelöscht und sind dann nicht länger abrufbar.",
+            "other": "Es ist wahrscheinlich, dass die Zahlung vom Kunden nicht abgeschlossen oder mit aktivierter Sandbox erstellt und jetzt mit Live-Daten angefordert wurde. Die Details für nicht abgeschlossene Zahlungen sind auf der PayPal-Seite nur für etwa 6 Stunden verfügbar."
         }
     },
     "sw-order-detail": {

--- a/src/Resources/app/administration/src/module/swag-paypal-payment/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/snippet/en-GB.json
@@ -138,8 +138,8 @@
         },
         "errorPage": {
             "title": "Payment details not available",
-            "canceledPaymentContent": "An error occurred while retrieving payment details from PayPal. If you see this message, it was probably a payment that was cancelled by the customer. Cancelled payments will be deleted by PayPal after a while and are then no longer available.",
-            "other": "Payment details could not be retrieved from PayPal. It is likely that the payment was not completed by the customer, or was created with sandbox enabled and has now been requested with live data. Details for uncompleted payments are only available for about 6 hours on the PayPal side."
+            "canceledPaymentContent": "If you see this message, it was probably a payment that was cancelled by the customer. Cancelled payments will be deleted by PayPal after a while and are then no longer available.",
+            "other": "It is likely that the payment was not completed by the customer, or was created with sandbox enabled and has now been requested with live data. Details for uncompleted payments are only available for about 6 hours on the PayPal side."
         }
     },
     "sw-order-detail": {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Empty state for missing payment details with transaction cancelled/failed was not shown correctly.
Also, it's not necessary to tell the user three times that something went wrong: Notification, empty state title and description.

### 2. What does this change do, exactly?
Fix empty state for cancelled/failed transactions and reduced the description. Should increase visibility of the causes for this. 

### 3. Describe each step to reproduce the issue or behaviour.
- Open payment details a no longer available paypal order 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
