### PR TITLE
feat: format country state

### DIFF
--- a/src/AgentCommerce/SalesChannel/CreateCartRoute.php
+++ b/src/AgentCommerce/SalesChannel/CreateCartRoute.php
@@ -79,7 +79,7 @@ class CreateCartRoute extends AbstractAgentCommerceRoute
 
     private function registerAndLoginCustomer(PayPalCart $payPalCart, SalesChannelContext $salesChannelContext): SalesChannelContext
     {
-        $customerData = $this->shopwareCartTransformer->extractCustomerData($payPalCart, $salesChannelContext->getSalesChannelId(), $salesChannelContext->getContext());
+        $customerData = $this->shopwareCartTransformer->extractCustomerData($payPalCart, $salesChannelContext->getSalesChannelId(), $salesChannelContext);
 
         $this->registerRoute->register(new RequestDataBag($customerData), $salesChannelContext, false);
 

--- a/src/AgentCommerce/SalesChannel/UpdateCartRoute.php
+++ b/src/AgentCommerce/SalesChannel/UpdateCartRoute.php
@@ -95,7 +95,7 @@ class UpdateCartRoute extends AbstractAgentCommerceRoute
             );
         }
 
-        $customerData = $this->shopwareCartTransformer->extractCustomerData($payPalCart, $salesChannelContext->getSalesChannelId(), $salesChannelContext->getContext());
+        $customerData = $this->shopwareCartTransformer->extractCustomerData($payPalCart, $salesChannelContext->getSalesChannelId(), $salesChannelContext);
         $customerData['id'] = $customer->getId();
         $customerData['shippingAddress']['id'] = $customer->getDefaultShippingAddressId();
         $customerData['defaultShippingAddress'] = $customerData['shippingAddress'];

--- a/src/AgentCommerce/Util/ShopwareCartTransformer.php
+++ b/src/AgentCommerce/Util/ShopwareCartTransformer.php
@@ -15,9 +15,12 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
 use Shopware\Core\System\Country\CountryCollection;
+use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalutationCollection;
 use Shopware\Core\System\Salutation\SalutationDefinition;
