### PR TITLE
fix: filter cookie provider by active sales channel payment method

### DIFF
--- a/phpstan-6.7.0.0.neon.dist
+++ b/phpstan-6.7.0.0.neon.dist
@@ -73,3 +73,28 @@ parameters:
 
         - message: '#(Call to an undefined method.*)?Shopware\\Core\\Framework\\Struct\\Struct::(all|getExtensionOfType)\(\).*(, string given)?#'
           path: src/Checkout/Payment/Service/VaultTokenService.php
+
+        - message: '#Shopware\\Core\\Content\\Cookie\\Event\\CookieGroupCollectEvent#'
+          paths:
+            - src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
+            - tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+
+        - message: '#Shopware\\Core\\Content\\Cookie\\Struct\\CookieEntry#'
+          paths:
+            - src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
+            - tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+
+        - message: '#Shopware\\Core\\Content\\Cookie\\Struct\\CookieGroup#'
+          path: tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+
+        - message: '#^Mixed variable in a `\$(required|entries)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+          identifier: typePerfect.noMixedMethodCaller
+          paths:
+            - src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
+            - tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+
+        - message: '#^Call to internal static method Shopware\\Core\\Framework\\Context\:\:createDefaultContext\(\) from outside its root namespace Shopware\.$#'
+          identifier: staticMethod.internal
+          paths:
+            - src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+            - src/Storefront/Framework/Cookie/PayPalCookieProvider.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -123,8 +123,9 @@ parameters:
 		-
 			message: '#^Call to internal static method Shopware\\Core\\Framework\\Context\:\:createDefaultContext\(\) from outside its root namespace Shopware\.$#'
 			identifier: staticMethod.internal
-			count: 1
-			path: src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+			paths:
+				- src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+				- src/Storefront/Framework/Cookie/PayPalCookieProvider.php
 
 		-
 			message: '#^Mixed variable in a `\$criteria\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -21,15 +21,24 @@
             </call>
         </service>
 
+        <service id="Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber">
+            <argument type="service" id="payment_method.repository"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider.inner"/>
+            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider.inner"/>
             <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\RequestSubscriber">

--- a/src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
+++ b/src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Storefront\Framework\Cookie;
+
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Content\Cookie\Struct\CookieEntry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class CookieProviderSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $paymentMethodRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CookieGroupCollectEvent::class => 'onCookieGroupCollect',
+        ];
+    }
+
+    public function onCookieGroupCollect(CookieGroupCollectEvent $event): void
+    {
+        $required = $event->cookieGroupCollection->get('cookie.groupRequired');
+        if (!($entries = $required?->getEntries())) {
+            return;
+        }
+
+        $payPalCookie = new CookieEntry('paypal-cookie-key');
+        $payPalCookie->name = 'paypal.cookie.name';
+
+        if ($this->isGooglePayActive($event->getSalesChannelContext())) {
+            $googleCookie = new CookieEntry('paypal-google-pay-cookie-key');
+            $googleCookie->name = 'paypal.cookie.googlePay';
+
+            $entries->add($payPalCookie);
+            $entries->add($googleCookie);
+        } elseif ($this->isPayPalPaymentActive($event->getSalesChannelContext())) {
+            $entries->add($payPalCookie);
+        }
+    }
+
+    private function isPayPalPaymentActive(SalesChannelContext $salesChannelContext): bool
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+        $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->addFilter(new PrefixFilter('technicalName', 'swag_paypal_'));
+        $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelContext->getSalesChannelId()));
+
+        return $this->paymentMethodRepository->searchIds($criteria, $salesChannelContext->getContext())->firstId() !== null;
+    }
+
+    private function isGooglePayActive(SalesChannelContext $salesChannelContext): bool
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+        $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->addFilter(new EqualsFilter('handlerIdentifier', GooglePayHandler::class));
+        $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelContext->getSalesChannelId()));
+
+        return $this->paymentMethodRepository->searchIds($criteria, $salesChannelContext->getContext())->firstId() !== null;
+    }
+}

--- a/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
@@ -7,13 +7,16 @@
 
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
@@ -31,6 +34,7 @@ class GooglePayCookieProvider implements CookieProviderInterface
     public function __construct(
         CookieProviderInterface $cookieProvider,
         private readonly EntityRepository $paymentMethodRepository,
+        private readonly RequestStack $requestStack,
     ) {
         $this->original = $cookieProvider;
     }
