### PR TITLE
fix: zero value cart rouding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 10.6.0
-- Added setting to disable the shipping callback for express checkouts.
-- Fixes an issue, where the shiiping callback required the store-api to be exposed.
+- Added setting to disable the shipping callback for express checkouts
+- Fixes an issue, where the shiiping callback required the store-api to be exposed
+- Fixes an issue, where the cart was not correctly detected as free, resulting in errors during the PayPal checkout (shopware/SwagPayPal#591)
 
 # 10.5.0
 - Added Austria to the countries where Pay Later is available

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # 10.6.0
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
 - Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte
+- Behebt ein Problem, bei dem Warenkorbe nicht korrekt als kostenlos erkannt wurden, was zu Fehlern beim PayPal-Checkout führte (shopware/SwagPayPal#591)
 
 # 10.5.0
 - Fügt Österreich zu den Ländern hinzu, in denen „Später bezahlen“ verfügbar ist

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -143,6 +143,11 @@ parameters:
                 - src/Migration/Migration1675420139AddManagerDataToRun.php
                 - src/Migration/Migration1626082072AddStatusAndMessageCountToRun.php
 
+        - # Only name change
+          identifier: method.deprecated
+          message: '#tag:v11.0.0 reason:parameter-type-change - `\$countryCode` will be renamed to `\$currencyIso`#'
+          path: '**/*.php'
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Internal\InternalClassRule

--- a/src/Checkout/Cart/Service/CartPriceService.php
+++ b/src/Checkout/Cart/Service/CartPriceService.php
@@ -9,10 +9,38 @@ namespace Swag\PayPal\Checkout\Cart\Service;
 
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Util\PriceFormatter;
 
 #[Package('checkout')]
 class CartPriceService
 {
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly PriceFormatter $priceFormatter,
+    ) {
+    }
+
+    public function hasZeroPrice(Cart $cart, SalesChannelContext $context): bool
+    {
+        if ($cart->getLineItems()->count() === 0) {
+            return false;
+        }
+
+        $price = $this->priceFormatter->roundPrice($cart->getPrice()->getTotalPrice(), $context->getCurrency()->getIsoCode());
+
+        if ($price > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @deprecated tag:v12.0.0 - Will be removed and is replaced by {@see self::hasZeroPrice}
+     */
     public function isZeroValueCart(Cart $cart): bool
     {
         if ($cart->getLineItems()->count() === 0) {

--- a/src/Checkout/Cart/Service/CartPriceService.php
+++ b/src/Checkout/Cart/Service/CartPriceService.php
@@ -39,7 +39,7 @@ class CartPriceService
     }
 
     /**
-     * @deprecated tag:v12.0.0 - Will be removed and is replaced by {@see self::hasZeroPrice}
+     * @deprecated tag:v11.0.0 - Will be removed and is replaced by {@see self::hasZeroPrice}
      */
     public function isZeroValueCart(Cart $cart): bool
     {

--- a/src/Checkout/Cart/Validation/CartValidator.php
+++ b/src/Checkout/Cart/Validation/CartValidator.php
@@ -75,7 +75,7 @@ class CartValidator implements CartValidatorInterface
             return;
         }
 
-        if ($this->cartPriceService->isZeroValueCart($cart)) {
+        if ($this->cartPriceService->hasZeroPrice($cart, $context)) {
             /** @deprecated tag:v11.0.0 - The order of parameters will be changed to: $id, $name, $reason */
             $errors->add(new PaymentMethodBlockedError($name, 'zero value cart', $id));
 

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -72,7 +72,7 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
             $this->logger->debug('Started');
             $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
 
-            if ($this->cartPriceService->isZeroValueCart($cart)) {
+            if ($this->cartPriceService->hasZeroPrice($cart, $salesChannelContext)) {
                 throw new OrderZeroValueException();
             }
 

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -57,7 +57,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService
             return null;
         }
 
-        if (!$addProductToCart && $this->cartPriceService->isZeroValueCart($cart)) {
+        if (!$addProductToCart && $this->cartPriceService->hasZeroPrice($cart, $salesChannelContext)) {
             return null;
         }
 

--- a/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
+++ b/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
@@ -73,7 +73,7 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
         }
 
         $cart = $this->cartService->getCart($context->getToken(), $context);
-        if ($this->cartPriceService->isZeroValueCart($cart)) {
+        if ($this->cartPriceService->hasZeroPrice($cart, $context)) {
             return $this->removeAllPaymentMethods($response);
         }
 

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -26,7 +26,9 @@
             <tag name="shopware.cart.validator"/>
         </service>
 
-        <service id="Swag\PayPal\Checkout\Cart\Service\CartPriceService"/>
+        <service id="Swag\PayPal\Checkout\Cart\Service\CartPriceService">
+            <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
+        </service>
 
         <service id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute" public="true">
             <argument type="service" id="monolog.logger.paypal"/>

--- a/src/Util/PriceFormatter.php
+++ b/src/Util/PriceFormatter.php
@@ -20,16 +20,22 @@ class PriceFormatter
         'TWD' => 0,
     ];
 
-    public function formatPrice(float $price, ?string $currencyIso = null): string
+    /**
+     * @deprecated tag:v11.0.0 reason:parameter-type-change - `$countryCode` will be renamed to `$currencyIso`
+     */
+    public function formatPrice(float $price, ?string $countryCode = null): string
     {
-        $decimals = $this->getDecimals($currencyIso);
+        $decimals = $this->getDecimals($countryCode);
 
-        return \number_format($this->roundPrice($price, $currencyIso), $decimals, '.', '');
+        return \number_format($this->roundPrice($price, $countryCode), $decimals, '.', '');
     }
 
-    public function roundPrice(float $price, ?string $currencyIso = null): float
+    /**
+     * @deprecated tag:v11.0.0 reason:parameter-type-change - `$countryCode` will be renamed to `$currencyIso`
+     */
+    public function roundPrice(float $price, ?string $countryCode = null): float
     {
-        $decimals = $this->getDecimals($currencyIso);
+        $decimals = $this->getDecimals($countryCode);
 
         return \round($price, $decimals);
     }

--- a/src/Util/PriceFormatter.php
+++ b/src/Util/PriceFormatter.php
@@ -20,26 +20,26 @@ class PriceFormatter
         'TWD' => 0,
     ];
 
-    public function formatPrice(float $price, ?string $countryCode = null): string
+    public function formatPrice(float $price, ?string $currencyIso = null): string
     {
-        $decimals = $this->getDecimals($countryCode);
+        $decimals = $this->getDecimals($currencyIso);
 
-        return \number_format($this->roundPrice($price, $countryCode), $decimals, '.', '');
+        return \number_format($this->roundPrice($price, $currencyIso), $decimals, '.', '');
     }
 
-    public function roundPrice(float $price, ?string $countryCode = null): float
+    public function roundPrice(float $price, ?string $currencyIso = null): float
     {
-        $decimals = $this->getDecimals($countryCode);
+        $decimals = $this->getDecimals($currencyIso);
 
         return \round($price, $decimals);
     }
 
-    private function getDecimals(?string $countryCode): int
+    private function getDecimals(?string $currencyIso): int
     {
-        if ($countryCode === null) {
+        if ($currencyIso === null) {
             return self::DEFAULT_DECIMALS;
         }
 
-        return self::OTHER_DECIMALS[$countryCode] ?? self::DEFAULT_DECIMALS;
+        return self::OTHER_DECIMALS[$currencyIso] ?? self::DEFAULT_DECIMALS;
     }
 }

--- a/tests/Checkout/Cart/Service/CartPriceServiceTest.php
+++ b/tests/Checkout/Cart/Service/CartPriceServiceTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\Cart\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
+use Swag\PayPal\Util\PriceFormatter;
+
+/**
+ * @internal
+ */
+class CartPriceServiceTest extends TestCase
+{
+    private PriceFormatter $priceFormatter;
+
+    private CartPriceService $cartPriceService;
+
+    protected function setUp(): void
+    {
+        $this->priceFormatter = new PriceFormatter();
+        $this->cartPriceService = new CartPriceService($this->priceFormatter);
+    }
+
+    #[DataProvider('hasZeroPriceProvider')]
+    public function testHasZeroPrice(bool $expected, float $totalPrice, string $currencyIso, bool $withLineItem): void
+    {
+        $cart = $this->createCart($totalPrice, $withLineItem);
+
+        static::assertSame($expected, $this->cartPriceService->hasZeroPrice($cart, $this->createSalesChannelContext($currencyIso)));
+    }
+
+    /**
+     * @return iterable<string, array{expected: bool, totalPrice: float, currencyIso: string, withLineItem: bool}>
+     */
+    public static function hasZeroPriceProvider(): iterable
+    {
+        yield 'empty carts are never treated as zero-value carts' => [
+            'expected' => false,
+            'totalPrice' => 0.0,
+            'currencyIso' => 'EUR',
+            'withLineItem' => false,
+        ];
+
+        yield 'positive totals are not zero-value carts' => [
+            'expected' => false,
+            'totalPrice' => 10.99,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+
+        yield 'rounded zero totals are treated as zero-value carts' => [
+            'expected' => true,
+            'totalPrice' => 0.004,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+
+        yield 'negative totals are treated as zero-value carts' => [
+            'expected' => true,
+            'totalPrice' => -5.0,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+
+        yield 'jpy totals are rounded using zero decimals' => [
+            'expected' => true,
+            'totalPrice' => 0.4,
+            'currencyIso' => 'JPY',
+            'withLineItem' => true,
+        ];
+
+        yield 'jpy totals above zero after rounding are not zero-value carts' => [
+            'expected' => false,
+            'totalPrice' => 0.5,
+            'currencyIso' => 'JPY',
+            'withLineItem' => true,
+        ];
+    }
+
+    private function createCart(float $totalPrice, bool $withLineItem): Cart
+    {
+        $cart = new Cart('test-token');
+        $cart->setPrice(new CartPrice(
+            $totalPrice,
+            $totalPrice,
+            $totalPrice,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection(),
+            CartPrice::TAX_STATE_GROSS
+        ));
+
+        if ($withLineItem) {
+            $cart->add(new LineItem('line-item', LineItem::PRODUCT_LINE_ITEM_TYPE));
+        }
+
+        return $cart;
+    }
+
+    private function createSalesChannelContext(string $currencyIso): SalesChannelContext
+    {
+        $currency = new CurrencyEntity();
+        $currency->setIsoCode($currencyIso);
+
+        return Generator::generateSalesChannelContext(currency: $currency);
+    }
+}

--- a/tests/Checkout/ExpressCheckout/ExpressCheckoutSubscriberTest.php
+++ b/tests/Checkout/ExpressCheckout/ExpressCheckoutSubscriberTest.php
@@ -65,6 +65,7 @@ use Swag\PayPal\Test\Mock\Repositories\LanguageRepoMock;
 use Swag\PayPal\Util\Lifecycle\Method\PayLaterMethodData;
 use Swag\PayPal\Util\LocaleCodeProvider;
 use Swag\PayPal\Util\PaymentMethodUtil;
+use Swag\PayPal\Util\PriceFormatter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -572,7 +573,7 @@ class ExpressCheckoutSubscriberTest extends TestCase
                 $this->getContainer()->get(PaymentMethodUtil::class),
                 $settings,
                 new CredentialsUtil($settings),
-                new CartPriceService(),
+                new CartPriceService(new PriceFormatter()),
                 new PayLaterMethodData($this->getContainer())
             ),
             new SettingsValidationService($settings, new NullLogger()),

--- a/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
@@ -46,6 +46,7 @@ use Swag\PayPal\Test\Mock\Repositories\LanguageRepoMock;
 use Swag\PayPal\Util\Lifecycle\Method\PayLaterMethodData;
 use Swag\PayPal\Util\LocaleCodeProvider;
 use Swag\PayPal\Util\PaymentMethodUtil;
+use Swag\PayPal\Util\PriceFormatter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -98,7 +99,7 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
             $this->paymentMethodUtil,
             $this->systemConfigService,
             new CredentialsUtil($this->systemConfigService),
-            new CartPriceService(),
+            new CartPriceService(new PriceFormatter()),
             $this->payLaterMethodData
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We don't round Shopware's total cart price to the value we will send to PayPal, resulting in discrepancies between zero value cart determination and the actual order

### 2. What does this change do, exactly?
Use price formatter to determinate zero value carts

### 3. Describe each step to reproduce the issue or behavior.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- fixes #591 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
