### PR TITLE
fix: add hint for contact phone number transmission for Express

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-settings/snippet/de.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/snippet/de.json
@@ -73,7 +73,9 @@
     "express": {
       "title": "Express Checkout Shortcut",
       "subtitle": "Express Checkouts erhöhen die Konversionsrate in Deinem Shop und stellen für Dich als Händler kein finanzielles Risiko dar, daher sollten sie immer aktiv sein.",
-      "alertMessage": "Double Opt-In für Gast-Bestellungen ist in einem Deiner Verkaufskanäle aktiviert. Diese Funktion ist nicht mit dem PayPal Express Checkout Shortcut kompatibel. Kunden, die sich über den Express Checkout Shortcut anmelden, erhalten keine Double-Opt-In-Verifizierungs-E-Mails."
+      "alertMessage": "Double Opt-In für Gast-Bestellungen ist in einem Deiner Verkaufskanäle aktiviert. Diese Funktion ist nicht mit dem PayPal Express Checkout Shortcut kompatibel. Kunden, die sich über den Express Checkout Shortcut anmelden, erhalten keine Double-Opt-In-Verifizierungs-E-Mails.",
+      "alertMessagePhone": "Telefonnummern von Kundenadressen sind bei einem Deiner Verkaufskanäle aktiviert. Bitte stell sicher, dass \"Kontakttelefonnummern\" von PayPal übertragen werden, um Fehler im Checkout zu vermeiden. Sie können diese Einstellung {url} finden.",
+      "alertMessagePhoneLink": "hier"
     },
     "installment": {
       "title": "'Später Bezahlen'-Banner",

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/snippet/en.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/snippet/en.json
@@ -73,7 +73,9 @@
     "express": {
       "title": "Express Checkout Shortcut",
       "subtitle": "Express Checkouts increase the conversion rate in your shop and pose no financial risk to you as a merchant. It is recommended to keep them activated. ",
-      "alertMessage": "Double opt-in for guests is activated in one of your Sales Channels. This feature is not compatible with PayPal Express Shortcut buttons. Customers who sign up via the Express Checkout Shortcut buttons won't receive double opt-in verification emails."
+      "alertMessage": "Double opt-in for guests is activated in one of your Sales Channels. This feature is not compatible with PayPal Express Shortcut buttons. Customers who sign up via the Express Checkout Shortcut buttons won't receive double opt-in verification emails.",
+      "alertMessagePhone": "Phone numbers are required for one of your Sales Channels. Please ensure that you have enabled the transmission for \"contact phone number\" in the PayPal account settings to avoid checkout issues. You can find this setting {url}.",
+      "alertMessagePhoneLink": "here"
     },
     "installment": {
       "title": "'Pay Later' banner",

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
@@ -1,16 +1,20 @@
 import template from './swag-paypal-settings-storefront.html.twig';
 import { BUTTON_COLORS, BUTTON_SHAPES } from 'SwagPayPal/constant/swag-paypal-settings.constant';
 
+const { Criteria } = Shopware.Data;
+
 export default Shopware.Component.wrapComponentConfig({
     template,
 
     inject: [
         'systemConfigApiService',
+        'repositoryFactory',
     ],
 
     data() {
         return {
             doubleOptInConfig: false,
+            phoneRequiredConfig: false,
         };
     },
 
@@ -45,6 +49,19 @@ export default Shopware.Component.wrapComponentConfig({
                 && !this.settingsStore.getActual('SwagPayPal.settings.ecsLoginEnabled')
                 && !this.settingsStore.getActual('SwagPayPal.settings.ecsListingEnabled');
         },
+
+        systemConfigRepository() {
+            return this.repositoryFactory.create('system_config');
+        },
+
+        systemConfigCriteria() {
+            const criteria = new Criteria();
+
+            criteria.addFilter(Criteria.equalsAny('configurationKey', ['core.loginRegistration.doubleOptInGuestOrder', 'core.loginRegistration.phoneNumberFieldRequired']));
+            criteria.addFilter(Criteria.equals('configurationValue', 'true'));
+
+            return criteria;
+        },
     },
 
     watch: {
@@ -58,9 +75,10 @@ export default Shopware.Component.wrapComponentConfig({
 
     methods: {
         async fetchDoubleOptIn() {
-            const config = await this.systemConfigApiService.getValues('core.loginRegistration.doubleOptInGuestOrder') as Record<string, boolean>;
+            const response = await this.systemConfigRepository.search(this.systemConfigCriteria);
 
-            this.doubleOptInConfig = !!config['core.loginRegistration.doubleOptInGuestOrder'];
+            this.doubleOptInConfig = response.some((config) => config.configurationKey === 'core.loginRegistration.doubleOptInGuestOrder');
+            this.phoneRequiredConfig = response.some((config) => config.configurationKey === 'core.loginRegistration.phoneNumberFieldRequired');
         },
     },
 });

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
@@ -62,8 +62,6 @@ export default Shopware.Component.wrapComponentConfig({
 
             if (this.settingsStore.salesChannel) {
                 criteria.addFilter(Criteria.equalsAny('salesChannelId', [this.settingsStore.salesChannel, null]));
-            } else {
-                criteria.addFilter(Criteria.equals('configurationValue', 'true'));
             }
 
             return criteria;
@@ -89,7 +87,7 @@ export default Shopware.Component.wrapComponentConfig({
 
         getInheritedConfigValue(response: EntityCollection<"system_config">, key: string): boolean {
             if (!this.settingsStore.salesChannel) {
-                return response.some((config) => config.configurationKey === key);
+                return response.some((config) => config.configurationKey === key && config.configurationValue === 'true');
             }
 
             const inheritedConfig = response.find((config) => !config.salesChannelId && config.configurationKey === key);

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
@@ -1,5 +1,6 @@
 import template from './swag-paypal-settings-storefront.html.twig';
 import { BUTTON_COLORS, BUTTON_SHAPES } from 'SwagPayPal/constant/swag-paypal-settings.constant';
+import type EntityCollection from "@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection";
 
 const { Criteria } = Shopware.Data;
 
@@ -58,10 +59,11 @@ export default Shopware.Component.wrapComponentConfig({
             const criteria = new Criteria();
 
             criteria.addFilter(Criteria.equalsAny('configurationKey', ['core.loginRegistration.doubleOptInGuestOrder', 'core.loginRegistration.phoneNumberFieldRequired']));
-            criteria.addFilter(Criteria.equals('configurationValue', 'true'));
 
             if (this.settingsStore.salesChannel) {
-                criteria.addFilter(Criteria.equals('salesChannelId', this.settingsStore.salesChannel));
+                criteria.addFilter(Criteria.equalsAny('salesChannelId', [this.settingsStore.salesChannel, null]));
+            } else {
+                criteria.addFilter(Criteria.equals('configurationValue', 'true'));
             }
 
             return criteria;
@@ -81,8 +83,24 @@ export default Shopware.Component.wrapComponentConfig({
         async fetchDoubleOptIn() {
             const response = await this.systemConfigRepository.search(this.systemConfigCriteria);
 
-            this.doubleOptInConfig = response.some((config) => config.configurationKey === 'core.loginRegistration.doubleOptInGuestOrder');
-            this.phoneRequiredConfig = response.some((config) => config.configurationKey === 'core.loginRegistration.phoneNumberFieldRequired');
+            this.doubleOptInConfig = this.getInheritedConfigValue(response, 'core.loginRegistration.doubleOptInGuestOrder');
+            this.phoneRequiredConfig = this.getInheritedConfigValue(response, 'core.loginRegistration.phoneNumberFieldRequired');
+        },
+
+        getInheritedConfigValue(response: EntityCollection<"system_config">, key: string): boolean {
+            if (!this.settingsStore.salesChannel) {
+                return response.some((config) => config.configurationKey === key);
+            }
+
+            const inheritedConfig = response.find((config) => !config.salesChannelId && config.configurationKey === key);
+            const specificConfig = response.find((config) => config.salesChannelId === this.settingsStore.salesChannel && config.configurationKey === key);
+
+            if (!specificConfig) {
+                return inheritedConfig?.configurationValue === 'true';
+            }
+
+            return specificConfig.configurationValue === 'true';
         },
     },
 });
+

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/index.ts
@@ -60,6 +60,10 @@ export default Shopware.Component.wrapComponentConfig({
             criteria.addFilter(Criteria.equalsAny('configurationKey', ['core.loginRegistration.doubleOptInGuestOrder', 'core.loginRegistration.phoneNumberFieldRequired']));
             criteria.addFilter(Criteria.equals('configurationValue', 'true'));
 
+            if (this.settingsStore.salesChannel) {
+                criteria.addFilter(Criteria.equals('salesChannelId', this.settingsStore.salesChannel));
+            }
+
             return criteria;
         },
     },

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.html.twig
@@ -8,6 +8,13 @@
     <mt-banner v-if="doubleOptInConfig" variant="attention">
         {{ $t('swag-paypal-settings.express.alertMessage') }}
     </mt-banner>
+    <mt-banner v-if="phoneRequiredConfig" variant="attention">
+        <i18n-t keypath="swag-paypal-settings.express.alertMessagePhone" tag="p">
+            <template #url>
+                <a href="https://www.paypal.com/businessmanage/preferences/website" target="_blank">{{ $t('swag-paypal-settings.express.alertMessagePhoneLink') }}</a>
+            </template>
+        </i18n-t>
+    </mt-banner>
 
     <swag-paypal-setting path="SwagPayPal.settings.ecsDetailEnabled" />
     <swag-paypal-setting path="SwagPayPal.settings.ecsCartEnabled" />

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.spec.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.spec.ts
@@ -3,10 +3,12 @@ import SwagPayPalSettingsStorefront from '.';
 import { SYSTEM_CONFIGS } from '../../../../constant/swag-paypal-settings.constant';
 import SettingsFixture from '../../../../app/store/settings.fixture';
 import type SwagPayPalSetting from 'SwagPayPal/app/component/swag-paypal-setting';
+import EntityCollection from "@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection";
+import Entity from "@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity";
 
 Shopware.Component.register('swag-paypal-settings-storefront', Promise.resolve(SwagPayPalSettingsStorefront));
 
-async function createWrapper() {
+async function createWrapper(systemConfigValues: EntityCollection<"system_config"> | null = null) {
     return mount(
         await Shopware.Component.build('swag-paypal-settings-storefront') as typeof SwagPayPalSettingsStorefront,
         {
@@ -24,7 +26,7 @@ async function createWrapper() {
                     systemConfigApiService: { getValues: () => false },
                     repositoryFactory: {
                         create: () => ({
-                            search: jest.fn(() => Promise.resolve([])),
+                            search: jest.fn(() => Promise.resolve(systemConfigValues ?? [])),
                         }),
                     },
                 },
@@ -143,5 +145,87 @@ describe('swag-paypal-settings-storefront', () => {
 
         expect(wrapper.vm.sbpSettingsDisabled).toBe(true);
         expect(disabledSettings.map((setting) => Boolean(settings[setting]?.vm.$attrs.disabled))).toStrictEqual(Array(5).fill(true));
+    });
+
+    it('should fetch config without selected sales channel', async () => {
+        store.salesChannel = null;
+        const wrapper = await createWrapper(
+            new EntityCollection('', 'system_config', Shopware.Context.api, null, [
+                new Entity('foo', 'system_config', {
+                    id: 'foo',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'true',
+                    createdAt: '',
+                }),
+            ]),
+        );
+        await flushPromises();
+
+        expect(wrapper.vm.phoneRequiredConfig).toBe(true);
+    });
+
+    it('should fetch specific config with selected sales channel if true', async () => {
+        store.salesChannel = 'foobar';
+        const wrapper = await createWrapper(
+            new EntityCollection('', 'system_config', Shopware.Context.api, null, [
+                new Entity('foo', 'system_config', {
+                    id: 'foo',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'true',
+                    createdAt: '',
+                    salesChannelId: 'foobar',
+                }),
+                new Entity('bar', 'system_config', {
+                    id: 'bar',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'false',
+                    createdAt: '',
+                }),
+            ]),
+        );
+        await flushPromises();
+
+        expect(wrapper.vm.phoneRequiredConfig).toBe(true);
+    });
+
+    it('should fetch specific config with selected sales channel if false', async () => {
+        store.salesChannel = 'foobar';
+        const wrapper = await createWrapper(
+            new EntityCollection('', 'system_config', Shopware.Context.api, null, [
+                new Entity('foo', 'system_config', {
+                    id: 'foo',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'false',
+                    createdAt: '',
+                    salesChannelId: 'foobar',
+                }),
+                new Entity('bar', 'system_config', {
+                    id: 'bar',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'true',
+                    createdAt: '',
+                }),
+            ]),
+        );
+        await flushPromises();
+
+        expect(wrapper.vm.phoneRequiredConfig).toBe(false);
+    });
+
+    it('should fetch inherited config with selected sales channel', async () => {
+        store.salesChannel = 'foobar';
+        const wrapper = await createWrapper(
+            new EntityCollection('', 'system_config', Shopware.Context.api, null, [
+                new Entity('bar', 'system_config', {
+                    id: 'bar',
+                    configurationKey: 'core.loginRegistration.phoneNumberFieldRequired',
+                    configurationValue: 'true',
+                    createdAt: '',
+                }),
+            ]),
+        );
+        await flushPromises();
+
+        expect(wrapper.vm.phoneRequiredConfig).toBe(true);
     });
 });

--- a/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.spec.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-settings/view/swag-paypal-settings-storefront/swag-paypal-settings-storefront.spec.ts
@@ -22,6 +22,11 @@ async function createWrapper() {
                 },
                 provide: {
                     systemConfigApiService: { getValues: () => false },
+                    repositoryFactory: {
+                        create: () => ({
+                            search: jest.fn(() => Promise.resolve([])),
+                        }),
+                    },
                 },
             },
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
If phone numbers are required in the Shopware registration settings, PayPal may not send their contact phone number. This is a setting the account settings of PayPal

### 2. What does this change do, exactly?
Add a hint in the settings for the Express checkout, that this needs to be enabled for the phone number to be transmitted.

### 3. Describe each step to reproduce the issue or behaviour.
Not reproducible in Sandbox!
- set phone number to required in Shopware settings ("login & registration")
- try to checkout
- the phone number will be missing by default and an error in the checkout will occur

### 4. Please link to the relevant issues (if any).
fixes #421 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