@@ -41,6 +45,9 @@ class GooglePayCookieProvider implements CookieProviderInterface
     public function getCookieGroups(): array
     {
         $cookies = $this->original->getCookieGroups();
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            return $cookies;
+        }
 
         foreach ($cookies as &$cookie) {
             if (!\is_array($cookie)) {
@@ -75,9 +82,18 @@ class GooglePayCookieProvider implements CookieProviderInterface
     private function isGooglePayActive(): bool
     {
         $criteria = new Criteria();
+        $criteria->setLimit(1);
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addFilter(new EqualsFilter('handlerIdentifier', GooglePayHandler::class));
 
-        return $this->paymentMethodRepository->searchIds($criteria, Context::createDefaultContext())->firstId() !== null;
+        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
+        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
+        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
+
+        if (Uuid::isValid($salesChannelId)) {
+            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        }
+
+        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
     }
 }

--- a/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
@@ -7,8 +7,16 @@
 
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
@@ -23,8 +31,11 @@ class PayPalCookieProvider implements CookieProviderInterface
      *
      * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
      */
-    public function __construct(CookieProviderInterface $cookieProvider)
-    {
+    public function __construct(
+        CookieProviderInterface $cookieProvider,
+        private readonly EntityRepository $paymentMethodRepository,
+        private readonly RequestStack $requestStack,
+    ) {
         $this->original = $cookieProvider;
     }
 
@@ -34,6 +45,9 @@ class PayPalCookieProvider implements CookieProviderInterface
     public function getCookieGroups(): array
     {
         $cookies = $this->original->getCookieGroups();
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            return $cookies;
+        }
 
         foreach ($cookies as &$cookie) {
             if (!\is_array($cookie)) {
@@ -45,6 +59,10 @@ class PayPalCookieProvider implements CookieProviderInterface
             }
 
             if (!\array_key_exists('entries', $cookie)) {
+                continue;
+            }
+
+            if (!$this->isPayPalPaymentActive()) {
                 continue;
             }
 
@@ -61,5 +79,23 @@ class PayPalCookieProvider implements CookieProviderInterface
     {
         return (\array_key_exists('isRequired', $cookie) && $cookie['isRequired'] === true)
             && (\array_key_exists('snippet_name', $cookie) && $cookie['snippet_name'] === 'cookie.groupRequired');
+    }
+
+    private function isPayPalPaymentActive(): bool
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+        $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->addFilter(new PrefixFilter('technicalName', 'swag_paypal_'));
+
+        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
+        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
+        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
+
+        if (Uuid::isValid($salesChannelId)) {
+            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        }
+
+        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
     }
 }

--- a/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+++ b/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
@@ -1,0 +1,175 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Storefront\Framework\Cookie;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Content\Cookie\Struct\CookieEntry;
+use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
+use Shopware\Core\Content\Cookie\Struct\CookieGroup;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(CookieProviderSubscriber::class)]
+#[Package('checkout')]
+class CookieProviderSubscriberTest extends TestCase
+{
+    #[DataProvider('dataStructs')]
+    public function testRequiredStructsNotSet(?CookieGroupCollection $cookieGroupCollection): void
+    {
+        // @deprecated tag:v11.0.0 - class exists with v6.7.3.0.
+        if (!$cookieGroupCollection) {
+            static::markTestSkipped('CookieGroupCollectEvent does not exist');
+        }
+
+        (new CookieProviderSubscriber($this->createMock(EntityRepository::class)))
+            ->onCookieGroupCollect(new CookieGroupCollectEvent(
+                $cookieGroupCollection,
+                new Request(),
+                $this->createMock(SalesChannelContext::class)
+            ));
+
+        $entries = $cookieGroupCollection->get('cookie.groupRequired')?->getEntries();
+
+        static::assertNull($entries);
+    }
+
+    public static function dataStructs(): array
+    {
+        // @deprecated tag:v11.0.0 - class exists with v6.7.3.0.
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            return ['class does not exist' => [null]];
+        }
+
+        $groupCollection = new CookieGroupCollection();
+        $groupCollection->add(new CookieGroup('cookie.groupRequired'));
+
+        $wrongGroupCollection = new CookieGroupCollection();
+        $wrongGroupCollection->add(new CookieGroup('cookie.groupNotRequired'));
+
+        return [
+            'empty Collection' => [new CookieGroupCollection()],
+            'empty group' => [$groupCollection],
+            'wrong group' => [$wrongGroupCollection],
+        ];
+    }
+
+    public function testNoPaymentMethodFound(): void
+    {
+        // @deprecated tag:v11.0.0 - class exists with v6.7.3.0.
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('CookieGroupCollectEvent does not exist');
+        }
+
+        $group = new CookieGroup('cookie.groupRequired');
+        $group->setEntries(new CookieEntryCollection());
+
+        $groupCollection = new CookieGroupCollection();
+        $groupCollection->add($group);
+
+        (new CookieProviderSubscriber($this->createMock(EntityRepository::class)))
+            ->onCookieGroupCollect(new CookieGroupCollectEvent(
+                $groupCollection,
+                new Request(),
+                $this->createMock(SalesChannelContext::class)
+            ));
+
+        $entries = $groupCollection->get('cookie.groupRequired')?->getEntries();
+
+        static::assertNotNull($entries);
+        static::assertFalse($entries->has('paypal-cookie-key'));
+        static::assertFalse($entries->has('paypal-google-pay-cookie-key'));
+    }
+
+    public function testActiveGooglePayment(): void
+    {
+        // @deprecated tag:v11.0.0 - class exists with v6.7.3.0.
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('CookieGroupCollectEvent does not exist');
+        }
+
+        $group = new CookieGroup('cookie.groupRequired');
+        $group->setEntries(new CookieEntryCollection());
+
+        $groupCollection = new CookieGroupCollection();
+        $groupCollection->add($group);
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository
+            ->expects($this->once())
+            ->method('searchIds')
+            ->willReturn(new IdSearchResult(1, [Uuid::randomHex() => ['primaryKey' => 'token-id', 'data' => []]], new Criteria(), Context::createCLIContext()));
+
+        (new CookieProviderSubscriber($repository))
+            ->onCookieGroupCollect(new CookieGroupCollectEvent(
+                $groupCollection,
+                new Request(),
+                $this->createMock(SalesChannelContext::class)
+            ));
+
+        $entries = $groupCollection->get('cookie.groupRequired')?->getEntries();
+
+        static::assertNotNull($entries);
+        static::assertInstanceOf(CookieEntry::class, $payPal = $entries->get('paypal-cookie-key'));
+        static::assertInstanceOf(CookieEntry::class, $google = $entries->get('paypal-google-pay-cookie-key'));
+
+        static::assertSame('paypal.cookie.name', $payPal->name);
+        static::assertSame('paypal.cookie.googlePay', $google->name);
+    }
+
+    public function testActivePayPalPayment(): void
+    {
+        // @deprecated tag:v11.0.0 - class exists with v6.7.3.0.
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('CookieGroupCollectEvent does not exist');
+        }
+
+        $group = new CookieGroup('cookie.groupRequired');
+        $group->setEntries(new CookieEntryCollection());
+
+        $groupCollection = new CookieGroupCollection();
+        $groupCollection->add($group);
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository
+            ->expects($this->exactly(2))
+            ->method('searchIds')
+            ->willReturnOnConsecutiveCalls(
+                new IdSearchResult(0, [], new Criteria(), Context::createCLIContext()),
+                new IdSearchResult(1, [Uuid::randomHex() => ['primaryKey' => 'token-id', 'data' => []]], new Criteria(), Context::createCLIContext())
+            );
+
+        (new CookieProviderSubscriber($repository))
+            ->onCookieGroupCollect(new CookieGroupCollectEvent(
+                $groupCollection,
+                new Request(),
+                $this->createMock(SalesChannelContext::class)
+            ));
+
+        $entries = $groupCollection->get('cookie.groupRequired')?->getEntries();
+
+        static::assertNotNull($entries);
+        static::assertInstanceOf(CookieEntry::class, $payPal = $entries->get('paypal-cookie-key'));
+        static::assertNull($entries->get('paypal-google-pay-cookie-key'));
+
+        static::assertSame('paypal.cookie.name', $payPal->name);
+    }
+}

