### PR TITLE
fix: Webhook registration with invalid Webhook ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Adjusted the amount that Pay Later is available for to the current limitations given (https://developer.paypal.com/studio/checkout/pay-later/de)
 - Fixes an issue, where Paypal Express Checkout does not recalculate cart price after changing shipping country (shopware/SwagPayPal#342)
 - Fixes an issue, where the Smart Payment Buttons were not stretched to full width on the product detail page for digital products
+- Fixes an issue, where the webhook registration could run into a loop, if the saved Webhook ID is invalid
 
 # 10.1.2
 - Fixes an issue, where the plugin could not be updated when Zettle Sales Channels were active (shopware/SwagPayPal#361)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,6 +2,7 @@
 - Passt den Betrag an, für den Pay Later zur Verfügung steht, an die aktuellen Beschränkungen an (https://developer.paypal.com/studio/checkout/pay-later/de)
 - Behebt ein Problem, bei dem der Warenkorbpreis beim Verändern des Versandlandes im Express Checkout nicht angepasst wurde (shopware/SwagPayPal#342)
 - Behebt ein Problem, bei dem die Smart Payment Buttons auf der Produktdetailseite für digitale Produkte nicht über die volle Breite dargestellt wurden
+- Behebt ein Problem, bei dem die Registrierung des Webhooks in eine Endlosschleife geraten kann, wenn die gespeicherte Webhook ID ungültig ist
 
 # 10.1.2
 - Behebt ein Problem, bei dem das Plugin bei aktiven Zettle Verkaufskanälen nicht aktualisiert werden konnte (shopware/SwagPayPal#361)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "shopware/core": "~6.7.0@dev",
-        "shopware/paypal-sdk": "^1.4.0"
+        "shopware/paypal-sdk": "^1.5.1"
     },
     "extra": {
         "shopware-plugin-class": "Swag\\PayPal\\SwagPayPal",

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -4672,6 +4672,20 @@
                 },
                 "type": "object"
             },
+            "paypal_v1_webhook_list": {
+                "required": [
+                    "webhooks"
+                ],
+                "properties": {
+                    "webhooks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_webhook"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_common_address": {
                 "required": [
                     "address_line_1",
@@ -6034,7 +6048,8 @@
                     "items",
                     "shipping",
                     "payments",
-                    "supplementary_data"
+                    "supplementary_data",
+                    "shipping_options"
                 ],
                 "properties": {
                     "reference_id": {
@@ -6077,6 +6092,13 @@
                     },
                     "supplementary_data": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                        },
+                        "nullable": true
                     }
                 },
                 "type": "object"
@@ -6648,6 +6670,37 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_purchase_unit_shipping_option": {
+                "required": [
+                    "id",
+                    "label",
+                    "amount",
+                    "type",
+                    "selected"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "SHIPPING",
+                            "PICKUP"
+                        ]
+                    },
+                    "selected": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_purchase_unit_supplementary_data": {
                 "required": [
                     "card",
@@ -6849,6 +6902,32 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_shipping_callback": {
+                "required": [
+                    "id",
+                    "shipping_address",
+                    "shipping_option",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "shipping_option": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                    },
+                    "purchase_units": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
                         }
                     }
                 },

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -3375,6 +3375,20 @@
                 },
                 "type": "object"
             },
+            "paypal_v1_webhook_list": {
+                "required": [
+                    "webhooks"
+                ],
+                "properties": {
+                    "webhooks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_webhook"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_common_address": {
                 "required": [
                     "address_line_1",
@@ -4737,7 +4751,8 @@
                     "items",
                     "shipping",
                     "payments",
-                    "supplementary_data"
+                    "supplementary_data",
+                    "shipping_options"
                 ],
                 "properties": {
                     "reference_id": {
@@ -4780,6 +4795,13 @@
                     },
                     "supplementary_data": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                        },
+                        "nullable": true
                     }
                 },
                 "type": "object"
