### PR TITLE
fix: Reduce shipping method message dispatch for unchanged data

### DIFF
--- a/src/Checkout/Order/Shipping/ShippingSubscriber.php
+++ b/src/Checkout/Order/Shipping/ShippingSubscriber.php
@@ -53,7 +53,7 @@ class ShippingSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            if (!isset($command->getPayload()['tracking_codes'])) {
+            if (!\array_key_exists('tracking_codes', $command->getPayload())) {
                 continue;
             }
 
@@ -79,7 +79,7 @@ class ShippingSubscriber implements EventSubscriberInterface
             }
 
             // If there is no change set (e.g. for a insert command), we only want to continue if tracking codes are part of the payload
-            if (!$changeSet && !isset($writeResult->getPayload()['trackingCodes'])) {
+            if (!$changeSet && !\array_key_exists('trackingCodes', $writeResult->getPayload())) {
                 continue;
             }
 

--- a/src/Checkout/Order/Shipping/ShippingSubscriber.php
+++ b/src/Checkout/Order/Shipping/ShippingSubscriber.php
@@ -72,8 +72,14 @@ class ShippingSubscriber implements EventSubscriberInterface
                 continue;
             }
 
+            // If there is a change set, we only want to continue if the tracking codes have changed
             $changeSet = $writeResult->getChangeSet();
-            if ((!$changeSet && !isset($writeResult->getPayload()['trackingCodes'])) || ($changeSet && !$changeSet->hasChanged('tracking_codes'))) {
+            if ($changeSet && !$changeSet->hasChanged('tracking_codes')) {
+                continue;
+            }
+
+            // If there is no change set (e.g. for a insert command), we only want to continue if tracking codes are part of the payload
+            if (!$changeSet && !isset($writeResult->getPayload()['trackingCodes'])) {
                 continue;
             }
 

--- a/src/Checkout/Order/Shipping/ShippingSubscriber.php
+++ b/src/Checkout/Order/Shipping/ShippingSubscriber.php
@@ -73,7 +73,7 @@ class ShippingSubscriber implements EventSubscriberInterface
             }
 
             $changeSet = $writeResult->getChangeSet();
-            if ($changeSet && !$changeSet->hasChanged('tracking_codes')) {
+            if ((!$changeSet && !isset($writeResult->getPayload()['trackingCodes'])) || ($changeSet && !$changeSet->hasChanged('tracking_codes'))) {
                 continue;
             }
 

--- a/tests/Checkout/Order/Shipping/ShippingSubscriberTest.php
+++ b/tests/Checkout/Order/Shipping/ShippingSubscriberTest.php
@@ -54,7 +54,6 @@ class ShippingSubscriberTest extends TestCase
         yield 'inserted one tracking code, without changeset' => [
             new EntityWriteResult(Uuid::randomHex(), ['trackingCodes' => [self::TEST_CODE]], 'order_delivery', EntityWriteResult::OPERATION_INSERT, null, null),
             [self::TEST_CODE],
-            [],
             true,
         ];
 
@@ -65,7 +64,6 @@ class ShippingSubscriberTest extends TestCase
                 false,
             )),
             [self::TEST_CODE],
-            [],
             true,
         ];
 
@@ -76,7 +74,6 @@ class ShippingSubscriberTest extends TestCase
                 false,
             )),
             [],
-            [self::TEST_CODE],
             true,
         ];
 
@@ -87,13 +84,11 @@ class ShippingSubscriberTest extends TestCase
                 true,
             )),
             null,
-            [],
             true,
         ];
 
         yield 'updated without tracking codes or changeset' => [
             new EntityWriteResult(Uuid::randomHex(), [], 'order_delivery', EntityWriteResult::OPERATION_UPDATE, null, null),
-            null,
             null,
             false,
         ];
@@ -142,7 +137,7 @@ class ShippingSubscriberTest extends TestCase
     }
 
     #[DataProvider('dataProviderWriteResult')]
