### PR TITLE
fix: express checkout sales channel country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where the express checkout could choose a customer country that was not assigned to the correct sales channel (shopware/SwagPayPal#479)
 - Fixes an issue, where cookies are added even though associated payment methods are not active (shopware/SwagPayPal#457)
 - Fixes an issue, where the state of a country was not correctly transmitted to PayPal (shopware/SwagPayPal#469)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Behebt ein Problem, bei dem beim Express-Checkout ein Kundenland ausgewählt werden konnte, das nicht dem richtigen Vertriebskanal zugeordnet war. (shopware/SwagPayPal#479)
+- Behebt ein Problem, bei dem beim Express-Checkout ein Kundenland ausgewählt werden konnte, das nicht dem richtigen Vertriebskanal zugeordnet war (shopware/SwagPayPal#479)
 - Behebt ein Problem, bei dem Cookies geladen wurden, obwohl die zugehörigen Zahlungsarten nicht aktiv sind (shopware/SwagPayPal#457)
 - Behebt ein Problem, bei dem der Bundesstaat nicht korrekt an PayPal übermittelt wurde (shopware/SwagPayPal#469)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem beim Express-Checkout ein Kundenland ausgewählt werden konnte, das nicht dem richtigen Vertriebskanal zugeordnet war. (shopware/SwagPayPal#479)
 - Behebt ein Problem, bei dem Cookies geladen wurden, obwohl die zugehörigen Zahlungsarten nicht aktiv sind (shopware/SwagPayPal#457)
 - Behebt ein Problem, bei dem der Bundesstaat nicht korrekt an PayPal übermittelt wurde (shopware/SwagPayPal#469)
 

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -88,9 +88,9 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
                 );
                 $callbackConfig->setCallbackUrl($callbackUrl);
                 $callbackConfig->setCallbackEvents([OrderUpdateCallbackConfig::CALLBACK_EVENT_SHIPPING_OPTIONS]);
-                $experienceContext->setOrderUpdateCallbackConfig($callbackConfig);
+                // $experienceContext->setOrderUpdateCallbackConfig($callbackConfig);
 
-                $this->logger->debug('Configured shipping callback', ['callbackUrl' => $callbackUrl]);
+                // $this->logger->debug('Configured shipping callback', ['callbackUrl' => $callbackUrl]);
             }
 
             $orderResponse = $this->orderResource->create(

--- a/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\PayPalSDK\Struct\V2\Order;
@@ -50,7 +51,7 @@ class ExpressCustomerService
      */
     public function __construct(
         private readonly AbstractRegisterRoute $registerRoute,
-        private readonly EntityRepository $countryRepository,
+        private readonly SalesChannelRepository $countryRepository,
         private readonly EntityRepository $countryStateRepository,
         private readonly EntityRepository $salutationRepository,
         private readonly EntityRepository $customerRepository,
@@ -214,9 +215,8 @@ class ExpressCustomerService
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('iso', $code));
-        $criteria->addFilter(new EqualsFilter('salesChannels.id', $context->getSalesChannelId()));
 
-        return $this->countryRepository->searchIds($criteria, $context->getContext())->firstId();
+        return $this->countryRepository->searchIds($criteria, $context)->firstId();
     }
 
     private function getCountryStateId(?string $countryId, string $countryCode, ?string $stateCode, Context $context): ?string

--- a/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
@@ -45,43 +45,19 @@ class ExpressCustomerService
         'additionalAddressLine1',
     ];
 
-    private AbstractRegisterRoute $registerRoute;
-
-    private EntityRepository $countryRepository;
-
-    private EntityRepository $countryStateRepository;
-
-    private EntityRepository $salutationRepository;
-
-    private EntityRepository $customerRepository;
-
-    private AccountService $accountService;
-
-    private SystemConfigService $systemConfigService;
-
-    private LoggerInterface $logger;
-
     /**
      * @internal
      */
     public function __construct(
-        AbstractRegisterRoute $registerRoute,
-        EntityRepository $countryRepository,
-        EntityRepository $countryStateRepository,
-        EntityRepository $salutationRepository,
-        EntityRepository $customerRepository,
-        AccountService $accountService,
-        SystemConfigService $systemConfigService,
-        LoggerInterface $logger,
+        private readonly AbstractRegisterRoute $registerRoute,
+        private readonly EntityRepository $countryRepository,
+        private readonly EntityRepository $countryStateRepository,
+        private readonly EntityRepository $salutationRepository,
+        private readonly EntityRepository $customerRepository,
+        private readonly AccountService $accountService,
+        private readonly SystemConfigService $systemConfigService,
+        private readonly LoggerInterface $logger,
     ) {
-        $this->registerRoute = $registerRoute;
-        $this->countryRepository = $countryRepository;
-        $this->countryStateRepository = $countryStateRepository;
-        $this->salutationRepository = $salutationRepository;
-        $this->customerRepository = $customerRepository;
-        $this->accountService = $accountService;
-        $this->systemConfigService = $systemConfigService;
-        $this->logger = $logger;
     }
 
     public function loginCustomer(Order $paypalOrder, SalesChannelContext $salesChannelContext, RequestDataBag $data): string
@@ -164,7 +140,7 @@ class ExpressCustomerService
             'email' => $paypal->getEmailAddress(),
             'firstName' => $paypal->getName()->getGivenName(),
             'lastName' => $paypal->getName()->getSurname(),
-            'billingAddress' => $this->getAddressData($paypalOrder, $salesChannelContext->getContext(), $salutationId),
+            'billingAddress' => $this->getAddressData($paypalOrder, $salesChannelContext, $salutationId),
             'acceptedDataProtection' => true,
             self::EXPRESS_PAYER_ID => $paypal->isset('accountId') ? $paypal->getAccountId() : null,
         ]);
@@ -175,7 +151,7 @@ class ExpressCustomerService
     /**
      * @return array<string, string|null>
      */
-    private function getAddressData(Order $order, Context $context, ?string $salutationId = null): array
+    private function getAddressData(Order $order, SalesChannelContext $context, ?string $salutationId = null): array
     {
         $paypal = $order->getPaymentSource()?->getPaypal();
         if (!$paypal) {
@@ -196,7 +172,7 @@ class ExpressCustomerService
 
         $countryCode = $address->getCountryCode();
         $countryId = $this->getCountryId($countryCode, $context);
-        $countryStateId = $this->getCountryStateId($countryId, $countryCode, $address->getAdminArea1(), $context);
+        $countryStateId = $this->getCountryStateId($countryId, $countryCode, $address->getAdminArea1(), $context->getContext());
         $phone = $paypal->getPhoneNumber();
 
         return [
@@ -234,12 +210,13 @@ class ExpressCustomerService
         return $salutationId;
     }
 
-    private function getCountryId(string $code, Context $context): ?string
+    private function getCountryId(string $code, SalesChannelContext $context): ?string
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('iso', $code));
+        $criteria->addFilter(new EqualsFilter('salesChannels.id', $context->getSalesChannelId()));
 
-        return $this->countryRepository->searchIds($criteria, $context)->firstId();
+        return $this->countryRepository->searchIds($criteria, $context->getContext())->firstId();
     }
 
     private function getCountryStateId(?string $countryId, string $countryCode, ?string $stateCode, Context $context): ?string
@@ -285,7 +262,7 @@ class ExpressCustomerService
     {
         $addressData = $this->getAddressData(
             $paypalOrder,
-            $salesChannelContext->getContext()
+            $salesChannelContext,
         );
 
         $matchingAddress = null;

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -11,7 +11,6 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
@@ -20,6 +19,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\PayPalSDK\Struct\V2\Order;
@@ -34,11 +34,11 @@ class ExpressShippingCallbackService
     /**
      * @internal
      *
-     * @param EntityRepository<CountryCollection> $countryRepository
+     * @param SalesChannelRepository<CountryCollection> $countryRepository
      */
     public function __construct(
         private readonly CartService $cartService,
-        private readonly EntityRepository $countryRepository,
+        private readonly SalesChannelRepository $countryRepository,
         private readonly AbstractOrderBuilder $orderBuilder,
         private readonly ShippingOptionsProvider $shippingOptionsProvider,
         private readonly AbstractContextSwitchRoute $contextSwitchRoute,
@@ -109,7 +109,7 @@ class ExpressShippingCallbackService
             ]))
             ->setLimit(1);
 
-        $country = $this->countryRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
+        $country = $this->countryRepository->search($criteria, $salesChannelContext)->getEntities()->first();
         if (!$country) {
             throw ExpressShippingCallbackException::countryError($callback);
         }

--- a/src/Resources/config/services/express_checkout.xml
+++ b/src/Resources/config/services/express_checkout.xml
@@ -26,7 +26,7 @@
 
         <service id="Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService">
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute"/>
-            <argument type="service" id="country.repository"/>
+            <argument type="service" id="sales_channel.country.repository"/>
             <argument type="service" id="country_state.repository"/>
             <argument type="service" id="salutation.repository"/>
             <argument type="service" id="customer.repository"/>
@@ -46,7 +46,7 @@
 
         <service id="Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService">
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
-            <argument type="service" id="country.repository"/>
+            <argument type="service" id="sales_channel.country.repository"/>
             <argument type="service" id="Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder"/>
             <argument type="service" id="Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -121,13 +121,10 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
         if ($cartService === null) {
             $cartService = $this->getContainer()->get(CartService::class);
         }
-        /** @var EntityRepository $countryRepo */
-        $countryRepo = $this->getContainer()->get('country.repository');
-        /** @var EntityRepository $countryStateRepo */
+
+        $countryRepo = $this->getContainer()->get('sales_channel.country.repository');
         $countryStateRepo = $this->getContainer()->get('country_state.repository');
-        /** @var EntityRepository $salutationRepo */
         $salutationRepo = $this->getContainer()->get('salutation.repository');
-        /** @var EntityRepository $customerRepo */
         $customerRepo = $this->getContainer()->get('customer.repository');
 
         return new ExpressPrepareCheckoutRoute(

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -16,11 +16,15 @@ use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutData;
@@ -49,9 +53,23 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
     public const TEST_PAYMENT_ID_WITH_COUNTRY_WITHOUT_STATES = 'testPaymentIdWithCountryWithoutStates';
     public const TEST_PAYMENT_ID_WITH_STATE_NOT_FOUND = 'testPaymentIdWithStateNotFound';
 
+    protected function setUp(): void
+    {
+        $criteria = (new Criteria())->setLimit(2)->addFilter(new EqualsAnyFilter('iso', ['US', 'NL']));
+        $ids = static::getContainer()->get('country.repository')->searchIds($criteria, Context::createDefaultContext())->getIds();
+
+        $this->getContainer()->get('country.repository')->upsert(\array_map(fn (string $id) => [
+            'id' => $id,
+            'salesChannels' => [['id' => TestDefaults::SALES_CHANNEL]],
+        ], $ids), Context::createDefaultContext());
+    }
+
     public function testPrepare(): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
+        );
+
         $this->getContainer()->get(SystemConfigService::class)->set(
             'core.loginRegistration.requireDataProtectionCheckbox',
             true,
@@ -164,7 +182,9 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
 
     private function assertNoState(string $testPaypalOrderId): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
+        );
 
         $request = new Request([], [
             ExpressPrepareCheckoutRoute::PAYPAL_REQUEST_PARAMETER_TOKEN => $testPaypalOrderId,

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -61,7 +61,7 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
         $this->getContainer()->get('country.repository')->upsert(\array_map(fn (string $id) => [
             'id' => $id,
             'salesChannels' => [['id' => TestDefaults::SALES_CHANNEL]],
-        ], $ids), Context::createDefaultContext());
+        ], \array_values($ids)), Context::createDefaultContext());
     }
 
     public function testPrepare(): void

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -56,10 +56,11 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
     protected function setUp(): void
     {
         $criteria = (new Criteria())->setLimit(2)->addFilter(new EqualsAnyFilter('iso', ['US', 'NL']));
+        /** @var list<string> $ids */
         $ids = static::getContainer()->get('country.repository')->searchIds($criteria, Context::createDefaultContext())->getIds();
 
-        $this->getContainer()->get('country.repository')->upsert(\array_map(fn ($id) => [
-            'id' => (string) $id,
+        $this->getContainer()->get('country.repository')->upsert(\array_map(fn (string $id) => [
+            'id' => $id,
             'salesChannels' => [['id' => TestDefaults::SALES_CHANNEL]],
         ], \array_values($ids)), Context::createDefaultContext());
     }

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -58,8 +58,8 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
         $criteria = (new Criteria())->setLimit(2)->addFilter(new EqualsAnyFilter('iso', ['US', 'NL']));
         $ids = static::getContainer()->get('country.repository')->searchIds($criteria, Context::createDefaultContext())->getIds();
 
-        $this->getContainer()->get('country.repository')->upsert(\array_map(fn (string $id) => [
-            'id' => $id,
+        $this->getContainer()->get('country.repository')->upsert(\array_map(fn ($id) => [
+            'id' => (string) $id,
             'salesChannels' => [['id' => TestDefaults::SALES_CHANNEL]],
         ], \array_values($ids)), Context::createDefaultContext());
     }

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -185,7 +185,7 @@ class ExpressCustomerServiceTest extends TestCase
             Settings::CLIENT_SECRET => 'testClientSecret',
         ]);
         /** @var EntityRepository $countryRepo */
-        $countryRepo = $this->getContainer()->get('country.repository');
+        $countryRepo = $this->getContainer()->get('sales_channel.country.repository');
         /** @var EntityRepository $countryStateRepo */
         $countryStateRepo = $this->getContainer()->get('country_state.repository');
         /** @var EntityRepository $salutationRepo */

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -12,10 +12,13 @@ use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
@@ -39,6 +42,17 @@ class ExpressCustomerServiceTest extends TestCase
     public const TEST_PAYMENT_ID_WITHOUT_STATE = 'testPaymentIdWithoutState';
     public const TEST_PAYMENT_ID_WITH_COUNTRY_WITHOUT_STATES = 'testPaymentIdWithCountryWithoutStates';
     public const TEST_PAYMENT_ID_WITH_STATE_NOT_FOUND = 'testPaymentIdWithStateNotFound';
+
+    protected function setUp(): void
+    {
+        $criteria = (new Criteria())->setLimit(1)->addFilter(new EqualsFilter('iso', 'US'));
+        $usCountryId = static::getContainer()->get('country.repository')->searchIds($criteria, Context::createDefaultContext())->firstId();
+
+        $this->getContainer()->get('country.repository')->upsert([[
+            'id' => $usCountryId,
+            'salesChannels' => [['id' => TestDefaults::SALES_CHANNEL]],
+        ]], Context::createDefaultContext());
+    }
 
     public function testLoginNewCustomer(): void
     {
@@ -134,7 +148,11 @@ class ExpressCustomerServiceTest extends TestCase
 
     private function doLogin(Order $order): CustomerEntity
     {
-        $contextToken = $this->createCustomerService()->loginCustomer($order, $this->getSalesChannelContext(), new RequestDataBag());
+        $context = $this->getContainer()->get(SalesChannelContextService::class)->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
+        );
+
+        $contextToken = $this->createCustomerService()->loginCustomer($order, $context, new RequestDataBag());
 
         $context = $this->getContainer()->get(SalesChannelContextService::class)->get(
             new SalesChannelContextServiceParameters(

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -184,13 +184,10 @@ class ExpressCustomerServiceTest extends TestCase
             Settings::CLIENT_ID => 'testClientId',
             Settings::CLIENT_SECRET => 'testClientSecret',
         ]);
-        /** @var EntityRepository $countryRepo */
+
         $countryRepo = $this->getContainer()->get('sales_channel.country.repository');
-        /** @var EntityRepository $countryStateRepo */
         $countryStateRepo = $this->getContainer()->get('country_state.repository');
-        /** @var EntityRepository $salutationRepo */
         $salutationRepo = $this->getContainer()->get('salutation.repository');
-        /** @var EntityRepository $customerRepo */
         $customerRepo = $this->getContainer()->get('customer.repository');
 
         return new ExpressCustomerService(


### PR DESCRIPTION
fixes #479

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If a country with the same ISO is created multiple times, the `ExpressCustomerService` can choose a country not assigned to the sales channel.

### 2. What does this change do, exactly?
Add a sales channel filter

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- fixes #479 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
