### PR TITLE
[6.6.x] ci: use self-hosted octo-sts

### DIFF
--- a/.github/actions/setup-paypal/action.yml
+++ b/.github/actions/setup-paypal/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: octo-sts/action@main
+    - uses: shopware/octo-sts-action@main
       id: octo-sts
       continue-on-error: true
       with:


### PR DESCRIPTION
backport of #444