-    public function testOnOrderDeliveryWritten(EntityWriteResult $result, ?array $expectedAfter, array $expectedBefore, bool $expectEvent): void
+    public function testOnOrderDeliveryWritten(EntityWriteResult $result, ?array $expectedAfter, bool $expectEvent): void
     {
         $event = new EntityWrittenEvent(
             'order_delivery',

--- a/tests/Checkout/Order/Shipping/ShippingSubscriberTest.php
+++ b/tests/Checkout/Order/Shipping/ShippingSubscriberTest.php
@@ -55,6 +55,7 @@ class ShippingSubscriberTest extends TestCase
             new EntityWriteResult(Uuid::randomHex(), ['trackingCodes' => [self::TEST_CODE]], 'order_delivery', EntityWriteResult::OPERATION_INSERT, null, null),
             [self::TEST_CODE],
             [],
+            true,
         ];
 
         yield 'updated one tracking code, with changeset' => [
@@ -65,6 +66,7 @@ class ShippingSubscriberTest extends TestCase
             )),
             [self::TEST_CODE],
             [],
+            true,
         ];
 
         yield 'deleted one existing tracking code, with changeset' => [
@@ -75,6 +77,7 @@ class ShippingSubscriberTest extends TestCase
             )),
             [],
             [self::TEST_CODE],
+            true,
         ];
 
         yield 'deleted one not existing tracking code, with changeset' => [
@@ -85,6 +88,14 @@ class ShippingSubscriberTest extends TestCase
             )),
             null,
             [],
+            true,
+        ];
+
+        yield 'updated without tracking codes or changeset' => [
+            new EntityWriteResult(Uuid::randomHex(), [], 'order_delivery', EntityWriteResult::OPERATION_UPDATE, null, null),
+            null,
+            null,
+            false,
         ];
     }
 
@@ -131,7 +142,7 @@ class ShippingSubscriberTest extends TestCase
     }
 
     #[DataProvider('dataProviderWriteResult')]
-    public function testOnOrderDeliveryWritten(EntityWriteResult $result, ?array $expectedAfter, array $expectedBefore): void
+    public function testOnOrderDeliveryWritten(EntityWriteResult $result, ?array $expectedAfter, array $expectedBefore, bool $expectEvent): void
     {
         $event = new EntityWrittenEvent(
             'order_delivery',
@@ -142,14 +153,20 @@ class ShippingSubscriberTest extends TestCase
             [],
         );
 
-        $this->bus
-            ->expects($expectedAfter === null ? $this->never() : $this->once())
-            ->method('dispatch')
-            ->willReturnCallback(function (ShippingInformationMessage $message) use (&$result): Envelope {
-                static::assertSame($result->getPrimaryKey(), $message->getOrderDeliveryId());
+        if ($expectEvent) {
+            $this->bus
+                ->expects($expectedAfter === null ? $this->never() : $this->once())
+                ->method('dispatch')
+                ->willReturnCallback(function (ShippingInformationMessage $message) use (&$result): Envelope {
+                    static::assertSame($result->getPrimaryKey(), $message->getOrderDeliveryId());
 
-                return new Envelope($message);
-            });
+                    return new Envelope($message);
+                });
+        } else {
+            $this->bus
+                ->expects($this->never())
+                ->method('dispatch');
+        }
 
         $this->subscriber->onOrderDeliveryWritten($event);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the ShippingInformationMessage is dispatched often where it is not needed (each time a order delivery is written) because the check currently always dispatches the ShippingInformationMessage event, if there is no changeset (which e.g. is the case for all inserts)

### 2. What does this change do, exactly?
- Changed ShippingSubscriber to no longer dispatch the ShippingInformationMessage event for unchanged tracking codes

### 3. Describe each step to reproduce the issue or behaviour.
- Create a order -> InsertCommand -> No Changeset -> If will not check correctly -> dispatch event even though tracking codes haven't changed

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
