### PR TITLE
feat: Move the funding eligibility check script out of footer

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -92,6 +92,17 @@ parameters:
             identifier: method.deprecated
             message: '#(setActiveBillingAddress|setActiveShippingAddress).*Shopware\\Core\\Checkout\\Customer\\CustomerEntity.*#'
 
+        - # v11.0.0 deprecation - addFundingAvailabilityDataToFooter will be removed
+            identifier: method.deprecated
+            message: '#Call to deprecated method addFundingAvailabilityDataToFooter\(\) of class Swag\\PayPal\\Storefront\\Data\\FundingSubscriber#'
+            path: tests/Storefront/Data/FundingSubscriberTest.php
+
+        - # Null check for extension before adding
+            identifier: argument.type
+            message: '#Parameter \#2 \$extension of method Shopware\\Core\\Framework\\Struct\\Struct::addExtension\(\) expects Shopware\\Core\\Framework\\Struct\\Struct, Shopware\\Core\\Framework\\Struct\\Struct\|null given#'
+            paths:
+                - tests/Storefront/Data/FundingSubscriberTest.php
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Internal\InternalClassRule

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -1,0 +1,16 @@
+{% sw_extends '@Storefront/storefront/base.html.twig' %}
+
+{% block base_body_script %}
+    {{ parent() }}
+
+    {% block paypal_funding_eligibility_script %}
+        {# @var \Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData fundingEligibilityData #}
+        {% set fundingEligibilityData = page.extensions[constant('Swag\\PayPal\\Storefront\\Data\\FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION')] %}
+
+        {% if fundingEligibilityData %}
+            <div data-swag-paypal-funding-eligibility="true"
+                 data-swag-paypal-funding-eligibility-options="{{ fundingEligibilityData|json_encode }}">
+            </div>
+        {% endif %}
+    {% endblock %}
+{% endblock %}

--- a/src/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Resources/views/storefront/layout/footer/footer.html.twig
@@ -14,15 +14,4 @@
     {% endblock %}
 
     {{ parent() }}
-
-    {% block layout_footer_payment_logos_paypal_funding_eligibility %}
-        {# @var \Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData fundingEligibilityData #}
-        {% set fundingEligibilityData = footer.extensions[constant('Swag\\PayPal\\Storefront\\Data\\FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION')] %}
-
-        {% if fundingEligibilityData %}
-            <div data-swag-paypal-funding-eligibility="true"
-                 data-swag-paypal-funding-eligibility-options="{{ fundingEligibilityData|json_encode }}">
-            </div>
-        {% endif %}
-    {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Resources/views/storefront/layout/footer/footer.html.twig
@@ -14,4 +14,8 @@
     {% endblock %}
 
     {{ parent() }}
+
+    {# @deprecated tag:v11.0.0 - `layout_footer_payment_logos_paypal_funding_eligibility` will be removed, use block `base_body_script` instead #}
+    {% block layout_footer_payment_logos_paypal_funding_eligibility %}
+    {% endblock %}
 {% endblock %}

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 /*
  * (c) shopware AG <info@shopware.com>
  * For the full copyright and license information, please view the LICENSE
@@ -45,6 +43,9 @@ class FundingSubscriber implements EventSubscriberInterface
         ];
     }
 
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed in 11.0.0.
+     */
     public function addFundingAvailabilityDataToFooter(FooterPageletLoadedEvent $event): void
     {
         try {

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -82,10 +82,7 @@ class FundingSubscriber implements EventSubscriberInterface
         $event->getPage()->addExtension(self::FUNDING_ELIGIBILITY_EXTENSION, $data);
     }
 
-    /**
-     * @param CheckoutConfirmPageLoadedEvent|CheckoutRegisterPageLoadedEvent $event
-     */
-    public function removeFundingAvailabilityDataFromPage($event): void
+    public function removeFundingAvailabilityDataFromPage(CheckoutConfirmPageLoadedEvent|CheckoutRegisterPageLoadedEvent $event): void
     {
         $event->getPage()->removeExtension(self::FUNDING_ELIGIBILITY_EXTENSION);
     }

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * (c) shopware AG <info@shopware.com>
  * For the full copyright and license information, please view the LICENSE
@@ -8,6 +10,7 @@
 namespace Swag\PayPal\Storefront\Data;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Page\GenericPageLoadedEvent;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedEvent;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
@@ -37,11 +40,12 @@ class FundingSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FooterPageletLoadedEvent::class => 'addFundingAvailabilityData',
+            FooterPageletLoadedEvent::class => 'addFundingAvailabilityDataToFooter',  // for backward compability
+            GenericPageLoadedEvent::class => 'addFundingAvailabilityDataToPage',
         ];
     }
 
-    public function addFundingAvailabilityData(FooterPageletLoadedEvent $event): void
+    public function addFundingAvailabilityDataToFooter(FooterPageletLoadedEvent $event): void
     {
         try {
             $this->settingsValidationService->validate($event->getSalesChannelContext()->getSalesChannelId());
@@ -55,5 +59,21 @@ class FundingSubscriber implements EventSubscriberInterface
         }
 
         $event->getPagelet()->addExtension(self::FUNDING_ELIGIBILITY_EXTENSION, $data);
+    }
+
+    public function addFundingAvailabilityDataToPage(GenericPageLoadedEvent $event): void
+    {
+        try {
+            $this->settingsValidationService->validate($event->getSalesChannelContext()->getSalesChannelId());
+        } catch (PayPalSettingsInvalidException $e) {
+            return;
+        }
+
+        $data = $this->fundingEligibilityDataService->buildData($event->getSalesChannelContext());
+        if ($data === null) {
+            return;
+        }
+
+        $event->getPage()->addExtension(self::FUNDING_ELIGIBILITY_EXTENSION, $data);
     }
 }

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -87,8 +87,6 @@ class FundingSubscriber implements EventSubscriberInterface
      */
     public function removeFundingAvailabilityDataFromPage($event): void
     {
-        if ($event instanceof CheckoutConfirmPageLoadedEvent || $event instanceof CheckoutRegisterPageLoadedEvent) {
-            $event->getPage()->removeExtension(self::FUNDING_ELIGIBILITY_EXTENSION);
-        }
+        $event->getPage()->removeExtension(self::FUNDING_ELIGIBILITY_EXTENSION);
     }
 }

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -8,6 +8,8 @@
 namespace Swag\PayPal\Storefront\Data;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
+use Shopware\Storefront\Page\Checkout\Register\CheckoutRegisterPageLoadedEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedEvent;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
@@ -40,6 +42,8 @@ class FundingSubscriber implements EventSubscriberInterface
         return [
             FooterPageletLoadedEvent::class => 'addFundingAvailabilityDataToFooter',  // for backward compability
             GenericPageLoadedEvent::class => 'addFundingAvailabilityDataToPage',
+            CheckoutConfirmPageLoadedEvent::class => ['removeFundingAvailabilityDataFromPage', -1],
+            CheckoutRegisterPageLoadedEvent::class => ['removeFundingAvailabilityDataFromPage', -1],
         ];
     }
 
