### PR TITLE
ci: use self-hosted octo-sts

### DIFF
--- a/.github/actions/setup-paypal/action.yml
+++ b/.github/actions/setup-paypal/action.yml
@@ -43,7 +43,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: octo-sts/action@main
+    - uses: shopware/octo-sts-action@main
       id: octo-sts
       continue-on-error: true
       with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup SwagPayPal
         uses: ./custom/plugins/SwagPayPal/.github/actions/setup-paypal
 
-      - uses: octo-sts/action@main
+      - uses: shopware/octo-sts-action@main
         id: create-pr-token
         with:
           scope: shopware


### PR DESCRIPTION
### 1. Why is this change necessary?
We hit the rate limit of the official octo-sts very often, so we decided to self-host it.

### 2. What does this change do, exactly?
Use a custom action, that first tries our self-hosted octo-sts and fall back to the official octo-sts if our octo-sts has problems.

### 3. Describe each step to reproduce the issue or behaviour.
Run a pipeline