### PR TITLE
feat: add Austria to Pay Later available countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.5.0
+- Added Austria to the countries where Pay Later is available
+
 # 10.4.4
 - Fixes an issue, where refunds where possible as order editor, whereas order refund editor should be prefered (shopware/SwagPayPal#556)
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.5.0
+- Fügt Österreich zu den Ländern hinzu, in denen „Später bezahlen“ verfügbar ist
+
 # 10.4.4
 - Behebt ein Problem, bei dem Rückerstattungen als Bestell-Editor möglich waren, obwohl der Rückerstattungs-Editor der Bestellung bevorzugt werden sollte (shopware/SwagPayPal#556)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.4.4",
+    "version": "10.5.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Util/Lifecycle/Method/PayLaterMethodData.php
+++ b/src/Util/Lifecycle/Method/PayLaterMethodData.php
@@ -31,6 +31,7 @@ class PayLaterMethodData extends AbstractMethodData implements CheckoutDataMetho
      * @see https://developer.paypal.com/studio/checkout/pay-later/{{countryCode}}
      */
     public const PAYPAL_PAY_LATER_CRITERIA = [
+        'AT' => ['currency' => 'EUR', 'minAmount' => 1.00, 'maxAmount' => 10000.00],
         'DE' => ['currency' => 'EUR', 'minAmount' => 1.00, 'maxAmount' => 10000.00],
         'FR' => ['currency' => 'EUR', 'minAmount' => 30.00, 'maxAmount' => 2000.00],
         'IT' => ['currency' => 'EUR', 'minAmount' => 30.00, 'maxAmount' => 2000.00],

--- a/tests/Util/Lifecycle/Method/PayLaterMethodDataTest.php
+++ b/tests/Util/Lifecycle/Method/PayLaterMethodDataTest.php
@@ -116,6 +116,9 @@ class PayLaterMethodDataTest extends TestCase
     {
         return [
             ['ZAR', 'ZA', 1000.00, false],
+            ['EUR', 'AT', 50.00, true],
+            ['EUR', 'AT', 0.50, false],
+            ['EUR', 'AT', 11000.00, false],
             ['EUR', 'DE', 50.00, true],
             ['EUR', 'DE', 0.50, false],
             ['EUR', 'DE', 11000.00, false],


### PR DESCRIPTION
### 1. Why is this change necessary?
Austria has become another Pay Later country

### 2. What does this change do, exactly?
Add Austria to availability rules

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #570 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
