### PR TITLE
[6.5.x] fix: smart payment buttons width by digital products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where the Smart Payment Buttons were not stretched to full width on the product detail page for digital products
+
 # 8.7.9
 - Fixes an issue, where the plugin could not be updated when Zettle Sales Channels were active (shopware/SwagPayPal#361)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem die Smart Payment Buttons auf der Produktdetailseite für digitale Produkte nicht über die volle Breite dargestellt wurden
+
 # 8.7.9
 - Fixes an issue, where the plugin could not be updated when Zettle Sales Channels were active (shopware/SwagPayPal#361)
 

--- a/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -12,7 +12,9 @@
 
             {% if expressSettings.productDetailEnabled %}
                 <div class="{{ isBootstrap5 ? 'row g-2 mt-0' : 'form-row mt-3' }} justify-content-end">
-                    {% sw_include '@SwagPayPal/storefront/component/ecs-spb-checkout/ecs-button.html.twig' with {button_class: 'col-8'} %}
+                    {% sw_include '@SwagPayPal/storefront/component/ecs-spb-checkout/ecs-button.html.twig' with {
+                        button_class: showQuantitySelect ? 'col-8' : 'col-12'
+                    } %}
                 </div>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Backport #411 