@@ -101,9 +104,14 @@ class ShopwareCartTransformer
     private function formatAddress(Address $address, CustomerName $name, ?Phone $phone, Context $context): array
     {
         $criteria = (new Criteria())->addFilter(new EqualsFilter('iso', $address->getCountryCode()));
-        $countryId = $this->countryRepository->searchIds($criteria, $context)->firstId();
 
-        if (!$countryId) {
+        if ($address->getAdminArea1()) {
+            $criteria->getAssociation('states')
+                ->addFilter(new SuffixFilter('shortCode', $address->getAdminArea1()));
+        }
+
+        $country = $this->countryRepository->search($criteria, $context)->first();
+        if (!$country instanceof CountryEntity) {
             throw AgentException::requiredFieldInvalid('address.countryCode', 'Country not found');
         }
 
@@ -113,7 +121,8 @@ class ShopwareCartTransformer
         return [
             'id' => Uuid::randomHex(),
             'salutationId' => $salutationId,
-            'countryId' => $countryId,
+            'countryId' => $country->getId(),
+            'countryStateId' => $this->getStateId($country->getStates(), $address->getAdminArea1()),
             'firstName' => $name->getGivenName(),
             'lastName' => $name->getSurname(),
             'zipcode' => $address->getPostalCode(),
@@ -136,5 +145,18 @@ class ShopwareCartTransformer
         }
 
         return $items;
+    }
+
+    private function getStateId(?CountryStateCollection $states, ?string $adminArea1): ?string
+    {
+        if ($states) {
+            foreach ($states as $state) {
+                if ($state->getShortCode() === $adminArea1 || str_ends_with($state->getShortCode(), '-' . $adminArea1)) {
+                    return $state->getId();
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/AgentCommerce/Util/ShopwareCartTransformer.php
+++ b/src/AgentCommerce/Util/ShopwareCartTransformer.php
@@ -11,16 +11,16 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItemFactoryHandler\ProductLineItemFactory;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalutationCollection;
 use Shopware\Core\System\Salutation\SalutationDefinition;
@@ -41,12 +41,12 @@ use Swag\PayPal\AgentCommerce\Struct\V1\ShippingAddress;
 class ShopwareCartTransformer
 {
     /**
-     * @param EntityRepository<CountryCollection> $countryRepository
+     * @param SalesChannelRepository<CountryCollection> $countryRepository
      * @param EntityRepository<SalutationCollection> $salutationRepository
      * @param EntityRepository<CustomerGroupCollection> $groupRepository
      */
     public function __construct(
-        private readonly EntityRepository $countryRepository,
+        private readonly SalesChannelRepository $countryRepository,
         private readonly EntityRepository $salutationRepository,
         private readonly EntityRepository $groupRepository,
         private readonly ProductLineItemFactory $lineItemFactory,
@@ -57,7 +57,7 @@ class ShopwareCartTransformer
     /**
      * @return array{firstName: string, lastName: string, email: string|null, salesChannelId: string, groupId: string|null, shippingAddress: array, guest: true, billingAddress?: array}
      */
-    public function extractCustomerData(PayPalCart $cart, string $salesChannelId, Context $context): array
+    public function extractCustomerData(PayPalCart $cart, string $salesChannelId, SalesChannelContext $context): array
     {
         /** @var Customer $customer */
         $customer = $cart->getCustomer();
@@ -72,7 +72,7 @@ class ShopwareCartTransformer
             'lastName' => $customer->getName()->getSurname(),
             'email' => $customer->getEmailAddress(),
             'salesChannelId' => $salesChannelId,
-            'groupId' => $this->groupRepository->searchIds($groupCriteria, $context)->firstId(),
+            'groupId' => $this->groupRepository->searchIds($groupCriteria, $context->getContext())->firstId(),
             'shippingAddress' => $this->formatAddress($shippingAddress, $customer->getName(), $customer->getPhone(), $context),
             'guest' => true,
         ];
@@ -101,13 +101,17 @@ class ShopwareCartTransformer
         return $lineItems;
     }
 
-    private function formatAddress(Address $address, CustomerName $name, ?Phone $phone, Context $context): array
+    private function formatAddress(Address $address, CustomerName $name, ?Phone $phone, SalesChannelContext $context): array
     {
         $criteria = (new Criteria())->addFilter(new EqualsFilter('iso', $address->getCountryCode()));
 
         if ($address->getAdminArea1()) {
             $criteria->getAssociation('states')
-                ->addFilter(new SuffixFilter('shortCode', $address->getAdminArea1()));
+                ->setLimit(1)
+                ->addFilter(new OrFilter([
+                    new EqualsFilter('shortCode', $address->getAdminArea1()),
+                    new SuffixFilter('shortCode', '-' . $address->getAdminArea1()),
+                ]));
         }
 
         $country = $this->countryRepository->search($criteria, $context)->first();
@@ -116,13 +120,13 @@ class ShopwareCartTransformer
         }
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('salutationKey', SalutationDefinition::NOT_SPECIFIED));
-        $salutationId = $this->salutationRepository->searchIds($criteria, $context)->firstId();
+        $salutationId = $this->salutationRepository->searchIds($criteria, $context->getContext())->firstId();
 
         return [
             'id' => Uuid::randomHex(),
             'salutationId' => $salutationId,
             'countryId' => $country->getId(),
-            'countryStateId' => $this->getStateId($country->getStates(), $address->getAdminArea1()),
+            'countryStateId' => $country->getStates()?->first()?->getId(),
             'firstName' => $name->getGivenName(),
             'lastName' => $name->getSurname(),
             'zipcode' => $address->getPostalCode(),
@@ -145,18 +149,5 @@ class ShopwareCartTransformer
         }
 
         return $items;
-    }
-
-    private function getStateId(?CountryStateCollection $states, ?string $adminArea1): ?string
-    {
-        if ($states) {
-            foreach ($states as $state) {
-                if ($state->getShortCode() === $adminArea1 || str_ends_with($state->getShortCode(), '-' . $adminArea1)) {
-                    return $state->getId();
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Resources/config/services/agent_commerce.xml
+++ b/src/Resources/config/services/agent_commerce.xml
@@ -89,7 +89,7 @@
         </service>
 
         <service id="Swag\PayPal\AgentCommerce\Util\ShopwareCartTransformer">
-            <argument type="service" id="country.repository"/>
+            <argument type="service" id="sales_channel.country.repository"/>
             <argument type="service" id="salutation.repository"/>
             <argument type="service" id="customer_group.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryHandler\ProductLineItemFactory"/>

--- a/tests/AgentCommerce/Util/ShopwareCartTransformerTest.php
+++ b/tests/AgentCommerce/Util/ShopwareCartTransformerTest.php
@@ -15,9 +15,15 @@ use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
+use Shopware\Core\System\Country\CountryCollection;
+use Shopware\Core\System\Country\CountryDefinition;
+use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\AgentCommerce\Exception\AgentException;
 use Swag\PayPal\AgentCommerce\Struct\V1\Coupon;
@@ -36,10 +42,33 @@ class ShopwareCartTransformerTest extends TestCase
         $overallRandomId = Uuid::randomHex();
         $idResult = new IdSearchResult(1, [['primaryKey' => $overallRandomId]], new Criteria(), Context::createDefaultContext());
 
+        $state1 = new CountryStateEntity();
+        $state1->setId(Uuid::randomHex());
+        $state1->setShortCode('CACA');
+
+        $caId = Uuid::randomHex();
+        $state2 = new CountryStateEntity();
+        $state2->setId($caId);
+        $state2->setShortCode('CA');
+
+        $nyId = Uuid::randomHex();
+        $state3 = new CountryStateEntity();
+        $state3->setId($nyId);
+        $state3->setShortCode('US-NY');
+
+        $country = new CountryEntity();
+        $country->setId($overallRandomId);
+        $country->setStates(new CountryStateCollection([$state1, $state2, $state3]));
+
+        $result = new EntitySearchResult(CountryDefinition::ENTITY_NAME, 1, new CountryCollection([$country]), null, new Criteria(), Context::createDefaultContext());
+
         $repository = $this->createMock(EntityRepository::class);
         $repository
             ->method('searchIds')
             ->willReturn($idResult);
+        $repository
+            ->method('search')
+            ->willReturn($result);
 
         $transformer = new ShopwareCartTransformer(
             $repository,
@@ -59,13 +88,19 @@ class ShopwareCartTransformerTest extends TestCase
         static::assertSame($overallRandomId, $customerData['groupId']);
         static::assertSame($overallRandomId, $customerData['shippingAddress']['salutationId']);
         static::assertSame($overallRandomId, $customerData['shippingAddress']['countryId']);
+        static::assertSame($caId, $customerData['shippingAddress']['countryStateId']);
+        static::assertArrayHasKey('billingAddress', $customerData);
+        static::assertSame($overallRandomId, $customerData['billingAddress']['salutationId']);
+        static::assertSame($overallRandomId, $customerData['billingAddress']['countryId']);
+        static::assertSame($nyId, $customerData['billingAddress']['countryStateId']);
+
         static::assertSame('John', $customerData['shippingAddress']['firstName']);
         static::assertSame('Smith', $customerData['shippingAddress']['lastName']);
         static::assertSame('12345', $customerData['shippingAddress']['zipcode']);
         static::assertSame('San Jose', $customerData['shippingAddress']['city']);
         static::assertSame('123 Main Street', $customerData['shippingAddress']['street']);
         static::assertSame('+1 12345-6789', $customerData['shippingAddress']['phoneNumber']);
-        static::assertArrayHasKey('billingAddress', $customerData);
+
         static::assertSame('John', $customerData['billingAddress']['firstName']);
         static::assertSame('Smith', $customerData['billingAddress']['lastName']);
         static::assertSame('10001', $customerData['billingAddress']['zipcode']);

--- a/tests/AgentCommerce/Util/ShopwareCartTransformerTest.php
+++ b/tests/AgentCommerce/Util/ShopwareCartTransformerTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\AgentCommerce\Exception\AgentException;
 use Swag\PayPal\AgentCommerce\Struct\V1\Coupon;
@@ -42,43 +43,45 @@ class ShopwareCartTransformerTest extends TestCase
         $overallRandomId = Uuid::randomHex();
         $idResult = new IdSearchResult(1, [['primaryKey' => $overallRandomId]], new Criteria(), Context::createDefaultContext());
 
-        $state1 = new CountryStateEntity();
-        $state1->setId(Uuid::randomHex());
-        $state1->setShortCode('CACA');
-
         $caId = Uuid::randomHex();
-        $state2 = new CountryStateEntity();
-        $state2->setId($caId);
-        $state2->setShortCode('CA');
+        $state1 = new CountryStateEntity();
+        $state1->setId($caId);
+        $state1->setShortCode('CA');
 
         $nyId = Uuid::randomHex();
-        $state3 = new CountryStateEntity();
-        $state3->setId($nyId);
-        $state3->setShortCode('US-NY');
+        $state2 = new CountryStateEntity();
+        $state2->setId($nyId);
+        $state2->setShortCode('US-NY');
 
-        $country = new CountryEntity();
-        $country->setId($overallRandomId);
-        $country->setStates(new CountryStateCollection([$state1, $state2, $state3]));
+        $country1 = new CountryEntity();
+        $country1->setId($overallRandomId);
+        $country1->setStates(new CountryStateCollection([$state1]));
+        $country2 = new CountryEntity();
+        $country2->setId($overallRandomId);
+        $country2->setStates(new CountryStateCollection([$state2]));
 
-        $result = new EntitySearchResult(CountryDefinition::ENTITY_NAME, 1, new CountryCollection([$country]), null, new Criteria(), Context::createDefaultContext());
+        $salesChannelRepository = $this->createMock(SalesChannelRepository::class);
+        $salesChannelRepository
+            ->method('search')
+            ->willReturnOnConsecutiveCalls(
+                new EntitySearchResult(CountryDefinition::ENTITY_NAME, 1, new CountryCollection([$country1]), null, new Criteria(), Context::createDefaultContext()),
+                new EntitySearchResult(CountryDefinition::ENTITY_NAME, 1, new CountryCollection([$country2]), null, new Criteria(), Context::createDefaultContext())
+            );
 
         $repository = $this->createMock(EntityRepository::class);
         $repository
             ->method('searchIds')
             ->willReturn($idResult);
-        $repository
-            ->method('search')
-            ->willReturn($result);
 
         $transformer = new ShopwareCartTransformer(
-            $repository,
+            $salesChannelRepository,
             $repository,
             $repository,
             $this->createMock(ProductLineItemFactory::class),
             $this->createMock(PromotionItemBuilder::class),
         );
 
-        $customerData = $transformer->extractCustomerData((new PayPalCart())->assign(self::requestCustomerData()), $overallRandomId, Context::createDefaultContext());
+        $customerData = $transformer->extractCustomerData((new PayPalCart())->assign(self::requestCustomerData()), $overallRandomId, $this->createMock(SalesChannelContext::class));
 
         static::assertSame('John', $customerData['firstName']);
         static::assertSame('Smith', $customerData['lastName']);
@@ -118,14 +121,14 @@ class ShopwareCartTransformerTest extends TestCase
         $this->expectExceptionMessage($exception->getMessage());
 
         $transformer = new ShopwareCartTransformer(
-            $this->createMock(EntityRepository::class),
+            $this->createMock(SalesChannelRepository::class),
             $this->createMock(EntityRepository::class),
             $this->createMock(EntityRepository::class),
             $this->createMock(ProductLineItemFactory::class),
             $this->createMock(PromotionItemBuilder::class),
         );
 
-        $transformer->extractCustomerData((new PayPalCart())->assign(self::requestCustomerData()), Uuid::randomHex(), Context::createDefaultContext());
+        $transformer->extractCustomerData((new PayPalCart())->assign(self::requestCustomerData()), Uuid::randomHex(), $this->createMock(SalesChannelContext::class));
     }
 
     public function testGetLineItems(): void
@@ -138,7 +141,7 @@ class ShopwareCartTransformerTest extends TestCase
             ->willReturn(new LineItem($itemId, LineItem::PRODUCT_LINE_ITEM_TYPE, $itemId, 2));
 
         $transformer = new ShopwareCartTransformer(
-            $this->createMock(EntityRepository::class),
+            $this->createMock(SalesChannelRepository::class),
             $this->createMock(EntityRepository::class),
             $this->createMock(EntityRepository::class),
             $itemFactory,


### PR DESCRIPTION
### 1. Why is this change necessary?
We need to set the `countryStateId` to the customer address, if adminArea1 is provided

### 2. What does this change do, exactly?
Load the country state filtered by `adminArea1`. Add the state id to the formatted address

### 3. Describe each step to reproduce the issue or behaviour.
.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
