### PR TITLE
Update store workflow to use client credentials [6.6.x]

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -9,6 +9,6 @@ jobs:
     with:
       extensionName: ${{ github.event.repository.name }}
     secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backport of #590.

## Summary

- Migrate the store release workflow from account user/password authentication to client ID/secret credentials
- Replace `accountUser` / `accountPassword` secrets with `clientId` / `clientSecret`
- Reference the new `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` organization secrets

## Test plan

- [ ] Trigger the "Release to Store" workflow manually and verify it authenticates successfully with the new client credentials