### PR TITLE
fix: correct refund ACL permission check in the Administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where ACL permissions were not set correctly (shopware/SwagPayPal#556)
+
 # 10.4.3
 - Fixes an issue, where causes for validation errors were not logged correctly
-- Correct refund ACL permission check in admin (shopware/SwagPayPal#556)
 
 # 10.4.2
 - Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Fixes an issue, where ACL permissions were not set correctly (shopware/SwagPayPal#556)
+- Fixes an issue, where refunds where possible as order editor, whereas order refund editor should be prefered (shopware/SwagPayPal#556)
 
 # 10.4.3
 - Fixes an issue, where causes for validation errors were not logged correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 10.4.3
 - Fixes an issue, where causes for validation errors were not logged correctly
+- Correct refund ACL permission check in admin (shopware/SwagPayPal#556)
 
 # 10.4.2
 - Fixes an issue, where if an order was edited in the Administration, the payment amount could differ from the newly calculated total

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,6 @@
 # 10.4.3
 - Behebt ein Problem, bei dem Ursachen für Validierungsfehler nicht korrekt protokolliert wurden
-- Korrekte ACL-Berechtigungsprüfung für Rückerstattungen in der Administration korrigieren (shopware/SwagPayPal#556)
+- Korrekte ACL-Berechtigungsprüfung für Rückerstattungen in der Administration (shopware/SwagPayPal#556)
 
 # 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Behebt ein Problem, bei dem ACL-Berechtigungen nicht korrekt festgelegt waren (shopware/SwagPayPal#556)
+- Behebt ein Problem, bei dem Rückerstattungen als Bestell-Editor möglich waren, obwohl der Rückerstattungs-Editor der Bestellung bevorzugt werden sollte (shopware/SwagPayPal#556)
 
 # 10.4.3
 - Behebt ein Problem, bei dem Ursachen für Validierungsfehler nicht korrekt protokolliert wurden

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,8 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem ACL-Berechtigungen nicht korrekt festgelegt waren (shopware/SwagPayPal#556)
+
 # 10.4.3
 - Behebt ein Problem, bei dem Ursachen für Validierungsfehler nicht korrekt protokolliert wurden
-- Korrekte ACL-Berechtigungsprüfung für Rückerstattungen in der Administration (shopware/SwagPayPal#556)
 
 # 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # 10.4.3
 - Behebt ein Problem, bei dem Ursachen für Validierungsfehler nicht korrekt protokolliert wurden
+- Korrekte ACL-Berechtigungsprüfung für Rückerstattungen in der Administration korrigieren (shopware/SwagPayPal#556)
 
 # 10.4.2
 - Behebt ein Problem, bei dem nach Bestelländerungen in der Administration Zahlungs- und Bestellsumme voneinander abweichen konnten

--- a/src/OrdersApi/Administration/PayPalOrdersController.php
+++ b/src/OrdersApi/Administration/PayPalOrdersController.php
@@ -212,7 +212,7 @@ class PayPalOrdersController extends AbstractController
             content: new OA\JsonContent(ref: Order\PurchaseUnit\Payments\Refund::class)
         )]
     )]
-    #[Route(path: '/api/paypal-v2/refund/{orderTransactionId}/{refundId}', name: 'api.paypal_v2.refund_details', defaults: ['_acl' => ['order.viewer']], methods: ['GET'])]
+    #[Route(path: '/api/paypal-v2/refund/{orderTransactionId}/{refundId}', name: 'api.paypal_v2.refund_details', defaults: ['_acl' => ['order_refund.viewer']], methods: ['GET'])]
     public function refundDetails(string $orderTransactionId, string $refundId, Context $context): JsonResponse
     {
         $refund = $this->refundResource->get(
@@ -267,7 +267,7 @@ class PayPalOrdersController extends AbstractController
             content: new OA\JsonContent(ref: Order\PurchaseUnit\Payments\Refund::class)
         )]
     )]
-    #[Route(path: '/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}', name: 'api.action.paypal_v2.refund_capture', defaults: ['_acl' => ['order.editor']], methods: ['POST'])]
+    #[Route(path: '/api/_action/paypal-v2/refund-capture/{orderTransactionId}/{captureId}/{paypalOrderId}', name: 'api.action.paypal_v2.refund_capture', defaults: ['_acl' => ['order_refund.editor']], methods: ['POST'])]
     public function refundCapture(
         string $orderTransactionId,
         string $captureId,

--- a/src/Resources/app/administration/src/module/swag-paypal-payment/component/swag-paypal-payment-actions-v2/swag-paypal-payment-actions-v2.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-payment/component/swag-paypal-payment-actions-v2/swag-paypal-payment-actions-v2.html.twig
@@ -31,7 +31,7 @@
         <mt-button
             variant="primary"
             size="small"
-            :disabled="refundableAmount <= 0 || !acl.can('order.editor')"
+            :disabled="refundableAmount <= 0 || !acl.can('order_refund.editor')"
             @click="spawnModal('refund')"
         >
             {{ $t('swag-paypal-payment.buttons.label.refund') }}


### PR DESCRIPTION
### 1. Why is this change necessary?
- The refund button in the admin currently checks the `order.editor` permission instead of `order_refund.editor`.
- Also the same ACL check for fetching refunds details on orders api.

### 2. What does this change do, exactly?
- This change updates the ACL check for the refund button to use `order_refund.editor`
- Also the same fix for fetching refunds details on orders api.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new user role
2. Disable the permission Orders -> Refunds
3. Assign the role to a user
4. Log in as that user
5. Open a PayPal-paid order and check the refund button state

### 4. Please link to the relevant issues
- Fixes https://github.com/shopware/SwagPayPal/issues/530

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
