### PR TITLE
fix: http cache unnecessary session creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where the HTTP cache was unnecessarily disturbed by creating a session
+
 # 10.4.2
 - Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total
 - Fixes an issue, where accessing an uninitialized object during express checkout (shopware/SwagPayPal#512)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Fixes an issue, where the HTTP cache was unnecessarily disturbed by creating a session
-
 # 10.4.2
 - Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total
 - Fixes an issue, where accessing an uninitialized object during express checkout (shopware/SwagPayPal#512)
+- Fixes an issue, where the HTTP cache was unnecessarily disturbed by creating a session (shopware/SwagPayPal#529)
 
 # 10.4.1
 - Fixes an issue, where required cookies were not displayed in the banner even though PayPal scripts had been loaded (shopware/SwagPayPal#506)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,9 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Behebt ein Problem, bei dem der HTTP-Cache durch das Erstellen einer Sitzung unnötig gestört wurde
-
 # 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten.
 - Behebt ein Problem, bei dem im PayPal Express Checkout der Zugriff auf ein nicht initialisiertes Objekt erfolgte (shopware/SwagPayPal#521)
+- Behebt ein Problem, bei dem der HTTP-Cache durch das Erstellen einer Sitzung unnötig gestört wurde (shopware/SwagPayPal#529)
 
 # 10.4.1
 - Behebt ein Problem, bei dem erforderliche Cookies nicht im Banner angezeigt wurden, obwohl PayPal-Skripte geladen wurden (shopware/SwagPayPal#506)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem der HTTP-Cache durch das Erstellen einer Sitzung unnötig gestört wurde
+
 # 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten.
 - Behebt ein Problem, bei dem im PayPal Express Checkout der Zugriff auf ein nicht initialisiertes Objekt erfolgte (shopware/SwagPayPal#521)

--- a/src/Storefront/Data/Service/FundingEligibilityDataService.php
+++ b/src/Storefront/Data/Service/FundingEligibilityDataService.php
@@ -44,16 +44,15 @@ class FundingEligibilityDataService extends AbstractScriptDataService
 
     private function getFilteredPaymentMethods(): array
     {
-        $handlers = $this->requestStack->getSession()->get(MethodEligibilityRoute::SESSION_KEY, []);
-        if (!$handlers) {
+        if (!$this->requestStack->getCurrentRequest()?->hasSession() || !$this->requestStack->getSession()->isStarted()) {
             return [];
         }
 
-        $methods = [];
-        foreach ($handlers as $handler) {
-            $methods[] = \array_search($handler, MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS, true);
-        }
+        $handlers = $this->requestStack->getSession()->get(MethodEligibilityRoute::SESSION_KEY, []);
 
-        return \array_filter($methods);
+        return \array_keys(\array_filter(\array_intersect(
+            MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS,
+            $handlers,
+        )));
     }
 }

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -50,7 +50,55 @@ class FundingSubscriberTest extends TestCase
 {
     private const TEST_CLIENT_ID = 'testClientId';
 
+    private SystemConfigService $systemConfigService;
+
     private Session $session;
+
+    private RequestStack $requestStack;
+
+    private FundingSubscriber $subscriber;
+
+    private FundingEligibilityDataService $dataService;
+
+    protected function setUp(): void
+    {
+        $this->systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+
+        $credentialsUtil = new CredentialsUtil($this->systemConfigService);
+
+        $localeCodeProvider = $this->createMock(LocaleCodeProvider::class);
+        $localeCodeProvider->method('getFormattedLocaleCode')->willReturn('en_GB');
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->atMost(2))->method('generate')->willReturn('/paypal/payment-method-eligibility');
+
+        $this->session = new Session(new MockArraySessionStorage());
+        $this->session->set(MethodEligibilityRoute::SESSION_KEY, [SEPAHandler::class]);
+
+        $request = new Request();
+        $request->setSession($this->session);
+
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push($request);
+
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->method('isPaymentMethodActive')
+            ->with(static::isInstanceOf(SalesChannelContext::class), \array_values(MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS))
+            ->willReturn(true);
+
+        $this->subscriber = new FundingSubscriber(
+            new SettingsValidationService($this->systemConfigService, new NullLogger()),
+            $this->dataService = new FundingEligibilityDataService(
+                $credentialsUtil,
+                $this->systemConfigService,
+                $localeCodeProvider,
+                $router,
+                $this->requestStack
+            ),
+            $paymentMethodUtil,
+        );
+    }
 
     public function testGetSubscribedEvents(): void
     {
@@ -66,11 +114,9 @@ class FundingSubscriberTest extends TestCase
 
     public function testAddNoSettings(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $subscriber = $this->createSubscriber($systemConfigService);
         $event = $this->createFooterPageletLoadedEvent();
         // @deprecated tag:v11.0.0 - Remove this line below.
-        $subscriber->addFundingAvailabilityDataToFooter($event);
+        $this->subscriber->addFundingAvailabilityDataToFooter($event);
 
         static::assertFalse($event->getPagelet()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
@@ -80,12 +126,11 @@ class FundingSubscriberTest extends TestCase
      */
     public function testAddFundingAvailabilityDataToFooter(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
-        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
-        $subscriber = $this->createSubscriber($systemConfigService);
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
         $event = $this->createFooterPageletLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToFooter($event);
+
+        $this->subscriber->addFundingAvailabilityDataToFooter($event);
 
         $extension = $event->getPagelet()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION);
 
@@ -100,34 +145,42 @@ class FundingSubscriberTest extends TestCase
 
     public function testAddFundingAvailabilityDataToPageNoSettings(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $subscriber = $this->createSubscriber($systemConfigService);
         $event = $this->createGenericPageLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToPage($event);
+
+        $this->subscriber->addFundingAvailabilityDataToPage($event);
 
         static::assertFalse($event->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
     public function testAddFundingAvailabilityDataToPageNoActivePaymentMethods(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
-        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
-        $subscriber = $this->createSubscriber($systemConfigService, false);
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+
+        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
+        $paymentMethodUtil
+            ->method('isPaymentMethodActive')
+            ->willReturn(false);
+
+        $this->subscriber = new FundingSubscriber(
+            new SettingsValidationService($this->systemConfigService, new NullLogger()),
+            $this->dataService,
+            $paymentMethodUtil,
+        );
+
         $event = $this->createGenericPageLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToPage($event);
+        $this->subscriber->addFundingAvailabilityDataToPage($event);
 
         static::assertFalse($event->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
     public function testAddFundingAvailabilityDataToPage(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
-        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
-        $subscriber = $this->createSubscriber($systemConfigService);
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
         $event = $this->createGenericPageLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToPage($event);
+
+        $this->subscriber->addFundingAvailabilityDataToPage($event);
 
         $extension = $event->getPage()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION);
 
@@ -140,16 +193,31 @@ class FundingSubscriberTest extends TestCase
         static::assertSame(['SEPA'], $extension->getFilteredPaymentMethods());
     }
 
+    public function testAddFundingAvailabilityDataToPageWithoutSession(): void
+    {
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
+        $event = $this->createGenericPageLoadedEvent();
+
+        $this->requestStack->pop();
+        $this->requestStack->push(new Request());
+
+        $this->subscriber->addFundingAvailabilityDataToPage($event);
+
+        $extension = $event->getPage()->getExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION);
+
+        static::assertInstanceOf(FundingEligibilityData::class, $extension);
+        static::assertSame([], $extension->getFilteredPaymentMethods());
+    }
+
     public function testRemoveFundingAvailabilityDataFromCheckoutConfirmPage(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
-        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
-        $subscriber = $this->createSubscriber($systemConfigService);
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
 
         // Add the extension via GenericPageLoadedEvent
         $genericEvent = $this->createGenericPageLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToPage($genericEvent);
+        $this->subscriber->addFundingAvailabilityDataToPage($genericEvent);
         static::assertTrue($genericEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
 
         // Create CheckoutConfirmPage with the extension
@@ -164,21 +232,19 @@ class FundingSubscriberTest extends TestCase
         );
 
         // Remove the extension
-        $subscriber->removeFundingAvailabilityDataFromPage($confirmEvent);
+        $this->subscriber->removeFundingAvailabilityDataFromPage($confirmEvent);
 
         static::assertFalse($confirmEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
     }
 
     public function testRemoveFundingAvailabilityDataFromCheckoutRegisterPage(): void
     {
-        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
-        $systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
-        $systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
-        $subscriber = $this->createSubscriber($systemConfigService);
+        $this->systemConfigService->set(Settings::CLIENT_ID, self::TEST_CLIENT_ID);
+        $this->systemConfigService->set(Settings::CLIENT_SECRET, 'testClientSecret');
 
         // First add the extension via GenericPageLoadedEvent
         $genericEvent = $this->createGenericPageLoadedEvent();
-        $subscriber->addFundingAvailabilityDataToPage($genericEvent);
+        $this->subscriber->addFundingAvailabilityDataToPage($genericEvent);
         static::assertTrue($genericEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
 
         // Create CheckoutRegisterPage with the extension
@@ -193,45 +259,9 @@ class FundingSubscriberTest extends TestCase
         );
 
         // Remove the extension
-        $subscriber->removeFundingAvailabilityDataFromPage($registerEvent);
+        $this->subscriber->removeFundingAvailabilityDataFromPage($registerEvent);
 
         static::assertFalse($registerEvent->getPage()->hasExtension(FundingSubscriber::FUNDING_ELIGIBILITY_EXTENSION));
-    }
-
-    private function createSubscriber(SystemConfigService $systemConfig, bool $paymentMethodsActive = true): FundingSubscriber
-    {
-        $credentialsUtil = new CredentialsUtil($systemConfig);
-
-        $localeCodeProvider = $this->createMock(LocaleCodeProvider::class);
-        $localeCodeProvider->method('getFormattedLocaleCode')->willReturn('en_GB');
-
-        $router = $this->createMock(RouterInterface::class);
-        $router->expects($this->atMost(1))->method('generate')->willReturn('/paypal/payment-method-eligibility');
-
-        $this->session = new Session(new MockArraySessionStorage());
-        $this->session->set(MethodEligibilityRoute::SESSION_KEY, [SEPAHandler::class]);
-        $request = new Request();
-        $request->setSession($this->session);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
-
-        $paymentMethodUtil = $this->createMock(PaymentMethodUtil::class);
-        $paymentMethodUtil
-            ->method('isPaymentMethodActive')
-            ->with(static::isInstanceOf(SalesChannelContext::class), \array_values(MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS))
-            ->willReturn($paymentMethodsActive);
-
-        return new FundingSubscriber(
-            new SettingsValidationService($systemConfig, new NullLogger()),
-            new FundingEligibilityDataService(
-                $credentialsUtil,
-                $systemConfig,
-                $localeCodeProvider,
-                $router,
-                $requestStack
-            ),
-            $paymentMethodUtil,
-        );
     }
 
     private function createFooterPageletLoadedEvent(): FooterPageletLoadedEvent


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
> The FundingEligibilityDataService::getFilteredPaymentMethods() method calls $this->requestStack->getSession() without a try-catch block. This starts a PHP
session for every visitor on every page load, because FundingSubscriber listens to FooterPageletLoadedEvent which fires on every storefront page.
> 
> This completely breaks Shopware's HTTP cache for anonymous visitors, as the session cookie prevents caching.

### 2. What does this change do, exactly?
Only check the session if one got started

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- fixes #529

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
