### PR TITLE
[6.6.x] fix: filter cookie provider by active sales channel payment method

### DIFF
--- a/.github/actions/setup-paypal/action.yml
+++ b/.github/actions/setup-paypal/action.yml
@@ -43,6 +43,13 @@ runs:
         scope: shopware
         identity: ${{ github.event.repository.name }}
 
+    - name: Ignore audit
+      if: ${{ inputs.shopware-version != 'trunk' }}
+      shell: bash
+      run: |
+        mkdir -p ~/.config/composer
+        yq e -n -o=json '.config.audit.block-insecure=false' > ~/.config/composer/config.json
+
     - name: Prepare dependency list
       id: dependency-list
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where cookies are added even though associated payment methods are not active (shopware/SwagPayPal#457)
+
 # 9.9.0
 - Fixes an issue, where Paypal Express Checkout does not recalculate cart price after changing shipping country (shopware/SwagPayPal#342)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem Cookies geladen wurden, obwohl die zugehörigen Zahlungsarten nicht aktiv sind (shopware/SwagPayPal#457)
+
 # 9.9.0
 - Behebt ein Problem, bei dem der Warenkorbpreis beim Verändern des Versandlandes im Express Checkout nicht angepasst wurde (shopware/SwagPayPal#342)
 

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -24,12 +24,15 @@
         <service id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider.inner"/>
+            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider.inner"/>
             <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\RequestSubscriber">

--- a/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
@@ -12,8 +12,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 #[Package('checkout')]
 class GooglePayCookieProvider implements CookieProviderInterface
@@ -26,6 +28,7 @@ class GooglePayCookieProvider implements CookieProviderInterface
     public function __construct(
         CookieProviderInterface $cookieProvider,
         private readonly EntityRepository $paymentMethodRepository,
+        private readonly RequestStack $requestStack,
     ) {
         $this->original = $cookieProvider;
     }
@@ -67,9 +70,18 @@ class GooglePayCookieProvider implements CookieProviderInterface
     private function isGooglePayActive(): bool
     {
         $criteria = new Criteria();
+        $criteria->setLimit(1);
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addFilter(new EqualsFilter('handlerIdentifier', GooglePayHandler::class));
 
-        return $this->paymentMethodRepository->searchIds($criteria, Context::createDefaultContext())->firstId() !== null;
+        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
+        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
+        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
+
+        if (Uuid::isValid($salesChannelId)) {
+            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        }
+
+        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
     }
 }

--- a/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
@@ -7,8 +7,15 @@
 
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 #[Package('checkout')]
 class PayPalCookieProvider implements CookieProviderInterface
@@ -18,8 +25,11 @@ class PayPalCookieProvider implements CookieProviderInterface
     /**
      * @internal
      */
-    public function __construct(CookieProviderInterface $cookieProvider)
-    {
+    public function __construct(
+        CookieProviderInterface $cookieProvider,
+        private readonly EntityRepository $paymentMethodRepository,
+        private readonly RequestStack $requestStack,
+    ) {
         $this->original = $cookieProvider;
     }
 
@@ -40,6 +50,10 @@ class PayPalCookieProvider implements CookieProviderInterface
                 continue;
             }
 
+            if (!$this->isPayPalPaymentActive()) {
+                continue;
+            }
+
             $cookie['entries'][] = [
                 'snippet_name' => 'paypal.cookie.name',
                 'cookie' => 'paypal-cookie-key',
@@ -53,5 +67,23 @@ class PayPalCookieProvider implements CookieProviderInterface
     {
         return (\array_key_exists('isRequired', $cookie) && $cookie['isRequired'] === true)
             && (\array_key_exists('snippet_name', $cookie) && $cookie['snippet_name'] === 'cookie.groupRequired');
+    }
+
+    private function isPayPalPaymentActive(): bool
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+        $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->addFilter(new PrefixFilter('technicalName', 'swag_paypal_'));
+
+        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
+        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
+        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
+
+        if (Uuid::isValid($salesChannelId)) {
+            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        }
+
+        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
     }
 }

--- a/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
@@ -39,7 +39,8 @@ class GooglePayCookieProviderTest extends TestCase
         $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
 
         $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
-        $this->requestStack = new RequestStack([$request]);
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push($request);
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void

--- a/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Test\Storefront\Framework\Cookie;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -15,20 +16,30 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
  */
 #[Package('checkout')]
+#[CoversClass(GooglePayCookieProvider::class)]
 class GooglePayCookieProviderTest extends TestCase
 {
     private EntityRepository&MockObject $paymentMethodRepository;
 
+    private RequestStack $requestStack;
+
     protected function setUp(): void
     {
+        $request = new Request();
+        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+
         $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
+        $this->requestStack = new RequestStack([$request]);
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
@@ -39,7 +50,7 @@ class GooglePayCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -54,7 +65,7 @@ class GooglePayCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -66,13 +77,17 @@ class GooglePayCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $searchResult = new IdSearchResult(0, [['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
+        $searchResult = new IdSearchResult(0, ['test-id' => ['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
 
         $this->paymentMethodRepository->expects($cookieAdded ? static::once() : static::never())
             ->method('searchIds')
-            ->willReturn($searchResult);
+            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
+                static::assertCount(3, $criteria->getFilters());
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository))->getCookieGroups();
+                return $searchResult;
+            });
+
+        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
 
         if (!$cookieAdded) {
             static::assertSame($cookies, $result);

--- a/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
@@ -39,7 +39,8 @@ class PayPalCookieProviderTest extends TestCase
         $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
 
         $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
-        $this->requestStack = new RequestStack([$request]);
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push($request);
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void

--- a/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
@@ -7,18 +7,41 @@
 
 namespace Swag\PayPal\Test\Storefront\Framework\Cookie;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
  */
+#[CoversClass(PayPalCookieProvider::class)]
 #[Package('checkout')]
 class PayPalCookieProviderTest extends TestCase
 {
+    private EntityRepository&MockObject $paymentMethodRepository;
+
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $request = new Request();
+        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+
+        $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
+        $this->requestStack = new RequestStack([$request]);
+    }
+
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
     {
         $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
@@ -27,7 +50,7 @@ class PayPalCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -42,7 +65,7 @@ class PayPalCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -54,7 +77,17 @@ class PayPalCookieProviderTest extends TestCase
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock))->getCookieGroups();
+        $searchResult = new IdSearchResult(0, [Uuid::randomHex() => ['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
+
+        $this->paymentMethodRepository->expects($payPalCookieAdded ? static::once() : static::never())
+            ->method('searchIds')
+            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
+                static::assertCount(3, $criteria->getFilters());
+
+                return $searchResult;
+            });
+
+        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
         if (!$payPalCookieAdded) {
             static::assertSame($cookies, $result);
 


### PR DESCRIPTION
- fixes https://github.com/shopware/shopware/issues/4375
- backport of https://github.com/shopware/SwagPayPal/pull/457