### PR TITLE
fix: automatic guest logout for PUI payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where PUI payment details were not shown, if the "logout guest customer after order" setting was enabled (shopware/SwagPayPal#315, requires Shopware 6.7.2.0 or higher)
+
 # 10.1.0
 - Added necessary payment means for e-invoice generation (shopware/SwagPayPal#255)
 - Fixes an issue where the form validation on the order confirmation page does not refer to the corresponding input field (shopware/SwagPayPal#267)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem Rechnungskauf-Details dem Kunden nicht angezeigt wurden, wenn die Einstellung "Gastkunde nach Bestellung ausloggen" aktiviert ist (shopware/SwagPayPal#315, benötigt Shopware 6.7.2.0 oder höher)
+
 # 10.1.0
 - Fügt notwenige Zahlungsmittelinformationen zu E-Rechnungen hinzu (shopware/SwagPayPal#255)
 - Behebt ein Problem, bei dem die Formularvalidierung auf der Bestellbestätigungsseite nicht auf das entsprechende Eingabefeld verweist (shopware/SwagPayPal#267)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -84,6 +84,10 @@ parameters:
             identifier: attribute.internalClass
             message: '#.*Shopware\\Core\\Framework\\Log\\Package#'
 
+        - # 6.8 deprecation
+            identifier: method.deprecated
+            message: '#__construct.*Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityDefinition.*#'
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Internal\InternalClassRule

--- a/src/Checkout/PUI/PUISubscriber.php
+++ b/src/Checkout/PUI/PUISubscriber.php
@@ -108,6 +108,7 @@ class PUISubscriber implements EventSubscriberInterface
         $event->getPage()->addExtension(self::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID, $puiPaymentInstructionData);
 
         // @deprecated tag:v11.0.0 - remove early return with min-version of 6.7.2.0
+        // @phpstan-ignore-next-line method may or may not exist depending on Shopware version
         if (method_exists($event->getPage(), 'setLogoutCustomer')) {
             return;
         }

--- a/src/Checkout/PUI/PUISubscriber.php
+++ b/src/Checkout/PUI/PUISubscriber.php
@@ -106,6 +106,13 @@ class PUISubscriber implements EventSubscriberInterface
         }
 
         $event->getPage()->addExtension(self::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID, $puiPaymentInstructionData);
+
+        // @deprecated tag:v11.0.0 - remove early return with min-version of 6.7.2.0
+        if (method_exists($event->getPage(), 'setLogoutCustomer')) {
+            return;
+        }
+
+        $event->getPage()->setLogoutCustomer(false);
     }
 
     private function checkSettings(SalesChannelContext $salesChannelContext, bool $checkPaymentMethod = true): bool

--- a/src/Checkout/PUI/PUISubscriber.php
+++ b/src/Checkout/PUI/PUISubscriber.php
@@ -109,7 +109,7 @@ class PUISubscriber implements EventSubscriberInterface
 
         // @deprecated tag:v11.0.0 - remove early return with min-version of 6.7.2.0
         // @phpstan-ignore-next-line method may or may not exist depending on Shopware version
-        if (method_exists($event->getPage(), 'setLogoutCustomer')) {
+        if (!method_exists($event->getPage(), 'setLogoutCustomer')) {
             return;
         }
 

--- a/tests/Checkout/PUI/PUISubscriberTest.php
+++ b/tests/Checkout/PUI/PUISubscriberTest.php
@@ -222,6 +222,7 @@ class PUISubscriberTest extends TestCase
         $page->setOrder($order);
 
         // @deprecated tag:v11.0.0 - remove if condition with min-version of 6.7.2.0, keep content
+        // @phpstan-ignore-next-line method may or may not exist depending on Shopware version
         if (method_exists($page, 'setLogoutCustomer')) {
             $page->setLogoutCustomer(true);
         }
@@ -232,6 +233,7 @@ class PUISubscriberTest extends TestCase
         static::assertSame($paymentInstructionData, $extension);
 
         // @deprecated tag:v11.0.0 - remove if condition with min-version of 6.7.2.0, keep content
+        // @phpstan-ignore-next-line method may or may not exist depending on Shopware version
         if (method_exists($page, 'isLogoutCustomer')) {
             static::assertFalse($page->isLogoutCustomer());
         }

--- a/tests/Checkout/PUI/PUISubscriberTest.php
+++ b/tests/Checkout/PUI/PUISubscriberTest.php
@@ -1,0 +1,305 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\PUI;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Page\Account\Order\AccountEditOrderPage;
+use Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoadedEvent;
+use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPage;
+use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
+use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPage;
+use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoadedEvent;
+use Swag\PayPal\Checkout\Payment\Method\PUIHandler;
+use Swag\PayPal\Checkout\PUI\PUIFraudNetData;
+use Swag\PayPal\Checkout\PUI\PUIPaymentInstructionData;
+use Swag\PayPal\Checkout\PUI\PUISubscriber;
+use Swag\PayPal\Checkout\PUI\Service\PUIFraudNetDataService;
+use Swag\PayPal\Checkout\PUI\Service\PUIPaymentInstructionDataService;
+use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
+use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PUISubscriberTest extends TestCase
+{
+    private PUISubscriber $subscriber;
+
+    /**
+     * @var SettingsValidationServiceInterface&MockObject
+     */
+    private SettingsValidationServiceInterface $settingsValidationService;
+
+    /**
+     * @var PUIFraudNetDataService&MockObject
+     */
+    private PUIFraudNetDataService $puiFraudNetDataService;
+
+    /**
+     * @var PUIPaymentInstructionDataService&MockObject
+     */
+    private PUIPaymentInstructionDataService $puiPaymentInstructionDataService;
+
+    private LoggerInterface $logger;
+
+    private SalesChannelContext $salesChannelContext;
+
+    protected function setUp(): void
+    {
+        $this->settingsValidationService = $this->createMock(SettingsValidationServiceInterface::class);
+        $this->puiFraudNetDataService = $this->createMock(PUIFraudNetDataService::class);
+        $this->puiPaymentInstructionDataService = $this->createMock(PUIPaymentInstructionDataService::class);
+        $this->logger = new NullLogger();
+
+        $this->salesChannelContext = Generator::generateSalesChannelContext();
+
+        $this->subscriber = new PUISubscriber(
+            $this->settingsValidationService,
+            $this->puiFraudNetDataService,
+            $this->puiPaymentInstructionDataService,
+            $this->logger
+        );
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        $expectedEvents = [
+            AccountEditOrderPageLoadedEvent::class => 'onAccountOrderEditLoaded',
+            CheckoutConfirmPageLoadedEvent::class => 'onCheckoutConfirmLoaded',
+            CheckoutFinishPageLoadedEvent::class => 'onCheckoutFinishLoaded',
+        ];
+
+        $actualEvents = PUISubscriber::getSubscribedEvents();
+
+        static::assertEquals($expectedEvents, $actualEvents);
+    }
+
+    public function testOnAccountOrderEditLoadedWithValidSettings(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier(PUIHandler::class);
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $fraudNetData = new PUIFraudNetData();
+        $this->puiFraudNetDataService->method('buildCheckoutData')->willReturn($fraudNetData);
+
+        $page = new AccountEditOrderPage();
+        $event = new AccountEditOrderPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onAccountOrderEditLoaded($event);
+        $extension = $page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID);
+        static::assertSame($fraudNetData, $extension);
+    }
+
+    public function testOnAccountOrderEditLoadedWithInvalidPaymentMethod(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier('InvalidHandler');
+        $this->puiFraudNetDataService->expects(static::never())->method('buildCheckoutData');
+
+        $page = new AccountEditOrderPage();
+        $event = new AccountEditOrderPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onAccountOrderEditLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnAccountOrderEditLoadedWithInvalidSettings(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier(PUIHandler::class);
+        $this->settingsValidationService->method('validate')->willThrowException(new PayPalSettingsInvalidException('Invalid settings'));
+        $this->puiFraudNetDataService->expects(static::never())->method('buildCheckoutData');
+
+        $page = new AccountEditOrderPage();
+        $event = new AccountEditOrderPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onAccountOrderEditLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutConfirmLoadedWithValidSettings(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier(PUIHandler::class);
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $fraudNetData = new PUIFraudNetData();
+        $this->puiFraudNetDataService->method('buildCheckoutData')->willReturn($fraudNetData);
+
+        $cart = new Cart('test');
+        $cart->setErrors(new ErrorCollection());
+        $page = new CheckoutConfirmPage();
+        $page->setCart($cart);
+        $event = new CheckoutConfirmPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutConfirmLoaded($event);
+        $extension = $page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID);
+        static::assertSame($fraudNetData, $extension);
+    }
+
+    public function testOnCheckoutConfirmLoadedWithInvalidPaymentMethod(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier('InvalidHandler');
+        $this->puiFraudNetDataService->expects(static::never())->method('buildCheckoutData');
+
+        $cart = new Cart('test');
+        $cart->setErrors(new ErrorCollection());
+        $page = new CheckoutConfirmPage();
+        $page->setCart($cart);
+        $event = new CheckoutConfirmPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutConfirmLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutConfirmLoadedWithInvalidSettings(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier(PUIHandler::class);
+        $this->settingsValidationService->method('validate')->willThrowException(new PayPalSettingsInvalidException('Invalid settings'));
+        $this->puiFraudNetDataService->expects(static::never())->method('buildCheckoutData');
+
+        $cart = new Cart('test');
+        $cart->setErrors(new ErrorCollection());
+        $page = new CheckoutConfirmPage();
+        $page->setCart($cart);
+        $event = new CheckoutConfirmPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutConfirmLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutConfirmLoadedWithBlockingErrors(): void
+    {
+        $paymentMethod = $this->salesChannelContext->getPaymentMethod();
+        $paymentMethod->setHandlerIdentifier(PUIHandler::class);
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $this->puiFraudNetDataService->expects(static::never())->method('buildCheckoutData');
+
+        $cart = new Cart('test');
+        $errors = new ErrorCollection();
+        $errors->add(new PaymentMethodBlockedError('test-payment-method'));
+        $cart->setErrors($errors);
+        $page = new CheckoutConfirmPage();
+        $page->setCart($cart);
+        $event = new CheckoutConfirmPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutConfirmLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_FRAUDNET_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutFinishLoadedWithValidSettings(): void
+    {
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $paymentInstructionData = new PUIPaymentInstructionData();
+        $this->puiPaymentInstructionDataService->method('buildFinishData')->willReturn($paymentInstructionData);
+
+        $transaction = new OrderTransactionEntity();
+        $transaction->setId('test-id');
+        $transactions = new OrderTransactionCollection([$transaction]);
+        $order = new OrderEntity();
+        $order->setTransactions($transactions);
+        $page = new CheckoutFinishPage();
+        $page->setOrder($order);
+
+        // @deprecated tag:v11.0.0 - remove if condition with min-version of 6.7.2.0, keep content
+        if (method_exists($page, 'setLogoutCustomer')) {
+            $page->setLogoutCustomer(true);
+        }
+        $event = new CheckoutFinishPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutFinishLoaded($event);
+        $extension = $page->getExtension(PUISubscriber::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID);
+        static::assertSame($paymentInstructionData, $extension);
+
+        // @deprecated tag:v11.0.0 - remove if condition with min-version of 6.7.2.0, keep content
+        if (method_exists($page, 'isLogoutCustomer')) {
+            static::assertFalse($page->isLogoutCustomer());
+        }
+    }
+
+    public function testOnCheckoutFinishLoadedWithInvalidSettings(): void
+    {
+        $this->settingsValidationService->method('validate')->willThrowException(new PayPalSettingsInvalidException('Invalid settings'));
+        $this->puiPaymentInstructionDataService->expects(static::never())->method('buildFinishData');
+
+        $transaction = new OrderTransactionEntity();
+        $transaction->setId('test-id');
+        $transactions = new OrderTransactionCollection([$transaction]);
+        $order = new OrderEntity();
+        $order->setTransactions($transactions);
+        $page = new CheckoutFinishPage();
+        $page->setOrder($order);
+        $event = new CheckoutFinishPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutFinishLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutFinishLoadedWithNoTransactions(): void
+    {
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $this->puiPaymentInstructionDataService->expects(static::never())->method('buildFinishData');
+
+        $order = new OrderEntity();
+        $page = new CheckoutFinishPage();
+        $page->setOrder($order);
+        $event = new CheckoutFinishPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutFinishLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutFinishLoadedWithEmptyTransactions(): void
+    {
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $this->puiPaymentInstructionDataService->expects(static::never())->method('buildFinishData');
+
+        $transactions = new OrderTransactionCollection([]);
+        $order = new OrderEntity();
+        $order->setTransactions($transactions);
+        $page = new CheckoutFinishPage();
+        $page->setOrder($order);
+        $event = new CheckoutFinishPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutFinishLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID));
+    }
+
+    public function testOnCheckoutFinishLoadedWithNoPaymentInstructionData(): void
+    {
+        $this->settingsValidationService->expects(static::once())->method('validate');
+        $this->puiPaymentInstructionDataService->method('buildFinishData')->willReturn(null);
+
+        $transaction = new OrderTransactionEntity();
+        $transaction->setId('test-id');
+        $transactions = new OrderTransactionCollection([$transaction]);
+        $order = new OrderEntity();
+        $order->setTransactions($transactions);
+        $page = new CheckoutFinishPage();
+        $page->setOrder($order);
+        $event = new CheckoutFinishPageLoadedEvent($page, $this->salesChannelContext, new Request());
+
+        $this->subscriber->onCheckoutFinishLoaded($event);
+        static::assertNull($page->getExtension(PUISubscriber::PAYPAL_PUI_PAYMENT_INSTRUCTIONS_PAGE_EXTENSION_ID));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
With the automatic guest logout, PUI payments do not show the payment details on the finish page, as there is no more session to validate against.

### 2. What does this change do, exactly?
We built a new manipulation toggle to modify this behavior. Therefore, this is only available for Shopware >= 6.7.3.0.

### 3. Describe each step to reproduce the issue or behaviour.
- Set guest logout on order finish to true
- Try a PUI payment

### 4. Please link to the relevant issues (if any).
fixes #315 
relates to shopware/shopware#11725

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
