### PR TITLE
fix: missing country state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where the state of a country was not correctly transmitted to PayPal (shopware/SwagPayPal#469)
+
 # 10.3.0
 - Added compatibility with subscription mixed carts (shopware/shopware#10486)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem der Bundesstaat nicht korrent an PayPal übermittelt wurde (shopware/SwagPayPal#469)
+
 # 10.3.0
 - Fügt Kompatibilität mit Abos in gemischten Warenkörben hinzu (shopware/shopware#10486)
 

--- a/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
+++ b/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
@@ -281,8 +281,10 @@ abstract class AbstractPaymentMethodHandler extends AbstractPaymentHandler
     {
         $criteria = new Criteria([$transactionId]);
         $criteria->addAssociation('order.billingAddress.country');
+        $criteria->addAssociation('order.billingAddress.countryState');
         $criteria->addAssociation('order.currency');
         $criteria->addAssociation('order.deliveries.shippingOrderAddress.country');
+        $criteria->addAssociation('order.deliveries.shippingOrderAddress.countryState');
         $criteria->addAssociation('order.lineItems');
         $criteria->addAssociation('order.orderCustomer.customer');
         $criteria->addAssociation('order.salesChannel');

--- a/src/Checkout/SalesChannel/CreateOrderRoute.php
+++ b/src/Checkout/SalesChannel/CreateOrderRoute.php
@@ -155,8 +155,10 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         $criteria->addAssociation('transactions');
         $criteria->addAssociation('lineItems');
         $criteria->addAssociation('billingAddress.country');
+        $criteria->addAssociation('billingAddress.countryState');
         $criteria->addAssociation('orderCustomer');
         $criteria->addAssociation('deliveries.shippingOrderAddress.country');
+        $criteria->addAssociation('deliveries.shippingOrderAddress.countryState');
         $criteria->addAssociation('subscription');
         $criteria->addAssociation('currency');
         $criteria->addAssociation('salesChannel');


### PR DESCRIPTION
### 1. Why is this change necessary?
Country State needs to be loaded, when creating an address object in PayPal

### 2. What does this change do, exactly?
Load it.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #469 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
