### PR TITLE
fix: call setPayment on getOrderFromOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total
+
 # 10.4.1
 - Fixes an issue, where required cookies were not displayed in the banner even though PayPal scripts had been loaded (shopware/SwagPayPal#506)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten.
+
 # 10.4.1
 - Behebt ein Problem, bei dem erforderliche Cookies nicht im Banner angezeigt wurden, obwohl PayPal-Skripte geladen wurden (shopware/SwagPayPal#506)
 

--- a/src/Checkout/SalesChannel/CreateOrderRoute.php
+++ b/src/Checkout/SalesChannel/CreateOrderRoute.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
+use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
 use Shopware\Core\Checkout\Payment\Cart\AbstractPaymentTransactionStructFactory;
 use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -57,6 +58,7 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         private readonly OrderResource $orderResource,
         private readonly LoggerInterface $logger,
         private readonly AbstractPaymentTransactionStructFactory $paymentTransactionStructFactory,
+        private readonly AbstractSetPaymentOrderRoute $paymentOrderRoute
     ) {
     }
 
@@ -151,6 +153,8 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         Request $request,
         SalesChannelContext $salesChannelContext,
     ): Order {
+        $this->paymentOrderRoute->setPayment($request, $salesChannelContext);
+
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('transactions');
         $criteria->addAssociation('lineItems');

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -43,6 +43,7 @@
             <argument type="service" id="Swag\PayPal\RestApi\V2\Resource\OrderResource"/>
             <argument type="service" id="monolog.logger.paypal"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStructFactory"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute" public="true">

--- a/tests/Checkout/SalesChannel/CreateOrderRouteTest.php
+++ b/tests/Checkout/SalesChannel/CreateOrderRouteTest.php
@@ -8,12 +8,14 @@
 namespace Swag\PayPal\Test\Checkout\SalesChannel;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\OrderCollection;
+use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
 use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStructFactory;
 use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
@@ -68,10 +70,12 @@ class CreateOrderRouteTest extends TestCase
 
     private CreateOrderRoute $route;
 
+    private MockObject&AbstractSetPaymentOrderRoute $paymentOrderRoute;
+
     protected function setUp(): void
     {
         $this->orderRepository = new StaticEntityRepository([]);
-        $systemConfig = $this->createSystemConfigServiceMock([
+        $systemConfig = self::createSystemConfigServiceMock([
             Settings::CLIENT_ID => 'testClientId',
             Settings::CLIENT_SECRET => 'testClientSecret',
         ]);
@@ -127,6 +131,7 @@ class CreateOrderRouteTest extends TestCase
             new OrderResource(self::orderGateway(), new ApiContextFactoryMock()),
             new NullLogger(),
             new PaymentTransactionStructFactory(),
+            $this->paymentOrderRoute = $this->createMock(AbstractSetPaymentOrderRoute::class),
         );
     }
 
@@ -163,6 +168,10 @@ class CreateOrderRouteTest extends TestCase
         $orderId = Uuid::randomHex();
         $request = new Request([], ['orderId' => $orderId]);
 
+        $this->paymentOrderRoute
+            ->expects($this->once())
+            ->method('setPayment');
+
         $orderEntity = $this->createOrderEntity($orderId);
         $orderTransaction = $this->createOrderTransaction();
         $orderTransaction->setOrderId($orderEntity->getId());
@@ -185,6 +194,10 @@ class CreateOrderRouteTest extends TestCase
         $salesChannelContext = $this->createSalesChannelContext($this->getContainer(), new PaymentMethodCollection());
         $this->orderRepository->addSearch(new OrderCollection());
 
+        $this->paymentOrderRoute
+            ->expects($this->once())
+            ->method('setPayment');
+
         $request = new Request([], ['orderId' => 'no-order-id']);
 
         $this->expectException(ShopwareHttpException::class);
@@ -195,6 +208,10 @@ class CreateOrderRouteTest extends TestCase
     public function testCreatePaymentWithOrderWithoutTransactions(): void
     {
         $salesChannelContext = $this->createSalesChannelContext($this->getContainer(), new PaymentMethodCollection());
+
+        $this->paymentOrderRoute
+            ->expects($this->once())
+            ->method('setPayment');
 
         $orderEntity = $this->createOrderEntity('no-order-transactions-id');
         $this->orderRepository->addSearch(new OrderCollection([$orderEntity]));
@@ -209,6 +226,10 @@ class CreateOrderRouteTest extends TestCase
     public function testCreatePaymentWithOrderWithoutTransaction(): void
     {
         $salesChannelContext = $this->createSalesChannelContext($this->getContainer(), new PaymentMethodCollection());
+
+        $this->paymentOrderRoute
+            ->expects($this->once())
+            ->method('setPayment');
 
         $orderEntity = $this->createOrderEntity('no-order-transaction-id');
         $orderEntity->setTransactions(new OrderTransactionCollection());


### PR DESCRIPTION
### 1. Why is this change necessary?
After changing the order in the administration, e.g. adding a line item or changing the price of a line item, the transaction amount can be divergent.

### 2. What does this change do, exactly?
Before loading the order in `CreateOrderRoute` we call `setPayment`. `setPayment` will set the right transaction with the right transaction amount.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a PayPal order
2. Change the price of a line item or add a line item
3. The customer now tries to pay the order within the storefront
4. The old transaction amount still occurs

### 4. Please link to the relevant issues (if any).
- related to https://github.com/shopware/shopware/pull/14022
- fixes https://github.com/shopware/shopware/issues/13625

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
