### PR TITLE
Fix User Deprecated tagged_iterator: Since symfony/dependency-injection 7.2

### DIFF
--- a/src/Resources/config/services/pos/webhook.xml
+++ b/src/Resources/config/services/pos/webhook.xml
@@ -26,7 +26,7 @@
 
         <!-- handler registry -->
         <service id="Swag\PayPal\Pos\Webhook\WebhookRegistry">
-            <argument type="tagged" tag="swag.paypal.pos.webhook.handler"/>
+            <argument type="tagged_iterator" tag="swag.paypal.pos.webhook.handler"/>
         </service>
 
         <!-- handler -->

--- a/src/Resources/config/services/webhook.xml
+++ b/src/Resources/config/services/webhook.xml
@@ -23,7 +23,7 @@
 
         <!-- handler registry -->
         <service id="Swag\PayPal\Webhook\WebhookRegistry">
-            <argument type="tagged" tag="swag.paypal.webhook.handler"/>
+            <argument type="tagged_iterator" tag="swag.paypal.webhook.handler"/>
         </service>
 
         <!-- handler -->


### PR DESCRIPTION
### 1. Why is this change necessary?

User Deprecated: Since symfony/dependency-injection 7.2: Type "tagged" is deprecated for tag <argument>, use "tagged_iterator" instead in "vendor/store.shopware.com/swagpaypal/src/Resources/config/services/pos/webhook.xml

Is in my logs

### 2. What does this change do, exactly?

Change `tagged` to `tagged_iterator`

### 3. Describe each step to reproduce the issue or behaviour.

Use this plugin with updated Symfony version and have expressive logs

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