@@ -76,5 +80,15 @@ class FundingSubscriber implements EventSubscriberInterface
         }
 
         $event->getPage()->addExtension(self::FUNDING_ELIGIBILITY_EXTENSION, $data);
+    }
+
+    /**
+     * @param CheckoutConfirmPageLoadedEvent|CheckoutRegisterPageLoadedEvent $event
+     */
+    public function removeFundingAvailabilityDataFromPage($event): void
+    {
+        if ($event instanceof CheckoutConfirmPageLoadedEvent || $event instanceof CheckoutRegisterPageLoadedEvent) {
+            $event->getPage()->removeExtension(self::FUNDING_ELIGIBILITY_EXTENSION);
+        }
     }
 }

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -48,7 +48,7 @@ class FundingSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @deprecated tag:v11.0.0 - Will be removed in 11.0.0.
+     * @deprecated tag:v11.0.0 - Will be removed.
      */
     public function addFundingAvailabilityDataToFooter(FooterPageletLoadedEvent $event): void
     {

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -16,6 +16,10 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
 use Shopware\PayPalSDK\Struct\ConstantsV2;
+use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPage;
+use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
+use Shopware\Storefront\Page\Checkout\Register\CheckoutRegisterPage;
+use Shopware\Storefront\Page\Checkout\Register\CheckoutRegisterPageLoadedEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
 use Shopware\Storefront\Page\Page;
 use Shopware\Storefront\Pagelet\Footer\FooterPagelet;
@@ -50,9 +54,11 @@ class FundingSubscriberTest extends TestCase
     {
         $events = FundingSubscriber::getSubscribedEvents();
 
-        static::assertCount(2, $events);
+        static::assertCount(4, $events);
         static::assertSame('addFundingAvailabilityDataToFooter', $events[FooterPageletLoadedEvent::class]);
         static::assertSame('addFundingAvailabilityDataToPage', $events[GenericPageLoadedEvent::class]);
+        static::assertSame(['removeFundingAvailabilityDataFromPage', -1], $events[CheckoutConfirmPageLoadedEvent::class]);
+        static::assertSame(['removeFundingAvailabilityDataFromPage', -1], $events[CheckoutRegisterPageLoadedEvent::class]);
     }
 
     public function testAddNoSettings(): void
@@ -113,6 +119,64 @@ class FundingSubscriberTest extends TestCase
         static::assertSame(\mb_strtolower(ConstantsV2::INTENT_CAPTURE), $extension->getIntent());
         static::assertSame('/paypal/payment-method-eligibility', $extension->getMethodEligibilityUrl());
         static::assertSame(['SEPA'], $extension->getFilteredPaymentMethods());
+    }
+
+    public function testRemoveFundingAvailabilityDataFromCheckoutConfirmPage(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+        $subscriber = $this->createSubscriber($systemConfigService);
+
+        // Add the extension via GenericPageLoadedEvent
+        $genericEvent = $this->createGenericPageLoadedEvent();
+        $subscriber->addFundingAvailabilityDataToPage($genericEvent);
+        static::assertTrue($genericEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+
+        // Create CheckoutConfirmPage with the extension
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $page = new CheckoutConfirmPage();
+        $page->addExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION, $genericEvent->getPage()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+
+        $confirmEvent = new CheckoutConfirmPageLoadedEvent(
+            $page,
+            $salesChannelContext,
+            new Request()
+        );
+
+        // Remove the extension
+        $subscriber->removeFundingAvailabilityDataFromPage($confirmEvent);
+
+        static::assertFalse($confirmEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+    }
+
+    public function testRemoveFundingAvailabilityDataFromCheckoutRegisterPage(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+        $subscriber = $this->createSubscriber($systemConfigService);
+
+        // First add the extension via GenericPageLoadedEvent
+        $genericEvent = $this->createGenericPageLoadedEvent();
+        $subscriber->addFundingAvailabilityDataToPage($genericEvent);
+        static::assertTrue($genericEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+
+        // Create CheckoutRegisterPage with the extension
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $page = new CheckoutRegisterPage();
+        $page->addExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION, $genericEvent->getPage()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+
+        $registerEvent = new CheckoutRegisterPageLoadedEvent(
+            $page,
+            $salesChannelContext,
+            new Request()
+        );
+
+        // Remove the extension
+        $subscriber->removeFundingAvailabilityDataFromPage($registerEvent);
+
+        static::assertFalse($registerEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
     private function createSubscriber(SystemConfigService $systemConfig): FundingSubscriber

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -55,6 +55,7 @@ class FundingSubscriberTest extends TestCase
         $events = FundingSubscriber::getSubscribedEvents();
 
         static::assertCount(4, $events);
+        // @deprecated tag:v11.0.0 - Remove this line below.
         static::assertSame('addFundingAvailabilityDataToFooter', $events[FooterPageletLoadedEvent::class]);
         static::assertSame('addFundingAvailabilityDataToPage', $events[GenericPageLoadedEvent::class]);
         static::assertSame(['removeFundingAvailabilityDataFromPage', -1], $events[CheckoutConfirmPageLoadedEvent::class]);
@@ -66,11 +67,15 @@ class FundingSubscriberTest extends TestCase
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
         $subscriber = $this->createSubscriber($systemConfigService);
         $event = $this->createFooterPageletLoadedEvent();
+        // @deprecated tag:v11.0.0 - Remove this line below.
         $subscriber->addFundingAvailabilityDataToFooter($event);
 
         static::assertFalse($event->getPagelet()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed.
+     */
     public function testAddFundingAvailabilityDataToFooter(): void
     {
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
 use Shopware\PayPalSDK\Struct\ConstantsV2;
+use Shopware\Storefront\Page\GenericPageLoadedEvent;
+use Shopware\Storefront\Page\Page;
 use Shopware\Storefront\Pagelet\Footer\FooterPagelet;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedEvent;
 use Swag\PayPal\Checkout\Payment\Method\SEPAHandler;
@@ -48,8 +50,9 @@ class FundingSubscriberTest extends TestCase
     {
         $events = FundingSubscriber::getSubscribedEvents();
 
-        static::assertCount(1, $events);
-        static::assertSame('addFundingAvailabilityData', $events[FooterPageletLoadedEvent::class]);
+        static::assertCount(2, $events);
+        static::assertSame('addFundingAvailabilityDataToFooter', $events[FooterPageletLoadedEvent::class]);
+        static::assertSame('addFundingAvailabilityDataToPage', $events[GenericPageLoadedEvent::class]);
     }
 
     public function testAddNoSettings(): void
@@ -57,21 +60,51 @@ class FundingSubscriberTest extends TestCase
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
         $subscriber = $this->createSubscriber($systemConfigService);
         $event = $this->createFooterPageletLoadedEvent();
-        $subscriber->addFundingAvailabilityData($event);
+        $subscriber->addFundingAvailabilityDataToFooter($event);
 
         static::assertFalse($event->getPagelet()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
-    public function testAdd(): void
+    public function testAddFundingAvailabilityDataToFooter(): void
     {
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
         $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
         $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
         $subscriber = $this->createSubscriber($systemConfigService);
         $event = $this->createFooterPageletLoadedEvent();
-        $subscriber->addFundingAvailabilityData($event);
+        $subscriber->addFundingAvailabilityDataToFooter($event);
 
         $extension = $event->getPagelet()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION);
+
+        static::assertInstanceOf(FundingEligibilityData::class, $extension);
+        static::assertSame(self::TEST_CLIENT_ID, $extension->getClientId());
+        static::assertSame('EUR', $extension->getCurrency());
+        static::assertSame('en_GB', $extension->getLanguageIso());
+        static::assertSame(\mb_strtolower(ConstantsV2::INTENT_CAPTURE), $extension->getIntent());
+        static::assertSame('/paypal/payment-method-eligibility', $extension->getMethodEligibilityUrl());
+        static::assertSame(['SEPA'], $extension->getFilteredPaymentMethods());
+    }
+
+    public function testAddFundingAvailabilityDataToPageNoSettings(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $subscriber = $this->createSubscriber($systemConfigService);
+        $event = $this->createGenericPageLoadedEvent();
+        $subscriber->addFundingAvailabilityDataToPage($event);
+
+        static::assertFalse($event->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+    }
+
+    public function testAddFundingAvailabilityDataToPage(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+        $subscriber = $this->createSubscriber($systemConfigService);
+        $event = $this->createGenericPageLoadedEvent();
+        $subscriber->addFundingAvailabilityDataToPage($event);
+
+        $extension = $event->getPage()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION);
 
         static::assertInstanceOf(FundingEligibilityData::class, $extension);
         static::assertSame(self::TEST_CLIENT_ID, $extension->getClientId());
@@ -118,6 +151,20 @@ class FundingSubscriberTest extends TestCase
 
         return new FooterPageletLoadedEvent(
             new FooterPagelet(null, new CategoryCollection(), new PaymentMethodCollection(), new ShippingMethodCollection()),
+            $salesChannelContext,
+            new Request()
+        );
+    }
+
+    private function createGenericPageLoadedEvent(): GenericPageLoadedEvent
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $salesChannelContext->getCurrency()->setIsoCode('EUR');
+
+        $page = new Page();
+
+        return new GenericPageLoadedEvent(
+            $page,
             $salesChannelContext,
             new Request()
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- The `layout_footer_payment_logos` block is commonly overridden by themes
- ESI caching of the footer caused stale funding eligibility data
- The new location ensures fresh data on every page load and reduces theme conflict risks

### 2. What does this change do, exactly?
- The funding eligibility script is now rendered in the `base_body_script` block instead of `layout_footer_payment_logos`
- The script now receives data via `GenericPageLoadedEvent` ensuring it's not affected by ESI caching
- Backward compatibility is maintained - the data is still available in the footer context for legacy integrations

### 3. Describe each step to reproduce the issue or behaviour.
<img width="755" height="404" alt="image" src="https://github.com/user-attachments/assets/e7f5c6cf-e6d3-415d-b430-63f2f6cdb746" />
The `paypal-funding-eligibility` element is moved out of footer, with options included.

### 4. Please link to the relevant issues (if any).
- Closes #377 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