--- a/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+++ b/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber;
@@ -32,6 +33,15 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('checkout')]
 class CookieProviderSubscriberTest extends TestCase
 {
+    use IntegrationTestBehaviour;
+
+    public function testLoadService(): void
+    {
+        $subscriber = $this->getContainer()->get(CookieProviderSubscriber::class);
+
+        static::assertInstanceOf(CookieProviderSubscriber::class, $subscriber);
+    }
+
     #[DataProvider('dataStructs')]
     public function testRequiredStructsNotSet(?CookieGroupCollection $cookieGroupCollection): void
     {

--- a/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
@@ -7,16 +7,21 @@
 
 namespace Swag\PayPal\Test\Storefront\Framework\Cookie;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
@@ -24,29 +29,44 @@ use Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider;
  * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
  */
 #[Package('checkout')]
+#[CoversClass(GooglePayCookieProvider::class)]
 class GooglePayCookieProviderTest extends TestCase
 {
     private EntityRepository&MockObject $paymentMethodRepository;
 
+    private RequestStack $requestStack;
+
     protected function setUp(): void
     {
+        $request = new Request();
+        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+
         $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
+        $this->requestStack = new RequestStack([$request]);
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [];
         $cookieProviderMock->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
     public function testGetCookieGroupsWithOriginalCookiesNotInSubArraysReturnsOriginalCookies(): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [
             'snippet_name' => 'cookie.example.name',
@@ -56,13 +76,17 @@ class GooglePayCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
     #[DataProvider('dataTestGetCookieGroupsWithRequiredCookieGroup')]
     public function testGetCookieGroupsWithRequiredCookieGroup(array $cookies, bool $cookieAdded): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookieProviderMock->expects($this->once())
             ->method('getCookieGroups')
@@ -72,9 +96,13 @@ class GooglePayCookieProviderTest extends TestCase
 
         $this->paymentMethodRepository->expects($cookieAdded ? $this->once() : $this->never())
             ->method('searchIds')
-            ->willReturn($searchResult);
+            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
+                static::assertCount(3, $criteria->getFilters());
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+                return $searchResult;
+            });
+
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
 
         if (!$cookieAdded) {
             static::assertSame($cookies, $result);
@@ -150,5 +178,28 @@ class GooglePayCookieProviderTest extends TestCase
             ],
             true,
         ];
+    }
+
+    public function testEarlyReturnsEmptyCookieGroups(): void
+    {
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
+        $cookies = [
+            'isRequired' => true,
+            'snippet_name' => 'cookie.groupRequired',
+            'cookie' => 'example-cookie-key',
+            'entries' => [],
+        ];
+
+        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
+        $cookieProviderMock->expects($this->once())
+            ->method('getCookieGroups')
+            ->willReturn($cookies);
+
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+
+        static::assertSame($cookies, $result);
     }
 }

