### PR TITLE
fix: smart payment buttons width by digital products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Adjusted the amount that Pay Later is available for to the current limitations given (https://developer.paypal.com/studio/checkout/pay-later/de)
 - Fixes an issue, where Paypal Express Checkout does not recalculate cart price after changing shipping country (shopware/SwagPayPal#342)
+- Fixes an issue, where the Smart Payment Buttons were not stretched to full width on the product detail page for digital products
 
 # 10.1.2
 - Fixes an issue, where the plugin could not be updated when Zettle Sales Channels were active (shopware/SwagPayPal#361)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Passt den Betrag an, für den Pay Later zur Verfügung steht, an die aktuellen Beschränkungen an (https://developer.paypal.com/studio/checkout/pay-later/de)
 - Behebt ein Problem, bei dem der Warenkorbpreis beim Verändern des Versandlandes im Express Checkout nicht angepasst wurde (shopware/SwagPayPal#342)
+- Behebt ein Problem, bei dem die Smart Payment Buttons auf der Produktdetailseite für digitale Produkte nicht über die volle Breite dargestellt wurden
 
 # 10.1.2
 - Behebt ein Problem, bei dem das Plugin bei aktiven Zettle Verkaufskanälen nicht aktualisiert werden konnte (shopware/SwagPayPal#361)

--- a/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -24,7 +24,9 @@
 
                 {% if (isProductDetail and expressSettings.productDetailEnabled) or (not isProductDetail and expressSettings.listingEnabled) %}
                     <div class="row g-2 mt-0 justify-content-end">
-                        {% sw_include '@SwagPayPal/storefront/component/ecs-spb-checkout/ecs-button.html.twig' with {button_class: 'col-8'} %}
+                        {% sw_include '@SwagPayPal/storefront/component/ecs-spb-checkout/ecs-button.html.twig' with {
+                            button_class: showQuantitySelect ? 'col-8' : 'col-12'
+                        } %}
                     </div>
                 {% endif %}
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

The Smart Payment Button does not use the full width when the quantity selector is not available, such as with digital products.

<img width="905" height="652" alt="image" src="https://github.com/user-attachments/assets/833b01ff-3e4d-45c4-8ba6-43e6570ee060" />


### 2. What does this change do, exactly?

Adjust the col width

<img width="759" height="528" alt="image" src="https://github.com/user-attachments/assets/5ca31ba6-2e6d-44fe-a3c4-5a6536384990" />
