### PR TITLE
fix: call deprecated method silently

### DIFF
--- a/src/OrdersApi/Builder/Util/ItemListProvider.php
+++ b/src/OrdersApi/Builder/Util/ItemListProvider.php
@@ -58,7 +58,7 @@ class ItemListProvider
             $this->setName($lineItem, $item);
             $this->setSku($lineItem, $item);
 
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @deprecated tag:v11.0.0 - state will be removed without replacement */
             /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
             $category = \in_array(State::IS_DOWNLOAD, $lineItem->getStates(), true) ? Item::CATEGORY_DIGITAL_GOODS : Item::CATEGORY_PHYSICAL_GOODS;
             if (
@@ -92,11 +92,11 @@ class ItemListProvider
             $this->setName($lineItem, $item);
             $this->setSku($lineItem, $item);
 
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @deprecated tag:v11.0.0 - state will be removed without replacement */
             /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
             $category = \in_array(State::IS_DOWNLOAD, $lineItem->getStates(), true) ? Item::CATEGORY_DIGITAL_GOODS : Item::CATEGORY_PHYSICAL_GOODS;
             if (Feature::isActive('v6.8.0.0') && \defined(ProductDefinition::class . '::TYPE_DIGITAL')) {
-                /** @deprecated tag:v12.0.0 - reason:return-type-change - will use "strong" return type `mixed` */
+                /** @deprecated tag:v11.0.0 - reason:return-type-change - will use "strong" return type `mixed` */
                 /** @phpstan-ignore method.deprecated */
                 $category = $lineItem->getPayloadValue('productType') === ProductDefinition::TYPE_DIGITAL ? Item::CATEGORY_DIGITAL_GOODS : Item::CATEGORY_PHYSICAL_GOODS;
             }

--- a/src/Util/Availability/AvailabilityContextBuilder.php
+++ b/src/Util/Availability/AvailabilityContextBuilder.php
@@ -30,15 +30,16 @@ final class AvailabilityContextBuilder
     public static function buildFromCart(Cart $cart, SalesChannelContext $salesChannelContext): AvailabilityContext
     {
         $lineItems = $cart->getLineItems();
-        /** @deprecated tag:v12.0.0 - state will be removed without replacement */
-        /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
-        $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
         if (
             Feature::isActive('v6.8.0.0')
             && \defined(ProductDefinition::class . '::TYPE_DIGITAL')
             && \method_exists($lineItems, 'hasLineItemWithProductType') // @phpstan-ignore function.alreadyNarrowedType
         ) {
             $hasDigitalProduct = $lineItems->hasLineItemWithProductType(ProductDefinition::TYPE_DIGITAL);
+        } else {
+            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
+            $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
         }
 
         return self::buildContext(
@@ -51,15 +52,16 @@ final class AvailabilityContextBuilder
 
     public static function buildFromProduct(SalesChannelProductEntity $product, SalesChannelContext $salesChannelContext): AvailabilityContext
     {
-        /** @deprecated tag:v12.0.0 - state will be removed without replacement */
-        /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
-        $isDigital = \in_array(State::IS_DOWNLOAD, $product->getStates(), true);
         if (
             Feature::isActive('v6.8.0.0')
             && \defined(ProductDefinition::class . '::TYPE_DIGITAL')
             && \method_exists($product, 'getType') // @phpstan-ignore function.alreadyNarrowedType
         ) {
             $isDigital = $product->getType() === ProductDefinition::TYPE_DIGITAL;
+        } else {
+            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
+            $isDigital = \in_array(State::IS_DOWNLOAD, $product->getStates(), true);
         }
 
         return self::buildContext(
@@ -75,15 +77,16 @@ final class AvailabilityContextBuilder
         $hasDigitalProduct = false;
         $lineItems = $order->getLineItems();
         if ($lineItems) {
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
-            /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
-            $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
             if (
                 Feature::isActive('v6.8.0.0')
                 && \defined(ProductDefinition::class . '::TYPE_DIGITAL')
                 && \method_exists($lineItems, 'hasLineItemWithType') // @phpstan-ignore function.alreadyNarrowedType
             ) {
                 $hasDigitalProduct = $lineItems->hasLineItemWithType(ProductDefinition::TYPE_DIGITAL);
+            } else {
+                /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+                /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
+                $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
             }
         }
 

--- a/src/Util/Availability/AvailabilityContextBuilder.php
+++ b/src/Util/Availability/AvailabilityContextBuilder.php
@@ -37,7 +37,7 @@ final class AvailabilityContextBuilder
         ) {
             $hasDigitalProduct = $lineItems->hasLineItemWithProductType(ProductDefinition::TYPE_DIGITAL);
         } else {
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @deprecated tag:v11.0.0 - state will be removed without replacement */
             /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
             $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
         }
@@ -59,7 +59,7 @@ final class AvailabilityContextBuilder
         ) {
             $isDigital = $product->getType() === ProductDefinition::TYPE_DIGITAL;
         } else {
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @deprecated tag:v11.0.0 - state will be removed without replacement */
             /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
             $isDigital = \in_array(State::IS_DOWNLOAD, $product->getStates(), true);
         }
@@ -84,7 +84,7 @@ final class AvailabilityContextBuilder
             ) {
                 $hasDigitalProduct = $lineItems->hasLineItemWithType(ProductDefinition::TYPE_DIGITAL);
             } else {
-                /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+                /** @deprecated tag:v11.0.0 - state will be removed without replacement */
                 /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
                 $hasDigitalProduct = $lineItems->hasLineItemWithState(State::IS_DOWNLOAD);
             }

--- a/tests/OrdersApi/Builder/Util/ItemListProviderTest.php
+++ b/tests/OrdersApi/Builder/Util/ItemListProviderTest.php
@@ -60,7 +60,7 @@ class ItemListProviderTest extends TestCase
 
         $lineItem = $order->getLineItems()?->first();
         if ($lineItem) {
-            /** @deprecated tag:v12.0.0 - state will be removed without replacement */
+            /** @deprecated tag:v11.0.0 - state will be removed without replacement */
             /** @phpstan-ignore classConstant.deprecatedClass, method.deprecated */
             $lineItem->setStates([State::IS_DOWNLOAD]);
 
@@ -75,7 +75,7 @@ class ItemListProviderTest extends TestCase
     }
 
     /**
-     * @deprecated tag:v12.0.0 - Will be removed
+     * @deprecated tag:v11.0.0 - Will be removed
      */
     public function testLegacyDigitalProduct(): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
With feature flag `6.8.0` active, this will throw an error

### 2. What does this change do, exactly?
Call deprecated method in `else`

### 3. Describe each step to reproduce the issue or behaviour.
Go to checkout with flag active

### 4. Please link to the relevant issues (if any).
.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
