### PR TITLE
fix: upstream phpstan

### DIFF
--- a/src/SwagPayPal.php
+++ b/src/SwagPayPal.php
@@ -239,7 +239,7 @@ class SwagPayPal extends Plugin
 
         $projectDir = $this->container->getParameter('kernel.project_dir');
 
-        if (!\file_exists($projectDir . '/vendor/autoload.php')) {
+        if (!\is_dir($projectDir . '/vendor') || !\is_file($projectDir . '/vendor/autoload.php')) {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
New phpstan rules in platform trunk: [NoFileExistsRule](https://github.com/shopware/shopware/blob/7dc57f0988f342ef0bb5385b32b5bc5dd365e96c/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoFileExistsRule.php#L20)

### 2. What does this change do, exactly?
change `file_exists` to `is_dir` and `is_file`

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
