### PR TITLE
fix: disable cookies and script loading when PMs are inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.4.1
+- Fixes an issue, where required cookies were not displayed in the banner even though PayPal scripts had been loaded (shopware/SwagPayPal#506)
+
 # 10.4.0
 - Fixes an issue, where the express checkout could choose a customer country that was not assigned to the correct sales channel (shopware/SwagPayPal#479)
 - Fixes an issue, where cookies are added even though associated payment methods are not active (shopware/SwagPayPal#457)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.4.1
+- Behebt ein Problem, bei dem erforderliche Cookies nicht im Banner angezeigt wurden, obwohl PayPal-Skripte geladen wurden (shopware/SwagPayPal#506)
+
 # 10.4.0
 - Behebt ein Problem, bei dem beim Express-Checkout ein Kundenland ausgewählt werden konnte, das nicht dem richtigen Vertriebskanal zugeordnet war (shopware/SwagPayPal#479)
 - Behebt ein Problem, bei dem Cookies geladen wurden, obwohl die zugehörigen Zahlungsarten nicht aktiv sind (shopware/SwagPayPal#457)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.4.0",
+    "version": "10.4.1",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,13 +121,6 @@ parameters:
 			path: src/Storefront/Data/CheckoutDataSubscriber.php
 
 		-
-			message: '#^Call to internal static method Shopware\\Core\\Framework\\Context\:\:createDefaultContext\(\) from outside its root namespace Shopware\.$#'
-			identifier: staticMethod.internal
-			paths:
-				- src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
-				- src/Storefront/Framework/Cookie/PayPalCookieProvider.php
-
-		-
 			message: '#^Mixed variable in a `\$criteria\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
 			identifier: typePerfect.noMixedMethodCaller
 			count: 1

--- a/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
+++ b/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Checkout\ExpressCheckout;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEvents;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -44,6 +45,7 @@ use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Setting\Settings;
+use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -272,17 +274,12 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
         }
 
         $confirmPage = $event->getPage();
-        $payPalPaymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId($event->getContext());
-        if ($payPalPaymentMethodId === null) {
+        $payPalMethod = $confirmPage->getPaymentMethods()->firstWhere(static fn (PaymentMethodEntity $paymentMethod) => $paymentMethod->getHandlerIdentifier() === PayPalPaymentHandler::class);
+        if (!$payPalMethod) {
             return;
         }
 
-        $paymentMethods = $confirmPage->getPaymentMethods();
-        if ($paymentMethods->has($payPalPaymentMethodId) === false) {
-            return;
-        }
-
-        $filtered = $paymentMethods->filterByProperty('id', $payPalPaymentMethodId);
+        $filtered = $confirmPage->getPaymentMethods()->filterByProperty('id', $payPalMethod->getId());
         $confirmPage->setPaymentMethods($filtered);
         $this->logger->debug('Removed other payment methods from selection for Express Checkout');
     }
@@ -322,13 +319,13 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
 
     private function checkSettings(SalesChannelContext $context, string $eventName): bool
     {
-        if ($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($context) === false) {
+        if ($this->paymentMethodUtil->isPaymentMethodActive($context, [PayPalMethodData::class]) === false) {
             return false;
         }
 
         try {
             $this->settingsValidationService->validate($context->getSalesChannelId());
-        } catch (PayPalSettingsInvalidException $e) {
+        } catch (PayPalSettingsInvalidException) {
             return false;
         }
 

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
@@ -17,6 +17,7 @@ use Swag\PayPal\Checkout\ExpressCheckout\Service\PayPalExpressCheckoutDataServic
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Setting\Settings;
+use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -82,7 +83,7 @@ class ExpressCategoryRoute extends AbstractCategoryRoute
 
     private function checkSettings(SalesChannelContext $context): bool
     {
-        if ($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($context) === false) {
+        if ($this->paymentMethodUtil->isPaymentMethodActive($context, [PayPalMethodData::class]) === false) {
             return false;
         }
 

--- a/src/Installment/Banner/InstallmentBannerSubscriber.php
+++ b/src/Installment/Banner/InstallmentBannerSubscriber.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Installment\Banner;
 
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPage;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoadedEvent;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPage;
@@ -33,6 +34,7 @@ use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Util\Availability\AvailabilityContext;
 use Swag\PayPal\Util\Availability\AvailabilityContextBuilder;
 use Swag\PayPal\Util\Lifecycle\Method\PayLaterMethodData;
+use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -72,13 +74,7 @@ class InstallmentBannerSubscriber implements EventSubscriberInterface
     public function addInstallmentBanner(PageLoadedEvent $pageLoadedEvent): void
     {
         $salesChannelContext = $pageLoadedEvent->getSalesChannelContext();
-        if ($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($salesChannelContext) === false) {
-            return;
-        }
-
-        try {
-            $this->settingsValidationService->validate($salesChannelContext->getSalesChannel()->getId());
-        } catch (PayPalSettingsInvalidException $e) {
+        if (!$this->checkSettings($salesChannelContext)) {
             return;
         }
 
@@ -127,13 +123,7 @@ class InstallmentBannerSubscriber implements EventSubscriberInterface
     public function addInstallmentBannerPagelet(PageletLoadedEvent $pageletLoadedEvent): void
     {
         $salesChannelContext = $pageletLoadedEvent->getSalesChannelContext();
-        if ($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($salesChannelContext) === false) {
-            return;
-        }
-
-        try {
-            $this->settingsValidationService->validate($salesChannelContext->getSalesChannelId());
-        } catch (PayPalSettingsInvalidException $e) {
+        if (!$this->checkSettings($salesChannelContext)) {
             return;
         }
 
@@ -151,6 +141,21 @@ class InstallmentBannerSubscriber implements EventSubscriberInterface
             self::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID,
             $bannerData
         );
+    }
+
+    private function checkSettings(SalesChannelContext $salesChannelContext): bool
+    {
+        if (!$this->paymentMethodUtil->isPaymentMethodActive($salesChannelContext, [PayPalMethodData::class])) {
+            return false;
+        }
+
+        try {
+            $this->settingsValidationService->validate($salesChannelContext->getSalesChannelId());
+        } catch (PayPalSettingsInvalidException) {
+            return false;
+        }
+
+        return true;
     }
 
     private function shouldDisplayPayLaterBanner(Page $page, AvailabilityContext $availabilityContext): bool

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -22,7 +22,7 @@
         </service>
 
         <service id="Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber">
-            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>
@@ -30,14 +30,14 @@
         <service id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider.inner"/>
-            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider.inner"/>
-            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <argument type="service" id="request_stack"/>
         </service>
 
@@ -49,6 +49,7 @@
         <service id="Swag\PayPal\Storefront\Data\FundingSubscriber">
             <argument type="service" id="Swag\PayPal\Setting\Service\SettingsValidationService"/>
             <argument type="service" id="Swag\PayPal\Storefront\Data\Service\FundingEligibilityDataService"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/config/services/util.xml
+++ b/src/Resources/config/services/util.xml
@@ -8,6 +8,7 @@
         <service id="Swag\PayPal\Util\PaymentMethodUtil">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="sales_channel.repository"/>
+            <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
         </service>
 
         <service id="Swag\PayPal\Util\PaymentStatusUtil">

--- a/src/Resources/config/services/util.xml
+++ b/src/Resources/config/services/util.xml
@@ -9,6 +9,8 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="sales_channel.repository"/>
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
+
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="Swag\PayPal\Util\PaymentStatusUtil">

--- a/src/Storefront/Data/FundingSubscriber.php
+++ b/src/Storefront/Data/FundingSubscriber.php
@@ -8,13 +8,17 @@
 namespace Swag\PayPal\Storefront\Data;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
 use Shopware\Storefront\Page\Checkout\Register\CheckoutRegisterPageLoadedEvent;
 use Shopware\Storefront\Page\GenericPageLoadedEvent;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedEvent;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Storefront\Data\Service\FundingEligibilityDataService;
+use Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -25,16 +29,11 @@ class FundingSubscriber implements EventSubscriberInterface
 {
     public const FUNDING_ELIGIBILITY_EXTENSION = 'swagPayPalFundingEligibility';
 
-    private FundingEligibilityDataService $fundingEligibilityDataService;
-
-    private SettingsValidationServiceInterface $settingsValidationService;
-
     public function __construct(
-        SettingsValidationServiceInterface $settingsValidationService,
-        FundingEligibilityDataService $fundingEligibilityDataService,
+        private readonly SettingsValidationServiceInterface $settingsValidationService,
+        private readonly FundingEligibilityDataService $fundingEligibilityDataService,
+        private readonly PaymentMethodUtil $paymentMethodUtil,
     ) {
-        $this->settingsValidationService = $settingsValidationService;
-        $this->fundingEligibilityDataService = $fundingEligibilityDataService;
     }
 
     public static function getSubscribedEvents(): array
@@ -52,13 +51,7 @@ class FundingSubscriber implements EventSubscriberInterface
      */
     public function addFundingAvailabilityDataToFooter(FooterPageletLoadedEvent $event): void
     {
-        try {
-            $this->settingsValidationService->validate($event->getSalesChannelContext()->getSalesChannelId());
-        } catch (PayPalSettingsInvalidException $e) {
-            return;
-        }
-
-        $data = $this->fundingEligibilityDataService->buildData($event->getSalesChannelContext());
+        $data = $this->getFundingEligiblityData($event->getSalesChannelContext());
         if ($data === null) {
             return;
         }
@@ -68,13 +61,7 @@ class FundingSubscriber implements EventSubscriberInterface
 
     public function addFundingAvailabilityDataToPage(GenericPageLoadedEvent $event): void
     {
-        try {
-            $this->settingsValidationService->validate($event->getSalesChannelContext()->getSalesChannelId());
-        } catch (PayPalSettingsInvalidException $e) {
-            return;
-        }
-
-        $data = $this->fundingEligibilityDataService->buildData($event->getSalesChannelContext());
+        $data = $this->getFundingEligiblityData($event->getSalesChannelContext());
         if ($data === null) {
             return;
         }
@@ -85,5 +72,20 @@ class FundingSubscriber implements EventSubscriberInterface
     public function removeFundingAvailabilityDataFromPage(CheckoutConfirmPageLoadedEvent|CheckoutRegisterPageLoadedEvent $event): void
     {
         $event->getPage()->removeExtension(self::FUNDING_ELIGIBILITY_EXTENSION);
+    }
+
+    private function getFundingEligiblityData(SalesChannelContext $salesChannelContext): ?FundingEligibilityData
+    {
+        if (!$this->paymentMethodUtil->isPaymentMethodActive($salesChannelContext, \array_values(MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS))) {
+            return null;
+        }
+
+        try {
+            $this->settingsValidationService->validate($salesChannelContext->getSalesChannelId());
+        } catch (PayPalSettingsInvalidException) {
+            return null;
+        }
+
+        return $this->fundingEligibilityDataService->buildData($salesChannelContext);
     }
 }

--- a/src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
+++ b/src/Storefront/Framework/Cookie/CookieProviderSubscriber.php
@@ -7,16 +7,11 @@
 
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
-use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Content\Cookie\Struct\CookieEntry;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -25,11 +20,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 #[Package('checkout')]
 class CookieProviderSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
-     */
     public function __construct(
-        private readonly EntityRepository $paymentMethodRepository,
+        private readonly PaymentMethodUtil $paymentMethodUtil,
     ) {
     }
 
@@ -50,36 +42,14 @@ class CookieProviderSubscriber implements EventSubscriberInterface
         $payPalCookie = new CookieEntry('paypal-cookie-key');
         $payPalCookie->name = 'paypal.cookie.name';
 
-        if ($this->isGooglePayActive($event->getSalesChannelContext())) {
+        if ($this->paymentMethodUtil->isPaymentMethodActive($event->getSalesChannelContext(), [GooglePayHandler::class])) {
             $googleCookie = new CookieEntry('paypal-google-pay-cookie-key');
             $googleCookie->name = 'paypal.cookie.googlePay';
 
             $entries->add($payPalCookie);
             $entries->add($googleCookie);
-        } elseif ($this->isPayPalPaymentActive($event->getSalesChannelContext())) {
+        } elseif ($this->paymentMethodUtil->isPaymentMethodActive($event->getSalesChannelContext())) {
             $entries->add($payPalCookie);
         }
-    }
-
-    private function isPayPalPaymentActive(SalesChannelContext $salesChannelContext): bool
-    {
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->addFilter(new EqualsFilter('active', true));
-        $criteria->addFilter(new PrefixFilter('technicalName', 'swag_paypal_'));
-        $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelContext->getSalesChannelId()));
-
-        return $this->paymentMethodRepository->searchIds($criteria, $salesChannelContext->getContext())->firstId() !== null;
-    }
-
-    private function isGooglePayActive(SalesChannelContext $salesChannelContext): bool
-    {
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->addFilter(new EqualsFilter('active', true));
-        $criteria->addFilter(new EqualsFilter('handlerIdentifier', GooglePayHandler::class));
-        $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelContext->getSalesChannelId()));
-
-        return $this->paymentMethodRepository->searchIds($criteria, $salesChannelContext->getContext())->firstId() !== null;
     }
 }

--- a/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/GooglePayCookieProvider.php
@@ -8,14 +8,11 @@
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -24,19 +21,16 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[Package('checkout')]
 class GooglePayCookieProvider implements CookieProviderInterface
 {
-    private CookieProviderInterface $original;
-
     /**
      * @internal
      *
      * @deprecated tag:v11.0.0 - Will be removed. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
      */
     public function __construct(
-        CookieProviderInterface $cookieProvider,
-        private readonly EntityRepository $paymentMethodRepository,
+        private CookieProviderInterface $cookieProvider,
+        private readonly PaymentMethodUtil $paymentMethodUtil,
         private readonly RequestStack $requestStack,
     ) {
-        $this->original = $cookieProvider;
     }
 
     /**
@@ -44,7 +38,7 @@ class GooglePayCookieProvider implements CookieProviderInterface
      */
     public function getCookieGroups(): array
     {
-        $cookies = $this->original->getCookieGroups();
+        $cookies = $this->cookieProvider->getCookieGroups();
         if (\class_exists(CookieGroupCollectEvent::class)) {
             return $cookies;
         }
@@ -81,19 +75,11 @@ class GooglePayCookieProvider implements CookieProviderInterface
 
     private function isGooglePayActive(): bool
     {
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->addFilter(new EqualsFilter('active', true));
-        $criteria->addFilter(new EqualsFilter('handlerIdentifier', GooglePayHandler::class));
-
-        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
-        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
-        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
-
-        if (Uuid::isValid($salesChannelId)) {
-            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        $salesChannelContext = $this->requestStack->getMainRequest()?->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+        if (!$salesChannelContext) {
+            return false;
         }
 
-        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
+        return $this->paymentMethodUtil->isPaymentMethodActive($salesChannelContext, [GooglePayHandler::class]);
     }
 }

--- a/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
+++ b/src/Storefront/Framework/Cookie/PayPalCookieProvider.php
@@ -8,14 +8,10 @@
 namespace Swag\PayPal\Storefront\Framework\Cookie;
 
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -33,7 +29,7 @@ class PayPalCookieProvider implements CookieProviderInterface
      */
     public function __construct(
         CookieProviderInterface $cookieProvider,
-        private readonly EntityRepository $paymentMethodRepository,
+        private readonly PaymentMethodUtil $paymentMethodUtil,
         private readonly RequestStack $requestStack,
     ) {
         $this->original = $cookieProvider;
@@ -83,19 +79,11 @@ class PayPalCookieProvider implements CookieProviderInterface
 
     private function isPayPalPaymentActive(): bool
     {
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->addFilter(new EqualsFilter('active', true));
-        $criteria->addFilter(new PrefixFilter('technicalName', 'swag_paypal_'));
-
-        $mainRequestAttributes = $this->requestStack->getMainRequest()?->attributes;
-        $context = $mainRequestAttributes?->get('sw-context') ?? Context::createDefaultContext();
-        $salesChannelId = $mainRequestAttributes?->getString('sw-sales-channel-id') ?? '';
-
-        if (Uuid::isValid($salesChannelId)) {
-            $criteria->addFilter(new EqualsFilter('salesChannels.id', $salesChannelId));
+        $salesChannelContext = $this->requestStack->getMainRequest()?->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+        if (!$salesChannelContext) {
+            return false;
         }
 
-        return $this->paymentMethodRepository->searchIds($criteria, $context)->firstId() !== null;
+        return $this->paymentMethodUtil->isPaymentMethodActive($salesChannelContext);
     }
 }

--- a/src/Util/PaymentMethodUtil.php
+++ b/src/Util/PaymentMethodUtil.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Util;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -20,48 +21,85 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
+use Swag\PayPal\Util\Lifecycle\Method\AbstractMethodData;
+use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
+use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('checkout')]
 class PaymentMethodUtil implements ResetInterface
 {
-    private EntityRepository $salesChannelRepository;
-
-    private Connection $connection;
-
     /**
-     * @var array<class-string, string>
+     * @var array<class-string, string> - array<handlerIdentifier, paymentMethodId>
      */
     private ?array $paymentMethodIds = null;
 
     /**
-     * @var string[]
+     * @var array<string, array<string, string>> - array<salesChannelId, array<handlerIdentifier, paymentMethodId>>
      */
-    private ?array $salesChannels = null;
+    private array $salesChannels = [];
 
     /**
      * @internal
+     *
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
-        Connection $connection,
-        EntityRepository $salesChannelRepository,
+        private readonly Connection $connection,
+        private readonly EntityRepository $salesChannelRepository,
+        private readonly PaymentMethodDataRegistry $paymentMethodDataRegistry,
     ) {
-        $this->connection = $connection;
-        $this->salesChannelRepository = $salesChannelRepository;
+    }
+
+    /**
+     * Checks if a payment method is active for a given sales channel (context).
+     * This does not mean that the payment method is available in the sense of the {@see AvailabilityContext}.
+     *
+     * @param array<string|AbstractMethodData|PaymentMethodEntity>|null $handlerIdentifier - If `null` given, all PayPal handlers will be considered
+     */
+    public function isPaymentMethodActive(SalesChannelContext $salesChannelContext, ?array $handlerIdentifier = null): bool
+    {
+        $handlerIdentifier ??= $this->paymentMethodDataRegistry->getPaymentHandlers();
+
+        if (!$handlerIdentifier) {
+            return false;
+        }
+
+        $handlerIdentifier = \array_map($this->intoHandlerIdentifier(...), $handlerIdentifier);
+        $handlerIdentifier = \array_flip($handlerIdentifier);
+
+        if ($paymentMethods = $salesChannelContext->getSalesChannel()->getPaymentMethods()) {
+            return (bool) $paymentMethods->firstWhere(static fn (PaymentMethodEntity $pm) => $pm->getActive() && isset($handlerIdentifier[$pm->getHandlerIdentifier()]));
+        }
+
+        $paymentMethodIds = $this->getAllPaymentMethodIdsPerSalesChannel($salesChannelContext->getSalesChannelId());
+        foreach ($handlerIdentifier as $hi => $_) {
+            if (isset($paymentMethodIds[$hi])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getPaymentMethodId(string|AbstractMethodData $handlerIdentifier): ?string
+    {
+        return $this->getAllPaymentMethodIds()[$this->intoHandlerIdentifier($handlerIdentifier)] ?? null;
     }
 
     public function getPayPalPaymentMethodId(Context $context): ?string
     {
-        return $this->getPaymentMethodIdByHandler(PayPalPaymentHandler::class);
+        return $this->getPaymentMethodId(PayPalPaymentHandler::class);
     }
 
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed and is replaced by {@see self::isPaymentMethodActive}
+     */
     public function isPaypalPaymentMethodInSalesChannel(
         SalesChannelContext $salesChannelContext,
         ?PaymentMethodCollection $paymentMethods = null,
     ): bool {
-        $context = $salesChannelContext->getContext();
-        $paypalPaymentMethodId = $this->getPayPalPaymentMethodId($context);
-        if (!$paypalPaymentMethodId) {
+        if (!($paypalPaymentMethodId = $this->getPayPalPaymentMethodId($salesChannelContext->getContext()))) {
             return false;
         }
 
@@ -69,56 +107,23 @@ class PaymentMethodUtil implements ResetInterface
             return $paymentMethods->has($paypalPaymentMethodId);
         }
 
-        $paymentMethods = $salesChannelContext->getSalesChannel()->getPaymentMethods();
-        if ($paymentMethods !== null) {
-            return $paymentMethods->filterByProperty('active', true)->has($paypalPaymentMethodId);
-        }
-
-        if ($this->salesChannels === null) {
-            // skip repository for performance reasons
-            $salesChannels = $this->connection->fetchFirstColumn(
-                'SELECT LOWER(HEX(assoc.`sales_channel_id`))
-                FROM `sales_channel_payment_method` AS assoc
-                    LEFT JOIN `payment_method` AS pm
-                        ON pm.`id` = assoc.`payment_method_id`
-                WHERE
-                    assoc.`payment_method_id` = ? AND
-                    pm.`active` = 1',
-                [Uuid::fromHexToBytes($paypalPaymentMethodId)]
-            );
-
-            $this->salesChannels = $salesChannels;
-        }
-
-        return \in_array($salesChannelContext->getSalesChannelId(), $this->salesChannels, true);
+        return $this->isPaymentMethodActive($salesChannelContext, [PayPalMethodData::class]);
     }
 
     public function setPayPalAsDefaultPaymentMethod(Context $context, ?string $salesChannelId): void
     {
-        $payPalPaymentMethodId = $this->getPayPalPaymentMethodId($context);
-        if ($payPalPaymentMethodId === null) {
+        if (!($payPalPaymentMethodId = $this->getPayPalPaymentMethodId($context))) {
             return;
         }
 
         $salesChannelsToChange = $this->getSalesChannelsToChange($context, $salesChannelId);
-        $updateData = [];
-
-        /** @var SalesChannelEntity $salesChannel */
-        foreach ($salesChannelsToChange as $salesChannel) {
-            $salesChannelUpdateData = [
-                'id' => $salesChannel->getId(),
-                'paymentMethodId' => $payPalPaymentMethodId,
-            ];
-
-            $paymentMethodCollection = $salesChannel->getPaymentMethods();
-            if ($paymentMethodCollection === null || $paymentMethodCollection->get($payPalPaymentMethodId) === null) {
-                $salesChannelUpdateData['paymentMethods'][] = [
-                    'id' => $payPalPaymentMethodId,
-                ];
-            }
-
-            $updateData[] = $salesChannelUpdateData;
-        }
+        $updateData = \array_values($salesChannelsToChange->map(static fn (SalesChannelEntity $salesChannel) => [
+            'id' => $salesChannel->getId(),
+            'paymentMethodId' => $payPalPaymentMethodId,
+            ...($salesChannel->getPaymentMethods()?->get($payPalPaymentMethodId) ? [] : [
+                'paymentMethods' => [['id' => $payPalPaymentMethodId]],
+            ]),
+        ]));
 
         $this->salesChannelRepository->update($updateData, $context);
     }
@@ -126,19 +131,7 @@ class PaymentMethodUtil implements ResetInterface
     public function reset(): void
     {
         $this->paymentMethodIds = null;
-        $this->salesChannels = null;
-    }
-
-    private function getPaymentMethodIdByHandler(string $handlerIdentifier): ?string
-    {
-        if ($this->paymentMethodIds === null) {
-            /** @var array<class-string, string> $ids */
-            $ids = $this->connection->fetchAllKeyValue('SELECT `handler_identifier`, LOWER(HEX(`id`)) FROM `payment_method`');
-
-            $this->paymentMethodIds = $ids;
-        }
-
-        return $this->paymentMethodIds[$handlerIdentifier] ?? null;
+        $this->salesChannels = [];
     }
 
     private function getSalesChannelsToChange(Context $context, ?string $salesChannelId): SalesChannelCollection
@@ -157,9 +150,39 @@ class PaymentMethodUtil implements ResetInterface
 
         $criteria->addAssociation('paymentMethods');
 
-        /** @var SalesChannelCollection $collection */
-        $collection = $this->salesChannelRepository->search($criteria, $context)->getEntities();
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
+    }
 
-        return $collection;
+    private function intoHandlerIdentifier(string|AbstractMethodData|PaymentMethodEntity $pm): string
+    {
+        return match (true) {
+            $pm instanceof PaymentMethodEntity => $pm->getHandlerIdentifier(),
+            $pm instanceof AbstractMethodData => $pm->getHandler(),
+            \is_a($pm, AbstractMethodData::class, true) => $this->paymentMethodDataRegistry->getPaymentMethod($pm)->getHandler(),
+            default => $pm,
+        };
+    }
+
+    /**
+     * @return array<string, string> - array<handlerIdentifier, paymentMethodId>
+     */
+    private function getAllPaymentMethodIdsPerSalesChannel(string $salesChannelId): array
+    {
+        // get all active sales channel payment method ids mapped by their handler identifier
+        return $this->salesChannels[$salesChannelId] ??= $this->connection->fetchAllKeyValue(
+            'SELECT pm.`handler_identifier`, LOWER(HEX(sc_pm.`payment_method_id`))
+                FROM `sales_channel_payment_method` AS sc_pm
+                LEFT JOIN `payment_method` AS pm ON pm.`id` = sc_pm.`payment_method_id`
+                WHERE sc_pm.`sales_channel_id` = ? AND pm.`active` = 1',
+            [Uuid::fromHexToBytes($salesChannelId)]
+        );
+    }
+
+    /**
+     * @return array<string, string> - array<handlerIdentifier, paymentMethodId>
+     */
+    private function getAllPaymentMethodIds(): array
+    {
+        return $this->paymentMethodIds ??= $this->connection->fetchAllKeyValue('SELECT `handler_identifier`, LOWER(HEX(`id`)) FROM `payment_method`');
     }
 }

--- a/tests/Administration/PayPalPaymentMethodControllerTest.php
+++ b/tests/Administration/PayPalPaymentMethodControllerTest.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\Test\Administration;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -17,6 +18,7 @@ use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
 use Swag\PayPal\Test\Mock\Repositories\PaymentMethodRepoMock;
 use Swag\PayPal\Test\Mock\Repositories\SalesChannelRepoMock;
 use Swag\PayPal\Test\Util\PaymentMethodUtilTest;
+use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,30 +29,41 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('checkout')]
 class PayPalPaymentMethodControllerTest extends TestCase
 {
+    private SalesChannelRepoMock $salesChannelRepo;
+
+    private MockObject&Connection $connection;
+
+    private PayPalPaymentMethodController $payPalPaymentMethodController;
+
+    protected function setUp(): void
+    {
+        $this->payPalPaymentMethodController = new PayPalPaymentMethodController(
+            new PaymentMethodUtil(
+                $this->connection = $this->createMock(Connection::class),
+                $this->salesChannelRepo = new SalesChannelRepoMock(),
+                $this->createMock(PaymentMethodDataRegistry::class),
+            ),
+        );
+    }
+
     public function testSetPayPalPaymentMethodAsSalesChannelDefault(): void
     {
-        $salesChannelRepoMock = new SalesChannelRepoMock();
-
-        $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
+        $this->connection->expects($this->once())
             ->method('fetchAllKeyValue')
             ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
-        $paymentMethodUtil = new PaymentMethodUtil($connection, $salesChannelRepoMock);
+
         $context = Context::createDefaultContext();
 
-        $response = $this->createPayPalPaymentMethodController($salesChannelRepoMock, $paymentMethodUtil)
-            ->setPayPalPaymentMethodAsSalesChannelDefault(new Request(), $context);
+        $response = $this->payPalPaymentMethodController->setPayPalPaymentMethodAsSalesChannelDefault(new Request(), $context);
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
-        $updates = $salesChannelRepoMock->getUpdateData();
+        $updates = $this->salesChannelRepo->getUpdateData();
         static::assertCount(1, $updates);
         $updateData = $updates[0];
         static::assertArrayHasKey('id', $updateData);
         static::assertSame(PaymentMethodUtilTest::SALESCHANNEL_WITHOUT_PAYPAL_PAYMENT_METHOD, $updateData['id']);
         static::assertArrayHasKey('paymentMethodId', $updateData);
-        $payPalPaymentMethodId = $paymentMethodUtil->getPayPalPaymentMethodId($context);
-        static::assertNotNull($payPalPaymentMethodId);
-        static::assertSame($payPalPaymentMethodId, $updateData['paymentMethodId']);
+        static::assertSame(PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID, $updateData['paymentMethodId']);
     }
 
     public function testSetPayPalPaymentMethodInvalidParameter(): void
@@ -60,20 +73,6 @@ class PayPalPaymentMethodControllerTest extends TestCase
 
         $this->expectException(RoutingException::class);
         $this->expectExceptionMessage('The parameter "salesChannelId" is invalid.');
-        $this->createPayPalPaymentMethodController()->setPayPalPaymentMethodAsSalesChannelDefault($request, $context);
-    }
-
-    private function createPayPalPaymentMethodController(
-        ?SalesChannelRepoMock $salesChannelRepoMock = null,
-        ?PaymentMethodUtil $paymentMethodUtil = null,
-    ): PayPalPaymentMethodController {
-        if ($salesChannelRepoMock === null) {
-            $salesChannelRepoMock = new SalesChannelRepoMock();
-        }
-        if ($paymentMethodUtil === null) {
-            $paymentMethodUtil = new PaymentMethodUtil($this->createMock(Connection::class), $salesChannelRepoMock);
-        }
-
-        return new PayPalPaymentMethodController($paymentMethodUtil);
+        $this->payPalPaymentMethodController->setPayPalPaymentMethodAsSalesChannelDefault($request, $context);
     }
 }

--- a/tests/Helper/CheckoutRouteTrait.php
+++ b/tests/Helper/CheckoutRouteTrait.php
@@ -7,7 +7,6 @@
 
 namespace Swag\PayPal\Test\Helper;
 
-use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
@@ -65,9 +64,7 @@ trait CheckoutRouteTrait
         $container = $this->getContainer();
         /** @var EntityRepository $salesChannelRepo */
         $salesChannelRepo = $container->get('sales_channel.repository');
-        /** @var Connection $connection */
-        $connection = $container->get(Connection::class);
-        $paymentMethodUtil = new PaymentMethodUtil($connection, $salesChannelRepo);
+        $paymentMethodUtil = $container->get(PaymentMethodUtil::class);
 
         $salesChannelId = TestDefaults::SALES_CHANNEL;
         $countryId = $this->getValidCountryId();

--- a/tests/Installment/Banner/InstallmentBannerSubscriberTest.php
+++ b/tests/Installment/Banner/InstallmentBannerSubscriberTest.php
@@ -110,7 +110,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerPayPalNotInSalesChannel(): void
     {
         $event = $this->createCheckoutCartPageLoadedEvent(false);
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(false);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(false);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
 
@@ -120,7 +120,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerInvalidSettings(): void
     {
         $event = $this->createCheckoutCartPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::CLIENT_ID => null,
@@ -133,7 +133,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerCheckoutCartDisabled(): void
     {
         $event = $this->createCheckoutCartPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::INSTALLMENT_BANNER_CART_ENABLED => false,
@@ -148,7 +148,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerCheckoutCart(): void
     {
         $event = $this->createCheckoutCartPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
 
@@ -171,7 +171,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerCheckoutCartExcludedProduct(): void
     {
         $event = $this->createCheckoutCartPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
         $this->excludedProductValidator->expects($this->once())->method('cartContainsExcludedProduct')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
@@ -182,7 +182,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerOffCanvasCartDisabled(): void
     {
         $event = $this->createOffCanvasCartPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::INSTALLMENT_BANNER_OFF_CANVAS_CART_ENABLED => false,
@@ -197,7 +197,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerProductPage(): void
     {
         $event = $this->createProductPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
 
@@ -211,7 +211,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerProductPageDisabled(): void
     {
         $event = $this->createProductPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::INSTALLMENT_BANNER_DETAIL_PAGE_ENABLED => false,
@@ -226,7 +226,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerProductPageExcludedProduct(): void
     {
         $event = $this->createProductPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
         $this->excludedProductValidator->expects($this->once())->method('isProductExcluded')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
@@ -237,7 +237,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerProductPageWithAdvancedPrices(): void
     {
         $event = $this->createProductPageLoadedEvent(true);
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBanner($event);
 
@@ -251,7 +251,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerFooterPayPalNotInSalesChannel(): void
     {
         $event = $this->createFooterPageletLoadedEvent(false);
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(false);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(false);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBannerPagelet($event);
 
@@ -261,7 +261,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerFooterInvalidSettings(): void
     {
         $event = $this->createFooterPageletLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::CLIENT_ID => null,
@@ -274,7 +274,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerFooterDisabled(): void
     {
         $event = $this->createFooterPageletLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::INSTALLMENT_BANNER_FOOTER_ENABLED => false,
@@ -289,7 +289,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerFooterPagelet(): void
     {
         $event = $this->createFooterPageletLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber()->addInstallmentBannerPagelet($event);
 
@@ -303,7 +303,7 @@ class InstallmentBannerSubscriberTest extends TestCase
     public function testAddInstallmentBannerAccountLoginPageDisabled(): void
     {
         $event = $this->createCheckoutRegisterPageLoadedEvent();
-        $this->paymentMethodUtil->expects($this->once())->method('isPaypalPaymentMethodInSalesChannel')->willReturn(true);
+        $this->paymentMethodUtil->expects($this->once())->method('isPaymentMethodActive')->willReturn(true);
 
         $this->createInstallmentBannerSubscriber([
             Settings::INSTALLMENT_BANNER_LOGIN_PAGE_ENABLED => false,

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
 use Shopware\PayPalSDK\Struct\ConstantsV2;
@@ -107,6 +108,18 @@ class FundingSubscriberTest extends TestCase
         static::assertFalse($event->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
+    public function testAddFundingAvailabilityDataToPageNoActivePaymentMethods(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+        $subscriber = $this->createSubscriber($systemConfigService, false);
+        $event = $this->createGenericPageLoadedEvent();
+        $subscriber->addFundingAvailabilityDataToPage($event);
+
+        static::assertFalse($event->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
+    }
+
     public function testAddFundingAvailabilityDataToPage(): void
     {
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
@@ -185,7 +198,7 @@ class FundingSubscriberTest extends TestCase
         static::assertFalse($registerEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
-    private function createSubscriber(SystemConfigService $systemConfig): FundingSubscriber
+    private function createSubscriber(SystemConfigService $systemConfig, bool $paymentMethodsActive = true): FundingSubscriber
     {
         $credentialsUtil = new CredentialsUtil($systemConfig);
 
@@ -202,6 +215,12 @@ class FundingSubscriberTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->method('isPaymentMethodActive')
+            ->with(static::isInstanceOf(SalesChannelContext::class), \array_values(MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS))
+            ->willReturn($paymentMethodsActive);
+
         return new FundingSubscriber(
             new SettingsValidationService($systemConfig, new NullLogger()),
             new FundingEligibilityDataService(
@@ -211,7 +230,7 @@ class FundingSubscriberTest extends TestCase
                 $router,
                 $requestStack
             ),
-            $this->createMock(PaymentMethodUtil::class),
+            $paymentMethodUtil,
         );
     }
 

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -34,6 +34,7 @@ use Swag\PayPal\Storefront\Data\Service\FundingEligibilityDataService;
 use Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData;
 use Swag\PayPal\Test\Mock\Setting\Service\SystemConfigServiceMock;
 use Swag\PayPal\Util\LocaleCodeProvider;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -209,7 +210,8 @@ class FundingSubscriberTest extends TestCase
                 $localeCodeProvider,
                 $router,
                 $requestStack
-            )
+            ),
+            $this->createMock(PaymentMethodUtil::class),
         );
     }
 

--- a/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+++ b/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
@@ -15,15 +15,12 @@ use Shopware\Core\Content\Cookie\Struct\CookieEntry;
 use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
 use Shopware\Core\Content\Cookie\Struct\CookieGroup;
 use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\Payment\Method\GooglePayHandler;
 use Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -50,7 +47,12 @@ class CookieProviderSubscriberTest extends TestCase
             static::markTestSkipped('CookieGroupCollectEvent does not exist');
         }
 
-        (new CookieProviderSubscriber($this->createMock(EntityRepository::class)))
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->expects($this->never())
+            ->method('isPaymentMethodActive');
+
+        (new CookieProviderSubscriber($paymentMethodUtil))
             ->onCookieGroupCollect(new CookieGroupCollectEvent(
                 $cookieGroupCollection,
                 new Request(),
@@ -95,7 +97,13 @@ class CookieProviderSubscriberTest extends TestCase
         $groupCollection = new CookieGroupCollection();
         $groupCollection->add($group);
 
-        (new CookieProviderSubscriber($this->createMock(EntityRepository::class)))
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->expects($this->exactly(2))
+            ->method('isPaymentMethodActive')
+            ->willReturn(false);
+
+        (new CookieProviderSubscriber($paymentMethodUtil))
             ->onCookieGroupCollect(new CookieGroupCollectEvent(
                 $groupCollection,
                 new Request(),
@@ -122,13 +130,14 @@ class CookieProviderSubscriberTest extends TestCase
         $groupCollection = new CookieGroupCollection();
         $groupCollection->add($group);
 
-        $repository = $this->createMock(EntityRepository::class);
-        $repository
-            ->expects($this->once())
-            ->method('searchIds')
-            ->willReturn(new IdSearchResult(1, [Uuid::randomHex() => ['primaryKey' => 'token-id', 'data' => []]], new Criteria(), Context::createCLIContext()));
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->expects($this->exactly(1))
+            ->method('isPaymentMethodActive')
+            ->with(static::isInstanceOf(SalesChannelContext::class), [GooglePayHandler::class])
+            ->willReturn(true);
 
-        (new CookieProviderSubscriber($repository))
+        (new CookieProviderSubscriber($paymentMethodUtil))
             ->onCookieGroupCollect(new CookieGroupCollectEvent(
                 $groupCollection,
                 new Request(),
@@ -158,16 +167,16 @@ class CookieProviderSubscriberTest extends TestCase
         $groupCollection = new CookieGroupCollection();
         $groupCollection->add($group);
 
-        $repository = $this->createMock(EntityRepository::class);
-        $repository
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
             ->expects($this->exactly(2))
-            ->method('searchIds')
-            ->willReturnOnConsecutiveCalls(
-                new IdSearchResult(0, [], new Criteria(), Context::createCLIContext()),
-                new IdSearchResult(1, [Uuid::randomHex() => ['primaryKey' => 'token-id', 'data' => []]], new Criteria(), Context::createCLIContext())
-            );
+            ->method('isPaymentMethodActive')
+            ->willReturnCallback(static function (SalesChannelContext $context, array $handlers) {
+                // GooglePayHandler is checked first
+                return \count($handlers) > 1;
+            });
 
-        (new CookieProviderSubscriber($repository))
+        (new CookieProviderSubscriber($paymentMethodUtil))
             ->onCookieGroupCollect(new CookieGroupCollectEvent(
                 $groupCollection,
                 new Request(),

--- a/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
+++ b/tests/Storefront/Framework/Cookie/CookieProviderSubscriberTest.php
@@ -171,9 +171,9 @@ class CookieProviderSubscriberTest extends TestCase
         $paymentMethodUtil
             ->expects($this->exactly(2))
             ->method('isPaymentMethodActive')
-            ->willReturnCallback(static function (SalesChannelContext $context, array $handlers) {
+            ->willReturnCallback(static function (SalesChannelContext $context, ?array $handlers = null) {
                 // GooglePayHandler is checked first
-                return \count($handlers) > 1;
+                return $handlers === null;
             });
 
         (new CookieProviderSubscriber($paymentMethodUtil))

--- a/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/GooglePayCookieProviderTest.php
@@ -12,14 +12,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\GooglePayCookieProvider;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -32,17 +30,22 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[CoversClass(GooglePayCookieProvider::class)]
 class GooglePayCookieProviderTest extends TestCase
 {
-    private EntityRepository&MockObject $paymentMethodRepository;
+    private CookieProviderInterface&MockObject $cookieProvider;
 
-    private RequestStack $requestStack;
+    private PaymentMethodUtil&MockObject $paymentMethodUtil;
+
+    private GooglePayCookieProvider $googlePayCookieProvider;
 
     protected function setUp(): void
     {
         $request = new Request();
-        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, Generator::generateSalesChannelContext());
 
-        $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
-        $this->requestStack = new RequestStack([$request]);
+        $this->googlePayCookieProvider = new GooglePayCookieProvider(
+            $this->cookieProvider = $this->createMock(CookieProviderInterface::class),
+            $this->paymentMethodUtil = $this->createMock(PaymentMethodUtil::class),
+            new RequestStack([$request]),
+        );
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
@@ -51,13 +54,12 @@ class GooglePayCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [];
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->googlePayCookieProvider->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -67,16 +69,15 @@ class GooglePayCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [
             'snippet_name' => 'cookie.example.name',
             'cookie' => 'example-cookie-key',
         ];
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->googlePayCookieProvider->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -87,22 +88,16 @@ class GooglePayCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $searchResult = new IdSearchResult(0, ['test-id' => ['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
+        $this->paymentMethodUtil
+            ->expects($cookieAdded ? $this->once() : $this->never())
+            ->method('isPaymentMethodActive')
+            ->willReturn(true);
 
-        $this->paymentMethodRepository->expects($cookieAdded ? $this->once() : $this->never())
-            ->method('searchIds')
-            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
-                static::assertCount(3, $criteria->getFilters());
-
-                return $searchResult;
-            });
-
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->googlePayCookieProvider->getCookieGroups();
 
         if (!$cookieAdded) {
             static::assertSame($cookies, $result);
@@ -193,12 +188,11 @@ class GooglePayCookieProviderTest extends TestCase
             'entries' => [],
         ];
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new GooglePayCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->googlePayCookieProvider->getCookieGroups();
 
         static::assertSame($cookies, $result);
     }

--- a/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
+++ b/tests/Storefront/Framework/Cookie/PayPalCookieProviderTest.php
@@ -12,14 +12,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
-use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 use Swag\PayPal\Storefront\Framework\Cookie\PayPalCookieProvider;
+use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -32,17 +30,22 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[Package('checkout')]
 class PayPalCookieProviderTest extends TestCase
 {
-    private EntityRepository&MockObject $paymentMethodRepository;
+    private CookieProviderInterface&MockObject $cookieProvider;
 
-    private RequestStack $requestStack;
+    private PaymentMethodUtil&MockObject $paymentMethodUtil;
+
+    private PayPalCookieProvider $payPalCookieProvider;
 
     protected function setUp(): void
     {
         $request = new Request();
-        $request->attributes->set('sw-sales-channel-id', Uuid::randomHex());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, Generator::generateSalesChannelContext());
 
-        $this->paymentMethodRepository = $this->createMock(EntityRepository::class);
-        $this->requestStack = new RequestStack([$request]);
+        $this->payPalCookieProvider = new PayPalCookieProvider(
+            $this->cookieProvider = $this->createMock(CookieProviderInterface::class),
+            $this->paymentMethodUtil = $this->createMock(PaymentMethodUtil::class),
+            new RequestStack([$request]),
+        );
     }
 
     public function testGetCookieGroupsWithEmptyOriginalCookiesReturnsOriginalCookies(): void
@@ -51,13 +54,12 @@ class PayPalCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [];
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->payPalCookieProvider->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -67,16 +69,15 @@ class PayPalCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
         $cookies = [
             'snippet_name' => 'cookie.example.name',
             'cookie' => 'example-cookie-key',
         ];
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->payPalCookieProvider->getCookieGroups();
         static::assertSame($cookies, $result);
     }
 
@@ -87,22 +88,16 @@ class PayPalCookieProviderTest extends TestCase
             static::markTestSkipped('Deprecated. Logic moved to Swag\PayPal\Storefront\Framework\Cookie\CookieProviderSubscriber');
         }
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $searchResult = new IdSearchResult(0, [Uuid::randomHex() => ['primaryKey' => 'test-id', 'data' => []]], new Criteria(), Context::createDefaultContext());
+        $this->paymentMethodUtil
+            ->expects($payPalCookieAdded ? $this->once() : $this->never())
+            ->method('isPaymentMethodActive')
+            ->willReturn(true);
 
-        $this->paymentMethodRepository->expects($payPalCookieAdded ? $this->once() : $this->never())
-            ->method('searchIds')
-            ->willReturnCallback(static function (Criteria $criteria) use ($searchResult) {
-                static::assertCount(3, $criteria->getFilters());
-
-                return $searchResult;
-            });
-
-        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->payPalCookieProvider->getCookieGroups();
         if (!$payPalCookieAdded) {
             static::assertSame($cookies, $result);
 
@@ -124,8 +119,7 @@ class PayPalCookieProviderTest extends TestCase
     public static function dataTestGetCookieGroupsWithRequiredCookieGroup(): array
     {
         return [
-            // Matching snippet name, missing is required flag
-            [
+            'Matching snippet name, missing is required flag' => [
                 [
                     [
                         'snippet_name' => 'cookie.groupRequired',
@@ -135,8 +129,7 @@ class PayPalCookieProviderTest extends TestCase
                 false,
             ],
 
-            // Matching snippet name, required flag false
-            [
+            'Matching snippet name, required flag false' => [
                 [
                     [
                         'isRequired' => false,
@@ -147,8 +140,7 @@ class PayPalCookieProviderTest extends TestCase
                 false,
             ],
 
-            // Required flag, wrong snippet name
-            [
+            'Required flag, wrong snippet name' => [
                 [
                     [
                         'isRequired' => true,
@@ -159,8 +151,7 @@ class PayPalCookieProviderTest extends TestCase
                 false,
             ],
 
-            // With required group, without entries
-            [
+            'With required group, without entries' => [
                 [
                     [
                         'isRequired' => true,
@@ -171,8 +162,7 @@ class PayPalCookieProviderTest extends TestCase
                 false,
             ],
 
-            // With required group, with entries
-            [
+            'With required group, with entries' => [
                 [
                     [
                         'isRequired' => true,
@@ -199,12 +189,11 @@ class PayPalCookieProviderTest extends TestCase
             'entries' => [],
         ];
 
-        $cookieProviderMock = $this->getMockBuilder(CookieProviderInterface::class)->getMock();
-        $cookieProviderMock->expects($this->once())
+        $this->cookieProvider->expects($this->once())
             ->method('getCookieGroups')
             ->willReturn($cookies);
 
-        $result = (new PayPalCookieProvider($cookieProviderMock, $this->paymentMethodRepository, $this->requestStack))->getCookieGroups();
+        $result = $this->payPalCookieProvider->getCookieGroups();
 
         static::assertSame($cookies, $result);
     }

--- a/tests/Util/PaymentMethodUtilTest.php
+++ b/tests/Util/PaymentMethodUtilTest.php
@@ -43,7 +43,6 @@ class PaymentMethodUtilTest extends TestCase
     protected function setUp(): void
     {
         $this->paymentMethodUtil = static::getContainer()->get(PaymentMethodUtil::class);
-        $this->paymentMethodUtil->reset();
         $this->paymentMethodDataRegistry = static::getContainer()->get(PaymentMethodDataRegistry::class);
     }
 

--- a/tests/Util/PaymentMethodUtilTest.php
+++ b/tests/Util/PaymentMethodUtilTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -82,7 +83,7 @@ class PaymentMethodUtilTest extends TestCase
 
     public function testIsPaymentMethodActiveWithoutAssignedPaymentMethods(): void
     {
-        $paypalPaymentMethods = $this->getSalesChannelPaymentMethods()->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal'));
+        $paypalPaymentMethods = $this->getSalesChannelPaymentMethods()->filter(fn (PaymentMethodEntity $pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal'));
 
         static::assertCount(0, $paypalPaymentMethods);
 
@@ -95,7 +96,7 @@ class PaymentMethodUtilTest extends TestCase
 
         $scPaymentMethods = $this->getSalesChannelPaymentMethods();
 
-        static::assertCount(17, $scPaymentMethods->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')));
+        static::assertCount(17, $scPaymentMethods->filter(fn (PaymentMethodEntity $pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')));
 
         static::assertFalse($this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), null));
     }
@@ -108,7 +109,7 @@ class PaymentMethodUtilTest extends TestCase
 
         static::assertCount(
             \count($this->paymentMethodDataRegistry->getPaymentMethods()),
-            $scPaymentMethods->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')),
+            $scPaymentMethods->filter(fn (PaymentMethodEntity $pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')),
         );
 
         foreach ($this->paymentMethodDataRegistry->getPaymentMethods() as $methodData) {

--- a/tests/Util/PaymentMethodUtilTest.php
+++ b/tests/Util/PaymentMethodUtilTest.php
@@ -7,17 +7,22 @@
 
 namespace Swag\PayPal\Test\Util;
 
-use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
-use Swag\PayPal\Test\Mock\Repositories\PaymentMethodRepoMock;
-use Swag\PayPal\Test\Mock\Repositories\SalesChannelRepoMock;
+use Swag\PayPal\Util\Lifecycle\Method\AbstractMethodData;
+use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
+use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 
 /**
@@ -26,146 +31,210 @@ use Swag\PayPal\Util\PaymentMethodUtil;
 #[Package('checkout')]
 class PaymentMethodUtilTest extends TestCase
 {
+    use IntegrationTestBehaviour;
+
     public const SALESCHANNEL_WITHOUT_PAYPAL_PAYMENT_METHOD = '4ce46b49d1904a5db0b41573e9355b51';
 
     private PaymentMethodUtil $paymentMethodUtil;
 
-    private SalesChannelRepoMock $salesChannelRepoMock;
-
-    /**
-     * @var Connection&MockObject
-     */
-    private Connection $connectionMock;
+    private PaymentMethodDataRegistry $paymentMethodDataRegistry;
 
     protected function setUp(): void
     {
-        parent::setUp();
-        $this->salesChannelRepoMock = new SalesChannelRepoMock();
-        $this->connectionMock = $this->createMock(Connection::class);
-        $this->paymentMethodUtil = new PaymentMethodUtil(
-            $this->connectionMock,
-            $this->salesChannelRepoMock
-        );
+        $this->paymentMethodUtil = static::getContainer()->get(PaymentMethodUtil::class);
+        $this->paymentMethodUtil->reset();
+        $this->paymentMethodDataRegistry = static::getContainer()->get(PaymentMethodDataRegistry::class);
+    }
+
+    public function testGetAllPaymentMethodIds(): void
+    {
+        foreach ($this->paymentMethodDataRegistry->getPaymentMethods() as $methodData) {
+            $fetchedId = $this->paymentMethodUtil->getPaymentMethodId($methodData);
+
+            $expectedId = static::getContainer()->get('payment_method.repository')
+                ->searchIds(
+                    (new Criteria())->addFilter(new EqualsFilter('handlerIdentifier', $methodData->getHandler())),
+                    Context::createDefaultContext(),
+                )
+                ->firstId();
+
+            static::assertNotNull($fetchedId);
+            static::assertNotNull($expectedId);
+            static::assertSame($expectedId, $fetchedId);
+        }
     }
 
     public function testGetPayPalPaymentMethodId(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
+        $fetchedId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
 
-        $paymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        $expectedId = static::getContainer()->get('payment_method.repository')
+            ->searchIds(
+                (new Criteria())->addFilter(new EqualsFilter('handlerIdentifier', PayPalPaymentHandler::class)),
+                Context::createDefaultContext(),
+            )
+            ->firstId();
 
-        static::assertSame(PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID, $paymentMethodId);
+        static::assertNotNull($fetchedId);
+        static::assertNotNull($expectedId);
+        static::assertSame($expectedId, $fetchedId);
     }
 
-    public function testGetPayPalPaymentMethodIdWithWrongHandler(): void
+    public function testIsPaymentMethodActiveWithoutAssignedPaymentMethods(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([]);
+        $paypalPaymentMethods = $this->getSalesChannelPaymentMethods()->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal'));
 
-        $paymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        static::assertCount(0, $paypalPaymentMethods);
 
-        static::assertNull($paymentMethodId);
+        static::assertFalse($this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), null));
     }
 
+    public function testIsPaymentMethodActiveWithoutActivePaymentMethods(): void
+    {
+        $this->assignPaymentMethods($this->paymentMethodDataRegistry->getPaymentMethods(), false);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+
+        static::assertCount(17, $scPaymentMethods->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')));
+
+        static::assertFalse($this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), null));
+    }
+
+    public function testIsPaymentMethodActiveWithActivePaymentMethods(): void
+    {
+        $this->assignPaymentMethods($this->paymentMethodDataRegistry->getPaymentMethods(), true);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+
+        static::assertCount(
+            \count($this->paymentMethodDataRegistry->getPaymentMethods()),
+            $scPaymentMethods->filter(fn ($pm) => \str_starts_with($pm->getHandlerIdentifier(), 'Swag\\PayPal')),
+        );
+
+        foreach ($this->paymentMethodDataRegistry->getPaymentMethods() as $methodData) {
+            static::assertTrue($this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), [$methodData->getHandler()]));
+        }
+    }
+
+    public function testGetPaymentMethodIdWithWrongHandler(): void
+    {
+        static::assertNull($this->paymentMethodUtil->getPaymentMethodId('non.existing.handler'));
+        static::assertNull($this->paymentMethodUtil->getPaymentMethodId(DefaultPayment::class));
+    }
+
+    #[DataProvider('providerHandlerIdentifiers')]
+    public function testIntoHandlerIdentifier(mixed $paypalHandlerIdentifier): void
+    {
+        $reflection = new \ReflectionClass(PaymentMethodUtil::class);
+        $result = $reflection
+            ->getMethod('intoHandlerIdentifier')
+            ->invoke($this->paymentMethodUtil, $paypalHandlerIdentifier);
+
+        static::assertSame(PayPalPaymentHandler::class, $result);
+    }
+
+    public static function providerHandlerIdentifiers(): \Generator
+    {
+        $paymentMethodEntity = static::getContainer()->get('payment_method.repository')
+            ->search((new Criteria())->addFilter(new EqualsFilter('handlerIdentifier', PayPalPaymentHandler::class)), Context::createDefaultContext())
+            ->first();
+
+        yield 'entity' => [$paymentMethodEntity];
+        yield 'method data' => [new PayPalMethodData(static::getContainer())];
+        yield 'class string' => [PayPalMethodData::class];
+        yield 'handler identifier' => [PayPalPaymentHandler::class];
+    }
+
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed
+     */
     public function testGetPaypalPaymentMethodInSalesChannel(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
+        $this->assignPaymentMethods($this->paymentMethodDataRegistry->getPaymentMethods(), true);
 
-        $this->connectionMock->expects($this->once())
-            ->method('fetchFirstColumn')
-            ->willReturn([TestDefaults::SALES_CHANNEL]);
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId(TestDefaults::SALES_CHANNEL);
-        $salesChannelContext = Generator::generateSalesChannelContext(
-            salesChannel: $salesChannel
-        );
+        $salesChannelContext = Generator::generateSalesChannelContext();
         static::assertTrue($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($salesChannelContext));
-    }
-
-    public function testGetPaypalPaymentMethodInSalesChannelWithoutPayPalPaymentMethodId(): void
-    {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([]);
-
-        $this->connectionMock->expects($this->never())->method('fetchFirstColumn');
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId(TestDefaults::SALES_CHANNEL);
-        $salesChannelContext = Generator::generateSalesChannelContext(
-            salesChannel: $salesChannel
-        );
-        static::assertFalse($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($salesChannelContext));
-    }
-
-    public function testGetPaypalPaymentMethodInSalesChannelWithoutAssignment(): void
-    {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
-
-        $this->connectionMock->expects($this->once())
-            ->method('fetchFirstColumn')
-            ->willReturn([]);
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId(TestDefaults::SALES_CHANNEL);
-        $salesChannelContext = Generator::generateSalesChannelContext(
-            salesChannel: $salesChannel
-        );
-        static::assertFalse($this->paymentMethodUtil->isPaypalPaymentMethodInSalesChannel($salesChannelContext));
     }
 
     public function testSetPayPalAsDefaultPaymentMethodForASpecificSalesChannel(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
+        $paypalPaymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        static::assertNotNull($paypalPaymentMethodId);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+        static::assertFalse($scPaymentMethods->has($paypalPaymentMethodId));
 
         $context = Context::createDefaultContext();
         $this->paymentMethodUtil->setPayPalAsDefaultPaymentMethod($context, TestDefaults::SALES_CHANNEL);
-        $this->assertPaymentMethodUpdate($context);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+        $paypalPaymentMethod = $scPaymentMethods->get($paypalPaymentMethodId);
+        static::assertNotNull($paypalPaymentMethod);
+        static::assertTrue($paypalPaymentMethod->getSalesChannelDefaultAssignments()?->has(TestDefaults::SALES_CHANNEL));
     }
 
     public function testSetPayPalAsDefaultPaymentMethodForAllCompatibleSalesChannels(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
+        $paypalPaymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        static::assertNotNull($paypalPaymentMethodId);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+        static::assertFalse($scPaymentMethods->has($paypalPaymentMethodId));
 
         $context = Context::createDefaultContext();
         $this->paymentMethodUtil->setPayPalAsDefaultPaymentMethod($context, null);
-        $this->assertPaymentMethodUpdate($context, false);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+        $paypalPaymentMethod = $scPaymentMethods->get($paypalPaymentMethodId);
+        static::assertNotNull($paypalPaymentMethod);
+        static::assertTrue($paypalPaymentMethod->getSalesChannelDefaultAssignments()?->has(TestDefaults::SALES_CHANNEL));
     }
 
-    public function testSetPayPalAsDefaultPaymentWithoutBeingPresentForTheRequestedSalesChannel(): void
+    public function testSetPayPalAsDefaultPaymentWithPaymentMethodAlreadyAssigned(): void
     {
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAllKeyValue')
-            ->willReturn([PayPalPaymentHandler::class => PaymentMethodRepoMock::PAYPAL_PAYMENT_METHOD_ID]);
+        $paypalPaymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        static::assertNotNull($paypalPaymentMethodId);
+
+        $this->assignPaymentMethods([new PayPalMethodData(static::getContainer())], true);
 
         $context = Context::createDefaultContext();
-        $this->paymentMethodUtil->setPayPalAsDefaultPaymentMethod($context, self::SALESCHANNEL_WITHOUT_PAYPAL_PAYMENT_METHOD);
-        $this->assertPaymentMethodUpdate($context, false);
+        $this->paymentMethodUtil->setPayPalAsDefaultPaymentMethod($context, TestDefaults::SALES_CHANNEL);
+
+        $scPaymentMethods = $this->getSalesChannelPaymentMethods();
+        $paypalPaymentMethod = $scPaymentMethods->get($paypalPaymentMethodId);
+        static::assertNotNull($paypalPaymentMethod);
+        static::assertTrue($paypalPaymentMethod->getSalesChannelDefaultAssignments()?->has(TestDefaults::SALES_CHANNEL));
     }
 
-    private function assertPaymentMethodUpdate(Context $context, bool $paypalPaymentMethodPresent = true): void
+    private function getSalesChannelPaymentMethods(): PaymentMethodCollection
     {
-        $updates = $this->salesChannelRepoMock->getUpdateData();
-        static::assertCount(1, $updates);
-        $updateData = $updates[0];
-        static::assertCount($paypalPaymentMethodPresent ? 2 : 3, $updateData);
-        static::assertArrayHasKey('id', $updateData);
-        static::assertSame($paypalPaymentMethodPresent ? TestDefaults::SALES_CHANNEL : self::SALESCHANNEL_WITHOUT_PAYPAL_PAYMENT_METHOD, $updateData['id']);
-        static::assertArrayHasKey('paymentMethodId', $updateData);
-        $payPalPaymentMethodId = $this->paymentMethodUtil->getPayPalPaymentMethodId($context);
-        static::assertNotNull($payPalPaymentMethodId);
-        static::assertSame($payPalPaymentMethodId, $updateData['paymentMethodId']);
+        /** @var SalesChannelEntity|null $salesChannel */
+        $salesChannel = static::getContainer()->get('sales_channel.repository')
+            ->search((new Criteria([TestDefaults::SALES_CHANNEL]))->addAssociation('paymentMethods.salesChannelDefaultAssignments'), Context::createDefaultContext())
+            ->first();
+
+        static::assertNotNull($salesChannel);
+        static::assertNotNull($salesChannel->getPaymentMethods());
+
+        return $salesChannel->getPaymentMethods();
+    }
+
+    /**
+     * @param array<AbstractMethodData> $methodData
+     */
+    private function assignPaymentMethods(array $methodData, bool $active): void
+    {
+        $update = [
+            'id' => TestDefaults::SALES_CHANNEL,
+            'paymentMethods' => \array_map(
+                fn ($md) => [
+                    'id' => $this->paymentMethodUtil->getPaymentMethodId($md),
+                    'active' => $active,
+                ],
+                $methodData,
+            ),
+        ];
+
+        static::getContainer()->get('sales_channel.repository')->update([$update], Context::createDefaultContext());
     }
 }

--- a/tests/Util/PaymentMethodUtilTest.php
+++ b/tests/Util/PaymentMethodUtilTest.php
@@ -58,9 +58,9 @@ class PaymentMethodUtilTest extends TestCase
                 )
                 ->firstId();
 
-            static::assertNotNull($fetchedId);
-            static::assertNotNull($expectedId);
-            static::assertSame($expectedId, $fetchedId);
+            static::assertNotNull($fetchedId, 'Failed to fetch payment method id for ' . $methodData->getHandler());
+            static::assertNotNull($expectedId, 'Failed to fetch expected payment method id for ' . $methodData->getHandler());
+            static::assertSame($expectedId, $fetchedId, 'Fetched payment method id returned from util does not match expected for ' . $methodData->getHandler());
         }
     }
 
@@ -112,7 +112,10 @@ class PaymentMethodUtilTest extends TestCase
         );
 
         foreach ($this->paymentMethodDataRegistry->getPaymentMethods() as $methodData) {
-            static::assertTrue($this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), [$methodData->getHandler()]));
+            static::assertTrue(
+                $this->paymentMethodUtil->isPaymentMethodActive(Generator::generateSalesChannelContext(), [$methodData->getHandler()]),
+                'Failed asserting that payment method ' . $methodData->getHandler() . ' is active',
+            );
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
With 10.4.0 we removed the PayPal cookie from the required cookies in the banner, if the plugin payment methods are inactive. Some scripts, like a funding eligibility script, were still executed, resulting in PayPal's JS loaded without the required cookie being set.

### 2. What does this change do, exactly?
Only add cookie and scripts, if the correct payment methods are active and assigned to the given sales channel.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- fixes shopware/SwagPayPal#506

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
