### PR TITLE
fix: Shipping can be nullable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,8 +95,8 @@ jobs:
           composer init:admin
           composer openapi:generate
           git update-index --refresh || printf ''
-          git diff --exit-code src/Resources/app/administration/src/types/openapi.d.ts || (echo "Please run 'composer openapi:generate' to update openapi.d.ts" && exit 1)
           git diff --exit-code src/Resources/Schema || (echo "Please run 'composer openapi:generate' to update Resources/Schema files" && exit 1)
+          git diff --exit-code src/Resources/app/administration/src/types/openapi.d.ts || (echo "Please run 'composer openapi:generate' to update openapi.d.ts" && exit 1)
 
   bc-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.4.2
 - Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total
+- Fixes an issue, where accessing an uninitialized object during express checkout (shopware/SwagPayPal#512)
 
 # 10.4.1
 - Fixes an issue, where required cookies were not displayed in the banner even though PayPal scripts had been loaded (shopware/SwagPayPal#506)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten.
+- Behebt ein Problem, bei dem im PayPal Express Checkout der Zugriff auf ein nicht initialisiertes Objekt erfolgte (shopware/SwagPayPal#521)
 
 # 10.4.1
 - Behebt ein Problem, bei dem erforderliche Cookies nicht im Banner angezeigt wurden, obwohl PayPal-Skripte geladen wurden (shopware/SwagPayPal#506)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.4.1",
+    "version": "10.4.2",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [
@@ -11,7 +11,7 @@
     ],
     "require": {
         "shopware/core": "~6.7.0@dev",
-        "shopware/paypal-sdk": "^1.5.1"
+        "shopware/paypal-sdk": "^1.6.2"
     },
     "extra": {
         "shopware-plugin-class": "Swag\\PayPal\\SwagPayPal",

--- a/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
@@ -158,9 +158,9 @@ class ExpressCustomerService
         if (!$paypal) {
             throw new MissingPayloadException($order->getId(), 'paymentSource.paypal');
         }
-        $purchaseUnit = $order->getPurchaseUnits()->first();
-        if ($purchaseUnit) {
-            $shipping = $purchaseUnit->getShipping();
+
+        $shipping = $order->getPurchaseUnits()->first()?->getShipping();
+        if ($shipping) {
             $address = $shipping->getAddress();
             $names = \explode(' ', $shipping->getName()->getFullName());
             $lastName = \array_pop($names);

--- a/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
+++ b/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
@@ -84,7 +84,7 @@ class ShippingInformationMessageHandler
             return;
         }
 
-        $orderTrackers = $order->getPurchaseUnits()->first()?->getShipping()->getTrackers()?->getTrackerCodes() ?? [];
+        $orderTrackers = $order->getPurchaseUnits()->first()?->getShipping()?->getTrackers()?->getTrackerCodes() ?? [];
         $deliveryTrackers = $this->trimTrackers($orderDelivery->getTrackingCodes());
         $itemCollection = $this->createItemCollection($orderLineItems);
 

--- a/src/DevOps/Command/CrawlWebhookEventNames.php
+++ b/src/DevOps/Command/CrawlWebhookEventNames.php
@@ -63,12 +63,12 @@ class CrawlWebhookEventNames extends Command
             foreach ($webhookTable as $webhooks) {
                 $webhooksString .= "\n";
                 foreach ($webhooks as $webhook) {
-                    $webhookName = $webhook[self::WEBHOOK_NAME_KEY];
+                    $webhookName = $webhook[self::WEBHOOK_NAME_KEY] ?? '';
                     if (\mb_strpos($webhooksString, $webhookName) !== false) {
                         continue;
                     }
 
-                    $webhookDescription = $webhook[self::WEBHOOK_DESCRIPTION_KEY];
+                    $webhookDescription = $webhook[self::WEBHOOK_DESCRIPTION_KEY] ?? '';
                     $webhookConstName = \str_replace(['.', '-'], '_', $webhookName);
                     $webhooksString .= \sprintf(
                         "    /* %s */\n    public const %s = '%s';\n",

--- a/src/Migration/Migration1626082072AddStatusAndMessageCountToRun.php
+++ b/src/Migration/Migration1626082072AddStatusAndMessageCountToRun.php
@@ -25,8 +25,8 @@ class Migration1626082072AddStatusAndMessageCountToRun extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        if ($this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'status')
-         || $this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'message_count')) {
+        if ($this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'status') // @phpstan-ignore method.deprecated
+         || $this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'message_count')) { // @phpstan-ignore method.deprecated
             return;
         }
 

--- a/src/Migration/Migration1675420139AddManagerDataToRun.php
+++ b/src/Migration/Migration1675420139AddManagerDataToRun.php
@@ -25,8 +25,8 @@ class Migration1675420139AddManagerDataToRun extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        if ($this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'step_index')
-            || $this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'steps')) {
+        if ($this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'step_index') // @phpstan-ignore method.deprecated
+            || $this->columnExists($connection, PosSalesChannelRunDefinition::ENTITY_NAME, 'steps')) { // @phpstan-ignore method.deprecated
             return;
         }
 

--- a/src/Migration/Migration1706111604AddCustomerIdToVault.php
+++ b/src/Migration/Migration1706111604AddCustomerIdToVault.php
@@ -24,6 +24,7 @@ class Migration1706111604AddCustomerIdToVault extends MigrationStep
 
     public function update(Connection $connection): void
     {
+        // @phpstan-ignore method.deprecated
         if ($this->columnExists($connection, 'swag_paypal_vault_token', 'token_customer')) {
             return;
         }

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -4830,6 +4830,345 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_eligible_methods_data": {
+                "required": [
+                    "eligible_methods",
+                    "supplementary_data"
+                ],
+                "properties": {
+                    "eligible_methods": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods": {
+                "required": [
+                    "paypal",
+                    "paypal_pay_later",
+                    "apple_pay",
+                    "google_pay",
+                    "advanced_cards",
+                    "eps",
+                    "p_2_4",
+                    "blik",
+                    "ideal",
+                    "bizum",
+                    "bancontact",
+                    "klarna"
+                ],
+                "properties": {
+                    "paypal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    "paypal_pay_later": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
+                    },
+                    "apple_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
+                    },
+                    "google_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
+                    },
+                    "advanced_cards": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
+                    },
+                    "eps": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
+                    },
+                    "p_2_4": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
+                    },
+                    "blik": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
+                    },
+                    "ideal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
+                    },
+                    "bizum": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
+                    },
+                    "bancontact": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
+                    },
+                    "klarna": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
+                "required": [
+                    "supports_installements",
+                    "cobranded_enabled",
+                    "vendors"
+                ],
+                "properties": {
+                    "supports_installements": {
+                        "type": "boolean"
+                    },
+                    "cobranded_enabled": {
+                        "type": "boolean"
+                    },
+                    "vendors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "eligible",
+                            "network",
+                            "branded"
+                        ],
+                        "properties": {
+                            "eligible": {
+                                "type": "boolean"
+                            },
+                            "network": {
+                                "type": "string"
+                            },
+                            "branded": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_blik": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_eps": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_p24": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
+                "required": [
+                    "can_be_vaulted"
+                ],
+                "properties": {
+                    "can_be_vaulted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "country_code",
+                            "product_code"
+                        ],
+                        "properties": {
+                            "country_code": {
+                                "description": "ISO 3166-1 alpha-2 country code",
+                                "type": "string",
+                                "maxLength": 2,
+                                "minLength": 2
+                            },
+                            "product_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_supplementary_data": {
+                "required": [
+                    "buyer_country_code"
+                ],
+                "properties": {
+                    "buyer_country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods": {
+                "required": [
+                    "customer",
+                    "preferences",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
+                    },
+                    "preferences": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
+                    },
+                    "purchase_units": {
+                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer": {
+                "required": [
+                    "country_code",
+                    "channel"
+                ],
+                "properties": {
+                    "country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "channel": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer_channel": {
+                "required": [
+                    "browser_type",
+                    "client_os",
+                    "device_type"
+                ],
+                "properties": {
+                    "browser_type": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "client_os": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "device_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences": {
+                "required": [
+                    "payment_flow",
+                    "commit",
+                    "intent",
+                    "vault",
+                    "payment_source_constraint"
+                ],
+                "properties": {
+                    "payment_flow": {
+                        "type": "string",
+                        "enum": [
+                            "ONE_TIME_PAYMENT"
+                        ]
+                    },
+                    "commit": {
+                        "type": "boolean"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "vault": {
+                        "type": "boolean"
+                    },
+                    "payment_source_constraint": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
+                "required": [
+                    "constraint_type",
+                    "payment_sources"
+                ],
+                "properties": {
+                    "constraint_type": {
+                        "type": "string",
+                        "enum": [
+                            "INCLUDE"
+                        ]
+                    },
+                    "payment_sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order": {
                 "required": [
                     "create_time",
@@ -4976,6 +5315,7 @@
             },
             "paypal_v2_order_payment_source": {
                 "required": [
+                    "afterpay",
                     "apple_pay",
                     "pay_upon_invoice",
                     "bancontact",
@@ -4984,17 +5324,27 @@
                     "card",
                     "eps",
                     "ideal",
+                    "klarna",
                     "multibanco",
                     "my_bank",
                     "oxxo",
                     "p_2_4",
                     "paypal",
+                    "swish",
                     "token",
                     "trustly",
                     "google_pay",
                     "venmo"
                 ],
                 "properties": {
+                    "afterpay": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_afterpay"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "apple_pay": {
                         "$ref": "#/components/schemas/paypal_v2_order_payment_source_apple_pay"
                     },
@@ -5054,6 +5404,14 @@
                         ],
                         "nullable": true
                     },
+                    "klarna": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_klarna"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "multibanco": {
                         "oneOf": [
                             {
@@ -5094,6 +5452,14 @@
                         ],
                         "nullable": true
                     },
+                    "swish": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_swish"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "token": {
                         "oneOf": [
                             {
@@ -5125,6 +5491,42 @@
                             }
                         ],
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_afterpay": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone",
+                    "birth_date"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "birth_date": {
+                        "type": "string",
+                        "format": "date"
                     }
                 },
                 "type": "object"
@@ -5696,6 +6098,37 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_payment_source_klarna": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_payment_source_multibanco": {
                 "required": [
                     "name",
@@ -5915,6 +6348,33 @@
                             }
                         ],
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_swish": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "phone": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -6988,7 +7448,8 @@
                     "products",
                     "capabilities",
                     "legal_consents",
-                    "links"
+                    "links",
+                    "legal_country_code"
                 ],
                 "properties": {
                     "business_entity": {
@@ -7032,6 +7493,9 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
+                    },
+                    "legal_country_code": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -7127,14 +7591,23 @@
             },
             "paypal_v2_referral_operation_api_integration_preference_rest_api_integration_third_party_details": {
                 "required": [
-                    "features"
+                    "features",
+                    "signup_mode",
+                    "organization"
                 ],
                 "properties": {
                     "features": {
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "deprecated": true
+                    },
+                    "signup_mode": {
+                        "type": "string"
+                    },
+                    "organization": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -3510,6 +3510,345 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_eligible_methods_data": {
+                "required": [
+                    "eligible_methods",
+                    "supplementary_data"
+                ],
+                "properties": {
+                    "eligible_methods": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods": {
+                "required": [
+                    "paypal",
+                    "paypal_pay_later",
+                    "apple_pay",
+                    "google_pay",
+                    "advanced_cards",
+                    "eps",
+                    "p_2_4",
+                    "blik",
+                    "ideal",
+                    "bizum",
+                    "bancontact",
+                    "klarna"
+                ],
+                "properties": {
+                    "paypal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    "paypal_pay_later": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
+                    },
+                    "apple_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
+                    },
+                    "google_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
+                    },
+                    "advanced_cards": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
+                    },
+                    "eps": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
+                    },
+                    "p_2_4": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
+                    },
+                    "blik": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
+                    },
+                    "ideal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
+                    },
+                    "bizum": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
+                    },
+                    "bancontact": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
+                    },
+                    "klarna": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
+                "required": [
+                    "supports_installements",
+                    "cobranded_enabled",
+                    "vendors"
+                ],
+                "properties": {
+                    "supports_installements": {
+                        "type": "boolean"
+                    },
+                    "cobranded_enabled": {
+                        "type": "boolean"
+                    },
+                    "vendors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "eligible",
+                            "network",
+                            "branded"
+                        ],
+                        "properties": {
+                            "eligible": {
+                                "type": "boolean"
+                            },
+                            "network": {
+                                "type": "string"
+                            },
+                            "branded": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_blik": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_eps": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_p24": {},
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
+                "required": [
+                    "can_be_vaulted"
+                ],
+                "properties": {
+                    "can_be_vaulted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "country_code",
+                            "product_code"
+                        ],
+                        "properties": {
+                            "country_code": {
+                                "description": "ISO 3166-1 alpha-2 country code",
+                                "type": "string",
+                                "maxLength": 2,
+                                "minLength": 2
+                            },
+                            "product_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_supplementary_data": {
+                "required": [
+                    "buyer_country_code"
+                ],
+                "properties": {
+                    "buyer_country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods": {
+                "required": [
+                    "customer",
+                    "preferences",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
+                    },
+                    "preferences": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
+                    },
+                    "purchase_units": {
+                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer": {
+                "required": [
+                    "country_code",
+                    "channel"
+                ],
+                "properties": {
+                    "country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "channel": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer_channel": {
+                "required": [
+                    "browser_type",
+                    "client_os",
+                    "device_type"
+                ],
+                "properties": {
+                    "browser_type": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "client_os": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "device_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences": {
+                "required": [
+                    "payment_flow",
+                    "commit",
+                    "intent",
+                    "vault",
+                    "payment_source_constraint"
+                ],
+                "properties": {
+                    "payment_flow": {
+                        "type": "string",
+                        "enum": [
+                            "ONE_TIME_PAYMENT"
+                        ]
+                    },
+                    "commit": {
+                        "type": "boolean"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "vault": {
+                        "type": "boolean"
+                    },
+                    "payment_source_constraint": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
+                "required": [
+                    "constraint_type",
+                    "payment_sources"
+                ],
+                "properties": {
+                    "constraint_type": {
+                        "type": "string",
+                        "enum": [
+                            "INCLUDE"
+                        ]
+                    },
+                    "payment_sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order": {
                 "required": [
                     "create_time",
@@ -3656,6 +3995,7 @@
             },
             "paypal_v2_order_payment_source": {
                 "required": [
+                    "afterpay",
                     "apple_pay",
                     "pay_upon_invoice",
                     "bancontact",
@@ -3664,17 +4004,27 @@
                     "card",
                     "eps",
                     "ideal",
+                    "klarna",
                     "multibanco",
                     "my_bank",
                     "oxxo",
                     "p_2_4",
                     "paypal",
+                    "swish",
                     "token",
                     "trustly",
                     "google_pay",
                     "venmo"
                 ],
                 "properties": {
+                    "afterpay": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_afterpay"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "apple_pay": {
                         "$ref": "#/components/schemas/paypal_v2_order_payment_source_apple_pay"
                     },
@@ -3734,6 +4084,14 @@
                         ],
                         "nullable": true
                     },
+                    "klarna": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_klarna"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "multibanco": {
                         "oneOf": [
                             {
@@ -3774,6 +4132,14 @@
                         ],
                         "nullable": true
                     },
+                    "swish": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_swish"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "token": {
                         "oneOf": [
                             {
@@ -3805,6 +4171,42 @@
                             }
                         ],
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_afterpay": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone",
+                    "birth_date"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "birth_date": {
+                        "type": "string",
+                        "format": "date"
                     }
                 },
                 "type": "object"
@@ -4376,6 +4778,37 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_payment_source_klarna": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_payment_source_multibanco": {
                 "required": [
                     "name",
@@ -4595,6 +5028,33 @@
                             }
                         ],
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_swish": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "phone": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -5668,7 +6128,8 @@
                     "products",
                     "capabilities",
                     "legal_consents",
-                    "links"
+                    "links",
+                    "legal_country_code"
                 ],
                 "properties": {
                     "business_entity": {
@@ -5712,6 +6173,9 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
+                    },
+                    "legal_country_code": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -5807,14 +6271,23 @@
             },
             "paypal_v2_referral_operation_api_integration_preference_rest_api_integration_third_party_details": {
                 "required": [
-                    "features"
+                    "features",
+                    "signup_mode",
+                    "organization"
                 ],
                 "properties": {
                     "features": {
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "deprecated": true
+                    },
+                    "signup_mode": {
+                        "type": "string"
+                    },
+                    "organization": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -1389,6 +1389,92 @@ export interface components {
             type: string;
             code: string;
         };
+        paypal_v2_eligible_methods_data: {
+            eligible_methods: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods"];
+            supplementary_data: components["schemas"]["paypal_v2_eligible_methods_data_supplementary_data"];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods: {
+            paypal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"];
+            paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"];
+            apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_apple_pay"];
+            google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_google_pay"];
+            advanced_cards: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"];
+            eps: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_eps"];
+            p_2_4: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_p24"];
+            blik: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_blik"];
+            ideal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_ideal"];
+            bizum: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bizum"];
+            bancontact: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bancontact"];
+            klarna: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_klarna"];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards: {
+            supports_installements: boolean;
+            cobranded_enabled: boolean;
+            vendors: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"][];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            eligible: boolean;
+            network: string;
+            branded: boolean;
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            config: Record<string, unknown>[];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_bancontact: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_bizum: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_blik: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_eps: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            config: Record<string, unknown>[];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_ideal: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_klarna: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_p24: unknown;
+        paypal_v2_eligible_methods_data_eligible_methods_paypal: {
+            can_be_vaulted: boolean;
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            /** @description ISO 3166-1 alpha-2 country code */
+            country_code: string;
+            product_code: string;
+        };
+        paypal_v2_eligible_methods_data_supplementary_data: {
+            /** @description ISO 3166-1 alpha-2 country code */
+            buyer_country_code: string;
+        };
+        paypal_v2_find_eligible_methods: {
+            customer: components["schemas"]["paypal_v2_find_eligible_methods_customer"];
+            preferences: components["schemas"]["paypal_v2_find_eligible_methods_preferences"];
+            /**
+             * @description Does not have to be a full purchase unit.
+             *     `[{"amount":{"currency_code":"<iso-4217-code>"},"payee":{"merchant_id":"<merchant-id>"}}]` is enough.
+             */
+            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
+        };
+        paypal_v2_find_eligible_methods_customer: {
+            /** @description ISO 3166-1 alpha-2 country code */
+            country_code: string;
+            channel: components["schemas"]["paypal_v2_find_eligible_methods_customer_channel"];
+        };
+        paypal_v2_find_eligible_methods_customer_channel: {
+            browser_type: string | null;
+            client_os: string | null;
+            device_type: string | null;
+        };
+        paypal_v2_find_eligible_methods_preferences: {
+            /** @enum {string} */
+            payment_flow: "ONE_TIME_PAYMENT";
+            commit: boolean;
+            /** @enum {string} */
+            intent: "CAPTURE" | "AUTHORIZE";
+            vault: boolean;
+            payment_source_constraint: components["schemas"]["paypal_v2_find_eligible_methods_preferences_payment_source_constraint"];
+        };
+        paypal_v2_find_eligible_methods_preferences_payment_source_constraint: {
+            /** @enum {string} */
+            constraint_type: "INCLUDE";
+            payment_sources: string[];
+        };
         paypal_v2_order: {
             create_time: string;
             update_time: string;
@@ -1431,6 +1517,7 @@ export interface components {
             address: components["schemas"]["paypal_v2_common_address"];
         };
         paypal_v2_order_payment_source: {
+            afterpay: components["schemas"]["paypal_v2_order_payment_source_afterpay"] | null;
             apple_pay: components["schemas"]["paypal_v2_order_payment_source_apple_pay"];
             pay_upon_invoice: components["schemas"]["paypal_v2_order_payment_source_pay_upon_invoice"] | null;
             bancontact: components["schemas"]["paypal_v2_order_payment_source_bancontact"] | null;
@@ -1439,15 +1526,26 @@ export interface components {
             card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
             eps: components["schemas"]["paypal_v2_order_payment_source_eps"] | null;
             ideal: components["schemas"]["paypal_v2_order_payment_source_ideal"] | null;
+            klarna: components["schemas"]["paypal_v2_order_payment_source_klarna"] | null;
             multibanco: components["schemas"]["paypal_v2_order_payment_source_multibanco"] | null;
             my_bank: components["schemas"]["paypal_v2_order_payment_source_my_bank"] | null;
             oxxo: components["schemas"]["paypal_v2_order_payment_source_oxxo"] | null;
             p_2_4: components["schemas"]["paypal_v2_order_payment_source_p24"] | null;
             paypal: components["schemas"]["paypal_v2_order_payment_source_paypal"] | null;
+            swish: components["schemas"]["paypal_v2_order_payment_source_swish"] | null;
             token: components["schemas"]["paypal_v2_order_payment_source_token"] | null;
             trustly: components["schemas"]["paypal_v2_order_payment_source_trustly"] | null;
             google_pay: components["schemas"]["paypal_v2_order_payment_source_google_pay"] | null;
             venmo: components["schemas"]["paypal_v2_order_payment_source_venmo"] | null;
+        };
+        paypal_v2_order_payment_source_afterpay: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            email: string;
+            phone: string;
+            /** Format: date */
+            birth_date: string;
         };
         paypal_v2_order_payment_source_apple_pay: {
             name: string;
@@ -1584,6 +1682,13 @@ export interface components {
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
         };
+        paypal_v2_order_payment_source_klarna: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            email: string;
+            phone: string;
+        };
         paypal_v2_order_payment_source_multibanco: {
             name: string;
             country_code: string;
@@ -1634,6 +1739,12 @@ export interface components {
             birth_date: string;
             phone_type: string;
             attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
+        };
+        paypal_v2_order_payment_source_swish: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            phone: string;
         };
         paypal_v2_order_payment_source_token: {
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
@@ -1874,6 +1985,7 @@ export interface components {
             capabilities: string[];
             legal_consents: components["schemas"]["paypal_v2_referral_legal_consent"][];
             links: components["schemas"]["paypal_v2_common_link"][];
+            legal_country_code: string;
         };
         paypal_v2_referral_business_entity: {
             addresses: components["schemas"]["paypal_v2_referral_business_entity_address"][];
@@ -1904,7 +2016,10 @@ export interface components {
             third_party_details: components["schemas"]["paypal_v2_referral_operation_api_integration_preference_rest_api_integration_third_party_details"];
         };
         paypal_v2_referral_operation_api_integration_preference_rest_api_integration_third_party_details: {
+            /** @deprecated */
             features: string[];
+            signup_mode: string;
+            organization: string;
         };
         paypal_v2_referral_partner_config_override: {
             return_url: string;

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -119,7 +119,7 @@ class ExpressCustomerServiceTest extends TestCase
         $orderData['payment_source']['paypal']['name']['given_name'] = 'Test Given';
         $orderData['payment_source']['paypal']['name']['surname'] = 'Test Surname';
 
-        $order = new Order()->assign($orderData);
+        $order = (new Order())->assign($orderData);
         $order->getPurchaseUnits()->first()?->setShipping(null);
         $customer = $this->doLogin($order);
 

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -113,6 +113,20 @@ class ExpressCustomerServiceTest extends TestCase
         static::assertCount(2, $addresses);
     }
 
+    public function testLoginWithoutShippingAddress(): void
+    {
+        $orderData = GetOrderCapture::get();
+        $orderData['payment_source']['paypal']['name']['given_name'] = 'Test Given';
+        $orderData['payment_source']['paypal']['name']['surname'] = 'Test Surname';
+
+        $order = new Order()->assign($orderData);
+        $order->getPurchaseUnits()->first()?->setShipping(null);
+        $customer = $this->doLogin($order);
+
+        static::assertSame('Test Surname', $customer->getLastName());
+        static::assertSame('Test Given', $customer->getFirstName());
+    }
+
     public function testLoginDifferentAccountSameEmail(): void
     {
         $order = new Order();

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -103,7 +103,7 @@ class ExpressCustomerServiceTest extends TestCase
         $order->assign(GetOrderCapture::get());
         $firstCustomer = $this->doLogin($order);
 
-        $order->getPurchaseUnits()->first()?->getShipping()->getAddress()->setPostalCode('abcde');
+        $order->getPurchaseUnits()->first()?->getShipping()?->getAddress()->setPostalCode('abcde');
         $secondCustomer = $this->doLogin($order);
 
         static::assertSame($firstCustomer->getId(), $secondCustomer->getId());


### PR DESCRIPTION
### 1. Why is this change necessary?
Shipping might not be set and therefore it is nullable. We need to check if this property is null

https://github.com/shopware/paypal-sdk/pull/72

### 2. What does this change do, exactly?
Checks, if the property `shipping` is null

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/SwagPayPal/issues/521

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
