### PR TITLE
feat: Add swag_paypal_order_id to order transaction

### DIFF
--- a/src/Checkout/Payment/MessageQueue/TransactionStatusSyncMessageHandler.php
+++ b/src/Checkout/Payment/MessageQueue/TransactionStatusSyncMessageHandler.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\StateMachineException;
 use Shopware\PayPalSDK\Struct\ConstantsV2;
+use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -39,6 +40,7 @@ class TransactionStatusSyncMessageHandler
         private readonly EntityRepository $orderTransactionRepository,
         private readonly OrderTransactionStateHandler $orderTransactionStateHandler,
         private readonly OrderResource $orderResource,
+        private readonly TransactionDataService $transactionDataService,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -74,6 +76,9 @@ class TransactionStatusSyncMessageHandler
             }
 
             $order = $this->orderResource->get($message->getPayPalOrderId(), $message->getSalesChannelId());
+
+            // Set the resource ID for the transaction
+            $this->transactionDataService->setResourceId($order, $message->getTransactionId(), $context);
 
             if ($order->getIntent() === ConstantsV2::INTENT_CAPTURE) {
                 match ($order->getPurchaseUnits()->first()?->getPayments()?->getCaptures()?->first()?->getStatus()) {

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -172,6 +172,7 @@
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Swag\PayPal\RestApi\V2\Resource\OrderResource"/>
+            <argument type="service" id="Swag\PayPal\Checkout\Payment\Service\TransactionDataService"/>
             <argument type="service" id="monolog.logger.paypal"/>
             <tag name="messenger.message_handler" />
         </service>

--- a/src/Resources/config/services/webhook.xml
+++ b/src/Resources/config/services/webhook.xml
@@ -39,6 +39,8 @@
             <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtilV2"/>
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
             <argument type="service" id="Swag\PayPal\Checkout\PUI\Service\PUIInstructionsFetchService"/>
+            <argument type="service" id="Swag\PayPal\Checkout\Payment\Service\TransactionDataService"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V2\Resource\OrderResource"/>
             <tag name="swag.paypal.webhook.handler"/>
         </service>
 

--- a/src/Webhook/Handler/CaptureCompleted.php
+++ b/src/Webhook/Handler/CaptureCompleted.php
@@ -13,12 +13,15 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Capture;
+use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\Checkout\PUI\Service\PUIInstructionsFetchService;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Swag\PayPal\Util\Lifecycle\Method\PUIMethodData;
 use Swag\PayPal\Util\PaymentStatusUtilV2;
 use Swag\PayPal\Webhook\Exception\WebhookException;
 use Swag\PayPal\Webhook\WebhookEventTypes;
+use Swag\PayPal\SwagPayPal;
 
 #[Package('checkout')]
 class CaptureCompleted extends AbstractWebhookHandler
@@ -32,6 +35,8 @@ class CaptureCompleted extends AbstractWebhookHandler
         private readonly PaymentStatusUtilV2 $paymentStatusUtil,
         private readonly PaymentMethodDataRegistry $methodDataRegistry,
         private readonly PUIInstructionsFetchService $instructionsFetchService,
+        private readonly TransactionDataService $transactionDataService,
+        private readonly OrderResource $orderResource,
     ) {
         parent::__construct($orderTransactionRepository, $orderTransactionStateHandler);
     }
@@ -63,5 +68,14 @@ class CaptureCompleted extends AbstractWebhookHandler
         }
 
         $this->paymentStatusUtil->applyCaptureState($orderTransaction->getId(), $capture, $context);
+
+        // Fetch the PayPal order and set the resource ID
+        $paypalOrderId = $orderTransaction->getCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_ORDER_ID);
+        if ($paypalOrderId && \is_string($paypalOrderId)) {
+            $salesChannelId = (string) $orderTransaction->getOrder()?->getSalesChannelId();
+            $paypalOrder = $this->orderResource->get($paypalOrderId, $salesChannelId);
+
+            $this->transactionDataService->setResourceId($paypalOrder, $orderTransaction->getId(), $context);
+        }
     }
 }

--- a/src/Webhook/Handler/CaptureCompleted.php
+++ b/src/Webhook/Handler/CaptureCompleted.php
@@ -16,12 +16,12 @@ use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Capture;
 use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\Checkout\PUI\Service\PUIInstructionsFetchService;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
+use Swag\PayPal\SwagPayPal;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Swag\PayPal\Util\Lifecycle\Method\PUIMethodData;
 use Swag\PayPal\Util\PaymentStatusUtilV2;
 use Swag\PayPal\Webhook\Exception\WebhookException;
 use Swag\PayPal\Webhook\WebhookEventTypes;
-use Swag\PayPal\SwagPayPal;
 
 #[Package('checkout')]
 class CaptureCompleted extends AbstractWebhookHandler

--- a/tests/Checkout/Payment/MessageQueue/TransactionStatusSyncMessageHandlerTest.php
+++ b/tests/Checkout/Payment/MessageQueue/TransactionStatusSyncMessageHandlerTest.php
@@ -27,6 +27,7 @@ use Shopware\PayPalSDK\Struct\ConstantsV2;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Swag\PayPal\Checkout\Payment\MessageQueue\TransactionStatusSyncMessage;
 use Swag\PayPal\Checkout\Payment\MessageQueue\TransactionStatusSyncMessageHandler;
+use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 
@@ -43,6 +44,8 @@ class TransactionStatusSyncMessageHandlerTest extends TestCase
 
     private OrderResource&MockObject $orderResource;
 
+    private TransactionDataService&MockObject $transactionDataService;
+
     private LoggerInterface&MockObject $logger;
 
     private TransactionStatusSyncMessageHandler $handler;