--- a/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
@@ -7,34 +7,66 @@
 
 namespace Swag\PayPal\Test\Storefront\Framework\Cookie;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
  *
  * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
  */
+#[CoversClass(PayPalCookieProvider::class)]
 #[Package('checkout')]
 class PayPalCookieProviderTest extends TestCase
 {
+    private EntityRepository&MockObject $paymentMethodRepository;
+
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $request = new Request();
+        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+
+        $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
+        $this->requestStack = new RequestStack([$request]);
+    }
+
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [];
         $cookieProviderMock->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
     public function testGetCookieGroupsWithOriginalCookiesNotInSubArraysReturnsOriginalCookies(): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [
             'snippet_name' => 'cookie.example.name',
@@ -44,19 +76,33 @@ class PayPalCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
     #[DataProvider('dataTestGetCookieGroupsWithRequiredCookieGroup')]
     public function testGetCookieGroupsWithRequiredCookieGroup(array $cookies, bool $payPalCookieAdded): void
     {
+        if (\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookieProviderMock->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $searchResult = new IdSearchResult(0, [Uuid::randomHex() => ['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
+
+        $this->paymentMethodRepository->expects($payPalCookieAdded ? $this->once() : $this->never())
+            ->method('searchIds')
+            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
+                static::assertCount(3, $criteria->getFilters());
+
+                return $searchResult;
+            });
+
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         if (!$payPalCookieAdded) {
             static::assertSame($cookies, $result);
 
@@ -138,5 +184,28 @@ class PayPalCookieProviderTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    public function testEarlyReturnsEmptyCookieGroups(): void
+    {
+        if (!\class_exists(CookieGroupCollectEvent::class)) {
+            static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
+        }
+
+        $cookies = [
+            'isRequired' => true,
+            'snippet_name' => 'cookie.groupRequired',
+            'cookie' => 'example-cookie-key',
+            'entries' => [],
+        ];
+
+        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
+        $cookieProviderMock->expects($this->once())
+            ->method('getCookieGroups')
+            ->willReturn($cookies);
+
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+
+        static::assertSame($cookies, $result);
     }
 }


### PR DESCRIPTION
- fixes: https://github.com/shopware/shopware/issues/4375

PayPal / Google cookies are now only loaded, if there are active PayPal / Google payment methods for that sales channel

New event subscriber will add the cookies after a validation check.
The deprecated provider will do the same for the old logic until the new event `Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent` (v6.7.3.0) is created.