### PR TITLE
[6.6.x] fix: prevent extensive invalid order transaction id error messages

### DIFF
--- a/src/Webhook/Exception/WebhookOrderTransactionInvalidIdException.php
+++ b/src/Webhook/Exception/WebhookOrderTransactionInvalidIdException.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Webhook\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('checkout')]
+class WebhookOrderTransactionInvalidIdException extends WebhookException
+{
+    public function __construct(
+        string $reason,
+        string $eventType,
+    ) {
+        parent::__construct(
+            $eventType,
+            '[PayPal {{ eventType }} Webhook] Could not handle order transaction id {{ reason }}',
+            [
+                'eventType' => $eventType,
+                'reason' => $reason,
+            ]
+        );
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__WEBHOOK_ORDER_TRANSACTION_INVALID';
+    }
+}

--- a/src/Webhook/Handler/AbstractWebhookHandler.php
+++ b/src/Webhook/Handler/AbstractWebhookHandler.php
@@ -15,12 +15,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Swag\PayPal\RestApi\V1\Api\Webhook;
 use Swag\PayPal\RestApi\V1\Api\Webhook\Resource;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\Payments\Payment;
 use Swag\PayPal\SwagPayPal;
 use Swag\PayPal\Webhook\Exception\ParentPaymentNotFoundException;
-use Swag\PayPal\Webhook\Exception\WebhookException;
+use Swag\PayPal\Webhook\Exception\WebhookOrderTransactionInvalidIdException;
 use Swag\PayPal\Webhook\Exception\WebhookOrderTransactionNotFoundException;
 use Swag\PayPal\Webhook\WebhookHandler;
 
@@ -86,7 +87,14 @@ abstract class AbstractWebhookHandler implements WebhookHandler
         }
 
         if ($orderTransactionId === null) {
-            throw new WebhookException($this->getEventType(), 'Given webhook resource data does not contain needed custom ID');
+            throw new WebhookOrderTransactionInvalidIdException('Given webhook resource data does not contain needed custom ID', $this->getEventType());
+        }
+
+        if (!Uuid::isValid($orderTransactionId)) {
+            throw new WebhookOrderTransactionInvalidIdException(
+                \sprintf('Given custom ID "%s" is not a valid UUID', $orderTransactionId),
+                $this->getEventType()
+            );
         }
 
         $criteria = new Criteria([$orderTransactionId]);

--- a/src/Webhook/WebhookController.php
+++ b/src/Webhook/WebhookController.php
@@ -20,6 +20,7 @@ use Swag\PayPal\RestApi\V1\Api\Webhook;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Webhook\Exception\WebhookException;
 use Swag\PayPal\Webhook\Exception\WebhookHandlerNotFoundException;
+use Swag\PayPal\Webhook\Exception\WebhookOrderTransactionInvalidIdException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -191,7 +192,7 @@ class WebhookController extends AbstractController
         try {
             $this->webhookService->executeWebhook($webhook, $context);
             $this->logger->info('[PayPal Webhook] Webhook successfully executed', $logContext);
-        } catch (WebhookHandlerNotFoundException $exception) {
+        } catch (WebhookHandlerNotFoundException|WebhookOrderTransactionInvalidIdException $exception) {
             $this->logger->info(\sprintf('[PayPal Webhook] %s', $exception->getMessage()), $logContext);
         } catch (WebhookException $webhookException) {
             $this->logger->error(\sprintf('[PayPal Webhook] %s', $webhookException->getMessage()), $logContext);


### PR DESCRIPTION
### 1. Why is this change necessary?
>- Currently there is always a error message in the logs, if the webhook tries to handle a invalid order transaction uuid, as there is no check as if the given custom id (order transaction id) is a valid uuid
>- This error messages overshadow real error messages as they can happen a lot
>- If you use the to the shop linked PayPal account for more than just the shop transactions the webhook will still receive all other transactions handled on the same PayPal account and will try to extract a order transaction id from the resources
>- We still fail with a WebhookException but with a better exception message and we no longer log it in the error log, but the info log

### 2. What does this change do, exactly?
>- Created a new exception `Swag\PayPal\Webhook\Exception\WebhookOrderTransactionInvalidIdException` to capture invalid order transaction ids
>- Updated `Swag\PayPal\Webhook\WebhookController` to catch `WebhookOrderTransactionInvalidIdException` for a logger into

### 3. Describe each step to reproduce the issue or behaviour.
>- Handle different data on the same PayPal Account which is linked with the Shop

### 4. Please link to the relevant issues (if any).
- Backport of #345
