### PR TITLE
Added missing throw on new exception

### DIFF
--- a/src/Checkout/SalesChannel/MethodEligibilityRoute.php
+++ b/src/Checkout/SalesChannel/MethodEligibilityRoute.php
@@ -73,7 +73,7 @@ class MethodEligibilityRoute extends AbstractMethodEligibilityRoute
         /** @var array $paymentMethods */
         $paymentMethods = $request->request->all()['paymentMethods'] ?? null;
         if (!\is_array($paymentMethods)) {
-            RoutingException::invalidRequestParameter('paymentMethods');
+            throw RoutingException::invalidRequestParameter('paymentMethods');
         }
 
         $handlers = [];


### PR DESCRIPTION
### 1. Why is this change necessary?
There are multiple warnings in our production logs - `Warning: foreach() argument must be of type array|object, null given`

### 2. What does this change do, exactly?
Fixing typo