@@ -5351,6 +5373,37 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_purchase_unit_shipping_option": {
+                "required": [
+                    "id",
+                    "label",
+                    "amount",
+                    "type",
+                    "selected"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "SHIPPING",
+                            "PICKUP"
+                        ]
+                    },
+                    "selected": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_purchase_unit_supplementary_data": {
                 "required": [
                     "card",
@@ -5552,6 +5605,32 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_shipping_callback": {
+                "required": [
+                    "id",
+                    "shipping_address",
+                    "shipping_option",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "shipping_option": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                    },
+                    "purchase_units": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
                         }
                     }
                 },

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/components/swag-paypal-settings-webhook/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/components/swag-paypal-settings-webhook/index.ts
@@ -111,6 +111,7 @@ export default Shopware.Component.wrapComponentConfig({
 
             this.status = 'none';
 
+            delete this.allWebhookStatus[String(this.settingsStore.salesChannel)];
             this.fetchWebhookStatus(this.settingsStore.salesChannel);
         },
     },

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -1340,6 +1340,9 @@ export interface components {
             state: string;
             merchant_id: string | null;
         };
+        paypal_v1_webhook_list: {
+            webhooks: components["schemas"]["paypal_v1_webhook"][];
+        };
         paypal_v2_common_address: {
             /** @description The first line of the address. For example, number or street. For example, 173 Drury Lane.
              *     Required for data entry and compliance and risk checks. Must contain the full address. */
@@ -1660,6 +1663,7 @@ export interface components {
             shipping: components["schemas"]["paypal_v2_order_purchase_unit_shipping"];
             payments: components["schemas"]["paypal_v2_order_purchase_unit_payments"] | null;
             supplementary_data: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data"];
+            shipping_options: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"][] | null;
         };
         paypal_v2_order_purchase_unit_amount: components["schemas"]["paypal_v2_common_money"] & {
             breakdown: components["schemas"]["paypal_v2_order_purchase_unit_amount_breakdown"] | null;
@@ -1781,6 +1785,14 @@ export interface components {
             url: string | null;
             image_url: string | null;
         };
+        paypal_v2_order_purchase_unit_shipping_option: {
+            id: string;
+            label: string;
+            amount: components["schemas"]["paypal_v2_common_money"];
+            /** @enum {string} */
+            type: "SHIPPING" | "PICKUP";
+            selected: boolean;
+        };
         paypal_v2_order_purchase_unit_supplementary_data: {
             card: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card"];
             risk: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_risk"];
@@ -1829,6 +1841,12 @@ export interface components {
             /** @default false */
             notify_payer: boolean;
             items: components["schemas"]["paypal_v2_order_purchase_unit_shipping_tracker_item"][];
+        };
+        paypal_v2_order_shipping_callback: {
+            id: string;
+            shipping_address: components["schemas"]["paypal_v2_common_address"];
+            shipping_option: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"];
+            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
         };
         paypal_v2_patch: {
             op: string;

--- a/src/RestApi/V1/Resource/WebhookResource.php
+++ b/src/RestApi/V1/Resource/WebhookResource.php
@@ -12,6 +12,7 @@ use Shopware\PayPalSDK\Gateway\WebhookGateway;
 use Shopware\PayPalSDK\Struct\V1\Patch;
 use Shopware\PayPalSDK\Struct\V1\PatchCollection;
 use Shopware\PayPalSDK\Struct\V1\Webhook;
+use Shopware\PayPalSDK\Struct\V1\Webhook\WebhookCollection;
 use Swag\PayPal\RestApi\ApiContextFactoryInterface;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\Webhook\Exception\WebhookAlreadyExistsException;
@@ -74,6 +75,13 @@ class WebhookResource
 
             throw $e;
         }
+    }
+
+    public function getAllWebhooks(?string $salesChannelId): WebhookCollection
+    {
+        $context = $this->apiContextFactory->getApiContext($salesChannelId);
+
+        return $this->webhookGateway->getWebhookList($context)->getWebhooks();
     }
 
     /**

--- a/src/Webhook/Registration/WebhookSystemConfigHelper.php
+++ b/src/Webhook/Registration/WebhookSystemConfigHelper.php
@@ -23,7 +23,6 @@ class WebhookSystemConfigHelper
         Settings::CLIENT_ID_SANDBOX,
         Settings::CLIENT_SECRET_SANDBOX,
         Settings::SANDBOX,
-        Settings::WEBHOOK_ID,
     ];
 
     private LoggerInterface $logger;

--- a/src/Webhook/WebhookService.php
+++ b/src/Webhook/WebhookService.php
@@ -72,13 +72,7 @@ class WebhookService implements WebhookServiceInterface
         }
 
         $webhookExecuteToken = $this->systemConfigService->getString(Settings::WEBHOOK_EXECUTE_TOKEN, $salesChannelId);
-
-        $this->router->getContext()->setScheme('https');
-        $webhookUrl = $this->router->generate(
-            'api.action.paypal.webhook.execute',
-            [self::PAYPAL_WEBHOOK_TOKEN_NAME => $webhookExecuteToken],
-            UrlGeneratorInterface::ABSOLUTE_URL
-        );
+        $webhookUrl = $this->createWebhookUrl($webhookExecuteToken);
 
         return $registeredWebhookUrl === $webhookUrl ? self::STATUS_WEBHOOK_VALID : self::STATUS_WEBHOOK_INVALID;
     }
@@ -96,13 +90,7 @@ class WebhookService implements WebhookServiceInterface
             $webhookExecuteToken = Random::getAlphanumericString(self::PAYPAL_WEBHOOK_TOKEN_LENGTH);
         }
 
-        $this->router->getContext()->setScheme('https');
-        $webhookUrl = $this->router->generate(
-            'api.action.paypal.webhook.execute',
-            [self::PAYPAL_WEBHOOK_TOKEN_NAME => $webhookExecuteToken],
-            UrlGeneratorInterface::ABSOLUTE_URL
-        );
-
+        $webhookUrl = $this->createWebhookUrl($webhookExecuteToken);
         $webhookId = $this->systemConfigService->getString(Settings::WEBHOOK_ID, $salesChannelId);
 
         if ($salesChannelId !== null && $webhookId === $this->systemConfigService->getString(Settings::WEBHOOK_ID)) {
@@ -118,7 +106,7 @@ class WebhookService implements WebhookServiceInterface
             if ($registeredWebhookUrl === $webhookUrl) {
                 return self::NO_WEBHOOK_ACTION_REQUIRED;
             }
-        } catch (WebhookIdInvalidException $e) {
+        } catch (WebhookIdInvalidException) {
             // do nothing, so the following code will be executed
         }
 
@@ -126,7 +114,7 @@ class WebhookService implements WebhookServiceInterface
             $this->webhookResource->updateWebhook($webhookUrl, $webhookId, $salesChannelId);
 
             return self::WEBHOOK_UPDATED;
-        } catch (WebhookIdInvalidException $e) {
+        } catch (WebhookIdInvalidException) {
             return $this->createWebhook($salesChannelId, $webhookUrl, $webhookExecuteToken);
         }
     }
@@ -153,7 +141,7 @@ class WebhookService implements WebhookServiceInterface
         try {
             $this->webhookResource->deleteWebhook($webhookId, $salesChannelId);
             $deleted = true;
-        } catch (WebhookIdInvalidException $e) {
+        } catch (WebhookIdInvalidException) {
             $deleted = false;
         }
 
@@ -190,5 +178,16 @@ class WebhookService implements WebhookServiceInterface
         } catch (WebhookAlreadyExistsException $e) {
             return self::NO_WEBHOOK_ACTION_REQUIRED;
         }
+    }
+
+    private function createWebhookUrl(string $executeToken): string
+    {
+        $this->router->getContext()->setScheme('https');
+
+        return $this->router->generate(
+            'api.action.paypal.webhook.execute',
+            [self::PAYPAL_WEBHOOK_TOKEN_NAME => $executeToken],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
     }
 }

--- a/src/Webhook/WebhookService.php
+++ b/src/Webhook/WebhookService.php
@@ -175,7 +175,17 @@ class WebhookService implements WebhookServiceInterface
             $this->systemConfigService->set(Settings::WEBHOOK_ID, $webhookId, $salesChannelId);
 
             return self::WEBHOOK_CREATED;
-        } catch (WebhookAlreadyExistsException $e) {
+        } catch (WebhookAlreadyExistsException) {
+            $webhooks = $this->webhookResource->getAllWebhooks($salesChannelId);
+
+            foreach ($webhooks as $webhook) {
+                if ($webhook->getUrl() === $webhookUrl) {
+                    $this->systemConfigService->set(Settings::WEBHOOK_ID, $webhook->getId(), $salesChannelId);
+
+                    break;
+                }
+            }
+
             return self::NO_WEBHOOK_ACTION_REQUIRED;
         }
     }

--- a/tests/TestBootstrap.php
+++ b/tests/TestBootstrap.php
@@ -7,12 +7,14 @@
 
 use Shopware\Core\TestBootstrapper;
 
+$projectDir = $_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4);
+
 return (new TestBootstrapper())
-    ->setProjectDir($_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4))
+    ->setProjectDir($projectDir)
     ->setLoadEnvFile(true)
     ->setForceInstallPlugins(true)
     ->addActivePlugins('SwagCmsExtensions')
     ->addCallingPlugin()
     ->bootstrap()
-    ->setClassLoader(require dirname(__DIR__) . '/vendor/autoload.php')
+    ->setClassLoader(require $projectDir . '/vendor/autoload.php')
     ->getClassLoader();

--- a/tests/Webhook/Registration/WebhookSystemConfigHelperTest.php
+++ b/tests/Webhook/Registration/WebhookSystemConfigHelperTest.php
@@ -31,7 +31,6 @@ class WebhookSystemConfigHelperTest extends TestCase
         Settings::CLIENT_ID_SANDBOX,
         Settings::CLIENT_SECRET_SANDBOX,
         Settings::SANDBOX,
-        Settings::WEBHOOK_ID,
     ];
 
     private WebhookSystemConfigHelper $helper;

--- a/tests/Webhook/WebhookServiceTest.php
+++ b/tests/Webhook/WebhookServiceTest.php
@@ -12,17 +12,16 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\TestDefaults;
+use Shopware\PayPalSDK\Struct\V1\Webhook;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
+use Shopware\PayPalSDK\Struct\V1\Webhook\WebhookCollection;
 use Swag\PayPal\RestApi\V1\Resource\WebhookResource;
 use Swag\PayPal\Setting\Settings;
-use Swag\PayPal\Test\Helper\ServicesTrait;
-use Swag\PayPal\Test\Mock\PayPalSDK\ApiContextFactoryMock;
-use Swag\PayPal\Test\Mock\PayPalSDK\GatewayTestBehaviour;
-use Swag\PayPal\Test\Mock\PayPalSDK\MockRequestHandler;
 use Swag\PayPal\Test\Mock\Repositories\OrderTransactionRepoMock;
 use Swag\PayPal\Test\Mock\Setting\Service\SystemConfigServiceMock;
 use Swag\PayPal\Test\Mock\Webhook\Handler\DummyWebhook;
-use Swag\PayPal\Test\RestApi\V1\Resource\WebhookResourceTest;
+use Swag\PayPal\Webhook\Exception\WebhookAlreadyExistsException;
+use Swag\PayPal\Webhook\Exception\WebhookIdInvalidException;
 use Swag\PayPal\Webhook\WebhookRegistry;
 use Swag\PayPal\Webhook\WebhookService;
 use Symfony\Component\Routing\RouterInterface;
@@ -33,15 +32,13 @@ use Symfony\Component\Routing\RouterInterface;
 #[Package('checkout')]
 class WebhookServiceTest extends TestCase
 {
-    use GatewayTestBehaviour;
-    use ServicesTrait;
-
     public const THROW_WEBHOOK_ID_INVALID = 'webhookIdInvalid';
-
-    public const THROW_WEBHOOK_ALREADY_EXISTS = 'webhookAlreadyExists';
 
     public const ALREADY_EXISTING_WEBHOOK_ID = 'alreadyExistingTestWebhookId';
     public const ALREADY_EXISTING_WEBHOOK_EXECUTE_TOKEN = 'testWebhookExecuteToken';
+
+    private const WEBHOOK_URL = 'testWebhookUrl';
+    private const WEBHOOK_ID = 'testWebhookId';
 
     private OrderTransactionRepoMock $orderTransactionRepo;
 
@@ -49,16 +46,24 @@ class WebhookServiceTest extends TestCase
 
     private RouterInterface&MockObject $router;
 
+    /**
+     * @var WebhookResource&MockObject
+     */
+    private WebhookResource $webhookResource;
+
     private WebhookService $webhookService;
 
     protected function setUp(): void
     {
         $this->orderTransactionRepo = new OrderTransactionRepoMock();
         $this->systemConfig = SystemConfigServiceMock::createWithCredentials();
+
         $this->router = $this->createMock(RouterInterface::class);
 
+        $this->webhookResource = $this->createMock(WebhookResource::class);
+
         $this->webhookService = new WebhookService(
-            new WebhookResource(self::webhookGateway(), new ApiContextFactoryMock()),
+            $this->webhookResource,
             new WebhookRegistry([new DummyWebhook($this->orderTransactionRepo)]),
             $this->systemConfig,
             $this->router,
@@ -74,7 +79,14 @@ class WebhookServiceTest extends TestCase
 
     public function testStatusWebhookWithoutRegisteredWebhook(): void
     {
-        $this->systemConfig->set(Settings::WEBHOOK_ID, WebhookResourceTest::THROW_EXCEPTION_INVALID_ID);
+        $this->systemConfig->set(Settings::WEBHOOK_ID, self::THROW_WEBHOOK_ID_INVALID);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getWebhookUrl')
+            ->with(self::THROW_WEBHOOK_ID_INVALID, null)
+            ->willThrowException(new WebhookIdInvalidException(self::THROW_WEBHOOK_ID_INVALID));
+
         $result = $this->webhookService->getStatus(null);
 
         static::assertSame(WebhookService::STATUS_WEBHOOK_MISSING, $result);
@@ -85,11 +97,19 @@ class WebhookServiceTest extends TestCase
         $this->systemConfig->set(Settings::WEBHOOK_ID, 'someId');
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, 'someToken');
 
+        $localUrl = 'https://unit.test/webhook?' . WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME . '=someToken';
+
         $this->router
             ->expects($this->once())
             ->method('generate')
             ->with('api.action.paypal.webhook.execute', [WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME => 'someToken'], RouterInterface::ABSOLUTE_URL)
-            ->willReturn(MockRequestHandler::GET_WEBHOOK_URL);
+            ->willReturn($localUrl);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getWebhookUrl')
+            ->with('someId', null)
+            ->willReturn($localUrl);
 
         $result = $this->webhookService->getStatus(null);
 
@@ -101,11 +121,20 @@ class WebhookServiceTest extends TestCase
         $this->systemConfig->set(Settings::WEBHOOK_ID, 'someId');
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, 'someToken');
 
+        $localUrl = 'https://unit.test/webhook?' . WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME . '=someToken';
+        $remoteUrlWithDifferentToken = 'https://unit.test/webhook?' . WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME . '=differentToken';
+
         $this->router
             ->expects($this->once())
             ->method('generate')
             ->with('api.action.paypal.webhook.execute', [WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME => 'someToken'], RouterInterface::ABSOLUTE_URL)
-            ->willReturn(MockRequestHandler::GET_WEBHOOK_URL . 'Invalid');
+            ->willReturn($localUrl);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getWebhookUrl')
+            ->with('someId', null)
+            ->willReturn($remoteUrlWithDifferentToken);
 
         $result = $this->webhookService->getStatus(null);
 
@@ -118,10 +147,17 @@ class WebhookServiceTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with('api.action.paypal.webhook.execute', [WebhookService::PAYPAL_WEBHOOK_TOKEN_NAME => 'someToken'], RouterInterface::ABSOLUTE_URL)
-            ->willReturn(MockRequestHandler::GET_WEBHOOK_URL);
+            ->willReturn(self::WEBHOOK_URL);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getWebhookUrl')
+            ->with('someId', null)
+            ->willReturn(self::WEBHOOK_URL);
 
         $this->systemConfig->set(Settings::WEBHOOK_ID, 'someId');
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, 'someToken');
+
         $result = $this->webhookService->registerWebhook(null);
 
         static::assertSame(WebhookService::NO_WEBHOOK_ACTION_REQUIRED, $result);
@@ -129,7 +165,53 @@ class WebhookServiceTest extends TestCase
 
     public function testRegisterWebhookWithoutTokenButWithId(): void
     {
-        $this->systemConfig->set(Settings::WEBHOOK_ID, self::ALREADY_EXISTING_WEBHOOK_ID);
+        $this->systemConfig->set(Settings::WEBHOOK_ID, self::THROW_WEBHOOK_ID_INVALID);
+        $this->router->method('generate')->willReturn(self::WEBHOOK_URL);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getWebhookUrl')
+            ->with(self::THROW_WEBHOOK_ID_INVALID, null)
+            ->willThrowException(new WebhookIdInvalidException('someId'));
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('updateWebhook')
+            ->with(self::WEBHOOK_URL, self::THROW_WEBHOOK_ID_INVALID, null)
+            ->willThrowException(new WebhookIdInvalidException('someId'));
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('createWebhook')
+            ->with(self::WEBHOOK_URL, static::anything(), null)
+            ->willThrowException(new WebhookAlreadyExistsException(self::WEBHOOK_URL));
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('getAllWebhooks')
+            ->with(null)
+            ->willReturn(
+                new WebhookCollection([(new Webhook())->assign([
+                    'id' => 'someId',
+                    'url' => self::WEBHOOK_URL,
+                ])])
+            );
+
+        $result = $this->webhookService->registerWebhook(null);
+
+        static::assertSame(WebhookService::NO_WEBHOOK_ACTION_REQUIRED, $result);
+        static::assertSame('someId', $this->systemConfig->getString(Settings::WEBHOOK_ID));
+    }
+
+    public function testRegisterWebhookWithInvalidId(): void
+    {
+        $this->systemConfig->set(Settings::WEBHOOK_ID, self::THROW_WEBHOOK_ID_INVALID);
+        $this->router->method('generate')->willReturn(self::WEBHOOK_URL);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('updateWebhook')
+            ->with(static::anything(), self::THROW_WEBHOOK_ID_INVALID, null);
 
         $result = $this->webhookService->registerWebhook(null);
 
@@ -138,11 +220,16 @@ class WebhookServiceTest extends TestCase
 
     public function testRegisterWebhookWithoutTokenAndId(): void
     {
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('createWebhook')
+            ->with(static::anything(), static::anything(), null)
+            ->willReturn(self::WEBHOOK_ID);
+
         $result = $this->webhookService->registerWebhook(null);
 
         static::assertSame(WebhookService::WEBHOOK_CREATED, $result);
-
-        static::assertSame(MockRequestHandler::TEST_WEBHOOK_ID, $this->systemConfig->getString(Settings::WEBHOOK_ID));
+        static::assertSame(self::WEBHOOK_ID, $this->systemConfig->getString(Settings::WEBHOOK_ID));
         static::assertSame(WebhookService::PAYPAL_WEBHOOK_TOKEN_LENGTH, \mb_strlen($this->systemConfig->getString(Settings::WEBHOOK_EXECUTE_TOKEN)));
     }
 
@@ -150,6 +237,9 @@ class WebhookServiceTest extends TestCase
     {
         $this->systemConfig->set(Settings::WEBHOOK_ID, self::ALREADY_EXISTING_WEBHOOK_ID);
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, self::ALREADY_EXISTING_WEBHOOK_EXECUTE_TOKEN);
+
+        // No deletion on inherited id
+        $this->webhookResource->expects($this->never())->method('deleteWebhook');
 
         $result = $this->webhookService->deregisterWebhook(TestDefaults::SALES_CHANNEL);
 
@@ -162,6 +252,11 @@ class WebhookServiceTest extends TestCase
     {
         $this->systemConfig->set(Settings::WEBHOOK_ID, self::ALREADY_EXISTING_WEBHOOK_ID);
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, self::ALREADY_EXISTING_WEBHOOK_EXECUTE_TOKEN);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('deleteWebhook')
+            ->with(self::ALREADY_EXISTING_WEBHOOK_ID, null);
 
         $result = $this->webhookService->deregisterWebhook(null);
 
@@ -198,6 +293,12 @@ class WebhookServiceTest extends TestCase
         $this->systemConfig->set(Settings::WEBHOOK_ID, self::THROW_WEBHOOK_ID_INVALID);
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, self::ALREADY_EXISTING_WEBHOOK_EXECUTE_TOKEN);
 
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('createWebhook')
+            ->with(static::anything(), static::anything(), TestDefaults::SALES_CHANNEL)
+            ->willReturn(self::WEBHOOK_ID);
+
         $result = $this->webhookService->registerWebhook(TestDefaults::SALES_CHANNEL);
 
         static::assertSame(WebhookService::WEBHOOK_CREATED, $result);
@@ -205,8 +306,14 @@ class WebhookServiceTest extends TestCase
 
     public function testDeregisterWebhookWithInvalidIdThrowsException(): void
     {
-        $this->systemConfig->set(Settings::WEBHOOK_ID, WebhookResourceTest::THROW_EXCEPTION_INVALID_ID);
+        $this->systemConfig->set(Settings::WEBHOOK_ID, self::THROW_WEBHOOK_ID_INVALID);
         $this->systemConfig->set(Settings::WEBHOOK_EXECUTE_TOKEN, self::ALREADY_EXISTING_WEBHOOK_EXECUTE_TOKEN);
+
+        $this->webhookResource
+            ->expects($this->once())
+            ->method('deleteWebhook')
+            ->with(self::THROW_WEBHOOK_ID_INVALID, null)
+            ->willThrowException(new WebhookIdInvalidException(self::THROW_WEBHOOK_ID_INVALID));
 
         $result = $this->webhookService->deregisterWebhook(null);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If the webhook ID in the system config is invalid, the registration of the webhook runs into an infinite loop due to the SystemConfig subscriber. In addition, if there is a webhook with the same URL on the PayPal server, then the correct status is not shown.

### 2. What does this change do, exactly?
- Remove subscription to webhook ID for the subscriber, which fixes the loop
- Add lookup of existing webhooks to correct webhook ID to the one with the same URL

### 3. Describe each step to reproduce the issue or behaviour.
- Generate a webhook regularly
- Modify the ID in the system_config to something invalid
- Try to re-register

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
