### PR TITLE
feat: tax status net

### DIFF
--- a/src/AgentCommerce/Subscriber/ProductFilterSubscriber.php
+++ b/src/AgentCommerce/Subscriber/ProductFilterSubscriber.php
@@ -7,11 +7,14 @@
 
 namespace Swag\PayPal\AgentCommerce\Subscriber;
 
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Content\Product\Events\ProductGatewayCriteriaEvent;
+use Shopware\Core\Content\ProductExport\Event\ProductExportProductCriteriaEvent;
 use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\AgentCommerce\Routing\AgentSource;
+use Swag\PayPal\SwagPayPal;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -24,6 +27,7 @@ class ProductFilterSubscriber implements EventSubscriberInterface
     {
         return [
             ProductGatewayCriteriaEvent::class => 'onProductGatewayCriteria',
+            ProductExportProductCriteriaEvent::class => 'onProductExportProductCriteria',
         ];
     }
 
@@ -37,5 +41,15 @@ class ProductFilterSubscriber implements EventSubscriberInterface
 
         $event->getCriteria()
             ->addFilter(new EqualsFilter('streams.id', $source->getStreamId()));
+    }
+
+    public function onProductExportProductCriteria(ProductExportProductCriteriaEvent $event): void
+    {
+        if ($event->getProductExport()->getSalesChannel()->getTypeId() !== SwagPayPal::SALES_CHANNEL_TYPE_AGENT_COMMERCE) {
+            return;
+        }
+
+        // Product Export for agent commerce should have net prices
+        $event->getSalesChannelContext()->setTaxState(CartPrice::TAX_STATE_NET);
     }
 }

--- a/src/AgentCommerce/Tax/AgenticTaxDetector.php
+++ b/src/AgentCommerce/Tax/AgenticTaxDetector.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\AgentCommerce\Tax;
+
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\AbstractTaxDetector;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class AgenticTaxDetector extends AbstractTaxDetector
+{
+    public function __construct(
+        private readonly AbstractTaxDetector $decorated,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function getDecorated(): AbstractTaxDetector
+    {
+        return $this->decorated;
+    }
+
+    public function useGross(SalesChannelContext $context): bool
+    {
+        $routeScope = $this->requestStack->getMainRequest()?->attributes->get('_routeScope');
+        if (\is_array($routeScope) && \in_array('paypal-agent', $routeScope, true)) {
+            return false;
+        }
+
+        return $this->getDecorated()->useGross($context);
+    }
+
+    public function isNetDelivery(SalesChannelContext $context): bool
+    {
+        return $this->getDecorated()->isNetDelivery($context);
+    }
+
+    public function getTaxState(SalesChannelContext $context): string
+    {
+        $routeScope = $this->requestStack->getMainRequest()?->attributes->get('_routeScope');
+        if (!\is_array($routeScope) || !\in_array('paypal-agent', $routeScope, true)) {
+            return $this->getDecorated()->getTaxState($context);
+        }
+
+        if ($this->isNetDelivery($context)) {
+            return CartPrice::TAX_STATE_FREE;
+        }
+
+        if ($this->useGross($context)) {
+            return CartPrice::TAX_STATE_GROSS;
+        }
+
+        return CartPrice::TAX_STATE_NET;
+    }
+
+    public function isCompanyTaxFree(SalesChannelContext $context, CountryEntity $shippingLocationCountry): bool
+    {
+        return $this->getDecorated()->isCompanyTaxFree($context, $shippingLocationCountry);
+    }
+}

--- a/src/Resources/config/services/agent_commerce.xml
+++ b/src/Resources/config/services/agent_commerce.xml
@@ -108,6 +108,13 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Swag\PayPal\AgentCommerce\Tax\AgenticTaxDetector"
+                 decorates="Shopware\Core\Checkout\Cart\Tax\TaxDetector"
+                 decoration-priority="-1000">
+            <argument type="service" id="Swag\PayPal\AgentCommerce\Tax\AgenticTaxDetector.inner"/>
+            <argument type="service" id="request_stack"/>
+        </service>
+
         <service id="swag.paypal.honey_webhook" class="GuzzleHttp\Client" lazy="true">
             <argument type="collection">
                 <argument key="base_uri">https://d.joinhoney.com/</argument>


### PR DESCRIPTION
The tax status should always be `net` for the agentic commerce routes