### PR TITLE
[6.5.x] fix: log constraint violation errors correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where causes for validation errors were not logged correctly
+
 # 8.9.1
 - Fixes an issue, where required cookies were not displayed in the banner even though PayPal scripts had been loaded (shopware/SwagPayPal#506)
 - Fixes an issue, where languages not supported by PayPal did not fall back to a supported language (shopware/shopware#13950)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem Ursachen für Validierungsfehler nicht korrekt protokolliert wurden
+
 # 8.9.1
 - Behebt ein Problem, bei dem erforderliche Cookies nicht im Banner angezeigt wurden, obwohl PayPal-Skripte geladen wurden (shopware/SwagPayPal#506)
 - Behebt ein Problem, bei dem nicht von PayPal unterstützte Sprachen nicht auf eine unterstützte Sprache korrigiert wurden (shopware/shopware#13950)

--- a/src/Util/IntrospectionProcessor.php
+++ b/src/Util/IntrospectionProcessor.php
@@ -15,6 +15,7 @@ use Psr\Log\LogLevel;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Swag\PayPal\Pos\Api\Exception\PosException;
 use Swag\PayPal\Pos\Client\AbstractClient as PosAbstractClient;
 use Swag\PayPal\RestApi\Client\AbstractClient;
@@ -140,20 +141,26 @@ class IntrospectionProcessor implements ProcessorInterface
      */
     private function exceptionToContext(\Throwable $exception): array
     {
-        $context = [
-            'message' => $exception->getMessage(),
-            'class' => $this->traceToClassString($exception->getTrace()[0]),
-            'file' => $exception->getFile(),
-            'line' => $exception->getLine(),
-        ];
+        $context = ['message' => $exception->getMessage()];
 
         if ($exception instanceof ShopwareHttpException) {
             $context['parameters'] = $exception->getParameters();
         }
 
+        if ($exception instanceof ConstraintViolationException) {
+            foreach ($exception->getViolations() as $violation) {
+                $context['parameters']['violations'][] = (string) $violation;
+            }
+        }
+
         if ($exception instanceof HttpException || $exception instanceof PosException) {
             $context['errorCode'] = $exception->getErrorCode();
         }
+
+        // Order class, file and line at the end to make the exception & the most important information more readable in logs
+        $context['class'] = $this->traceToClassString($exception->getTrace()[0]);
+        $context['file'] = $exception->getFile();
+        $context['line'] = $exception->getLine();
 
         if ($exception->getPrevious()) {
             $context['previous'] = $this->exceptionToContext($exception->getPrevious());

--- a/tests/Util/IntrospectionProcessorTest.php
+++ b/tests/Util/IntrospectionProcessorTest.php
@@ -12,6 +12,7 @@ use Monolog\Logger;
 use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\Kernel;
 use Swag\PayPal\Checkout\Payment\Handler\PayPalHandler;
 use Swag\PayPal\Pos\Api\Exception\PosException;
@@ -21,6 +22,8 @@ use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\Storefront\Controller\PayPalController;
 use Swag\PayPal\Util\IntrospectionProcessor;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * @internal
@@ -268,6 +271,24 @@ class IntrospectionProcessorTest extends TestCase
                 'message' => 'The error "test-name" occurred with the following message: test-message',
                 'parameters' => ['name' => 'test-name', 'message' => 'test-message'],
                 'errorCode' => 'SWAG_PAYPAL__POS_EXCEPTION',
+            ]],
+        ];
+
+        yield 'ConstraintViolationException' => [
+            ['exception' => new ConstraintViolationException(new ConstraintViolationList([new ConstraintViolation(
+                'test message',
+                'test message template with {{ type }}',
+                ['{{ type }}' => 'testParameter'],
+                '/root',
+                'testProperty',
+                'VIOLATION_TESTPROPERTY_INVALID'
+            )]), [])],
+            ['exception' => [
+                'message' => 'Caught 1 violation errors.',
+                'parameters' => [
+                    'count' => 1,
+                    'violations' => ["/root.testProperty:\n    test message"],
+                ],
             ]],
         ];
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Constraint violation errors were not logged correctly, as the json-seralized exception does not contain any information about the reasons for the violations - just the amount of them

### 2. What does this change do, exactly?
Serializes the constraint violation list correctly

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

- relates #550

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