@@ -52,12 +55,14 @@ class TransactionStatusSyncMessageHandlerTest extends TestCase
         $this->orderTransactionRepository = $this->createMock(EntityRepository::class);
         $this->orderTransactionStateHandler = $this->createMock(OrderTransactionStateHandler::class);
         $this->orderResource = $this->createMock(OrderResource::class);
+        $this->transactionDataService = $this->createMock(TransactionDataService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->handler = new TransactionStatusSyncMessageHandler(
             $this->orderTransactionRepository,
             $this->orderTransactionStateHandler,
             $this->orderResource,
+            $this->transactionDataService,
             $this->logger,
         );
     }
@@ -92,6 +97,11 @@ class TransactionStatusSyncMessageHandlerTest extends TestCase
             ->method('get')
             ->with('paypal-order-id', 'sales-channel-id')
             ->willReturn($payPalOrder);
+
+        $this->transactionDataService
+            ->expects($this->once())
+            ->method('setResourceId')
+            ->with($payPalOrder, 'transaction-id');
 
         $this->orderTransactionStateHandler
             ->expects($stateHandlerMethod ? $this->once() : $this->never())
@@ -156,6 +166,11 @@ class TransactionStatusSyncMessageHandlerTest extends TestCase
             ->method('get')
             ->with('paypal-order-id', 'sales-channel-id')
             ->willReturn($payPalOrder);
+
+        $this->transactionDataService
+            ->expects($this->once())
+            ->method('setResourceId')
+            ->with($payPalOrder, 'transaction-id');
 
         $exception = StateMachineException::illegalStateTransition(
             'invalid-state',
@@ -338,6 +353,11 @@ class TransactionStatusSyncMessageHandlerTest extends TestCase
             ->method('get')
             ->with('paypal-order-id', 'sales-channel-id')
             ->willReturn($payPalOrder);
+
+        $this->transactionDataService
+            ->expects($this->once())
+            ->method('setResourceId')
+            ->with($payPalOrder, 'transaction-id');
 
         $this->orderTransactionStateHandler
             ->expects($this->never())

--- a/tests/Webhook/Handler/CaptureCompletedTest.php
+++ b/tests/Webhook/Handler/CaptureCompletedTest.php
@@ -15,7 +15,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
+use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\Checkout\PUI\Service\PUIInstructionsFetchService;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\Util\Lifecycle\Method\AbstractMethodData;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Swag\PayPal\Util\Lifecycle\Method\PUIMethodData;
@@ -103,6 +105,8 @@ class CaptureCompletedTest extends AbstractWebhookHandlerTestCase
                 $paymentStatusUtil,
                 $methodDataRegistry,
                 $instructionsFetchService,
+                $this->createMock(TransactionDataService::class),
+                $this->createMock(OrderResource::class),
             ])
             ->onlyMethods(['getOrderTransactionV2'])
             ->getMock();
@@ -125,7 +129,9 @@ class CaptureCompletedTest extends AbstractWebhookHandlerTestCase
             new OrderTransactionStateHandler($this->stateMachineRegistry),
             $this->getContainer()->get(PaymentStatusUtilV2::class),
             $this->getContainer()->get(PaymentMethodDataRegistry::class),
-            $this->getContainer()->get(PUIInstructionsFetchService::class)
+            $this->getContainer()->get(PUIInstructionsFetchService::class),
+            $this->getContainer()->get(TransactionDataService::class),
+            $this->getContainer()->get(OrderResource::class)
         );
     }
 }

--- a/tests/Webhook/Handler/CaptureCompletedTest.php
+++ b/tests/Webhook/Handler/CaptureCompletedTest.php
@@ -124,14 +124,20 @@ class CaptureCompletedTest extends AbstractWebhookHandlerTestCase
 
     protected function createWebhookHandler()
     {
+        // Mock OrderResource to avoid actual API calls
+        $orderResource = $this->createMock(OrderResource::class);
+
+        // Mock TransactionDataService
+        $transactionDataService = $this->createMock(TransactionDataService::class);
+
         return new CaptureCompleted(
             $this->orderTransactionRepository,
             new OrderTransactionStateHandler($this->stateMachineRegistry),
             $this->getContainer()->get(PaymentStatusUtilV2::class),
             $this->getContainer()->get(PaymentMethodDataRegistry::class),
             $this->getContainer()->get(PUIInstructionsFetchService::class),
-            $this->getContainer()->get(TransactionDataService::class),
-            $this->getContainer()->get(OrderResource::class)
+            $transactionDataService,
+            $orderResource
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, the mentioned id is only set in the `TransactionDataService` during the immediate payment process (handler) and during PUI data fetching. This should also happen on certain Webhooks and the `TransactionStatusSyncMessageHandler`.


### 2. What does this change do, exactly?
- To save the resource ID:
  - Webhook Handler (`CaptureCompleted.php lines 72-79`)
    - When PayPal sends a "payment completed" webhook
    - Fetches the PayPal order and saves the capture/authorization ID
  - Background Sync Job (`TransactionStatusSyncMessageHandler.php lines 80-81`)
    - When checking payment status asynchronously
    - Saves the resource ID while syncing status

### 3. Describe each step to reproduce the issue or behaviour.
- See https://github.com/shopware/shopware/issues/10604
- Tested fix in local
<img width="523" height="372" alt="image" src="https://github.com/user-attachments/assets/62db9aa8-4e9a-4144-8eed-8d10c8625d59" />


### 4. Please link to the relevant issues (if any).
- Closes https://github.com/shopware/shopware/issues/10604


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
