### PR TITLE
fix: correctly serialize expireDateTime in POS token cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Fixes an issue, where POS tokens could not be retrieved from the cache (shopware/SwagPayPal#594)
-
 # 10.6.0
 - Added setting to disable the shipping callback for express checkouts.
 - Fixes an issue, where the shipping callback required the store-api to be exposed.
+- Fixes an issue, where the Zettle connection was only working for a few hours (shopware/SwagPayPal#594)
 
 # 10.5.0
 - Added Austria to the countries where Pay Later is available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where POS tokens could not be retrieved from the cache (shopware/SwagPayPal#594)
+
 # 10.6.0
 - Added setting to disable the shipping callback for express checkouts.
-- Fixes an issue, where the shiiping callback required the store-api to be exposed.
+- Fixes an issue, where the shipping callback required the store-api to be exposed.
 
 # 10.5.0
 - Added Austria to the countries where Pay Later is available

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,9 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Behebt ein Problem, bei dem POS-Token nicht aus dem Cache abgerufen werden konnten (shopware/SwagPayPal#594).
-
 # 10.6.0
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
 - Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte
+- Behebt ein Problem, bei dem die Zettle-Verbindung nur für einige Stunden funktionierte (shopware/SwagPayPal#594)
 
 # 10.5.0
 - Fügt Österreich zu den Ländern hinzu, in denen „Später bezahlen“ verfügbar ist

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem POS-Token nicht aus dem Cache abgerufen werden konnten (shopware/SwagPayPal#594).
+
 # 10.6.0
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
 - Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte

--- a/src/Pos/Resource/TokenResource.php
+++ b/src/Pos/Resource/TokenResource.php
@@ -62,19 +62,25 @@ class TokenResource
     private function getTokenFromCache(string $cacheId): ?Token
     {
         $raw = $this->cache->getItem(self::CACHE_ID . $cacheId)->get();
-        if ($raw === null || $raw === '') {
+
+        if (!\is_string($raw) || $raw === '') {
             return null;
         }
 
         $data = \json_decode($raw, true);
-        if (!\is_array($data)) {
-            return null;
-        }
+
+        return \is_array($data) ? $this->hydrateToken($data) : null;
+    }
+
+    private function hydrateToken(array $data): Token
+    {
+        $expireDateTime = $data['expireDateTime'] ?? null;
+        unset($data['expireDateTime']);
 
         $token = (new Token())->assign($data);
 
-        if (isset($data['expireDateTime']) && \is_string($data['expireDateTime'])) {
-            $token->setExpireDateTime(new \DateTime($data['expireDateTime']));
+        if (\is_string($expireDateTime)) {
+            $token->setExpireDateTime(new \DateTime($expireDateTime));
         }
 
         return $token;
@@ -83,7 +89,12 @@ class TokenResource
     private function setToken(Token $token, string $cacheId): void
     {
         $item = $this->cache->getItem(self::CACHE_ID . $cacheId);
-        $item->set(\json_encode($token->jsonSerialize()));
+
+        $item->set(\json_encode([
+            ...$token->jsonSerialize(),
+            'expireDateTime' => $token->getExpireDateTime()->format(\DateTimeInterface::ATOM),
+        ]));
+
         $this->cache->save($item);
     }
 

--- a/tests/Pos/Resource/TokenResourceTest.php
+++ b/tests/Pos/Resource/TokenResourceTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Pos\Resource;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
+use Swag\PayPal\Pos\Api\Authentication\OAuthCredentials;
+use Swag\PayPal\Pos\Resource\TokenResource;
+use Swag\PayPal\Test\Pos\ConstantsForTesting;
+use Swag\PayPal\Test\Pos\Mock\Client\_fixtures\CreateTokenResponseFixture;
+use Swag\PayPal\Test\Pos\Mock\Client\TokenClientFactoryMock;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class TokenResourceTest extends TestCase
+{
+    private const CACHE_ID = 'pos_auth_';
+
+    public function testExpireDateTimeIsSerializedAsString(): void
+    {
+        $cache = new ArrayAdapter();
+        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+
+        $resource->getToken($this->createCredentials());
+
+        $cacheKey = self::CACHE_ID . Hasher::hash(ConstantsForTesting::VALID_API_KEY);
+        $raw = $cache->getItem($cacheKey)->get();
+        static::assertIsString($raw);
+
+        $data = \json_decode($raw, true);
+        static::assertIsArray($data);
+        static::assertIsString(
+            $data['expireDateTime'],
+            'expireDateTime must be stored as an ISO string'
+        );
+
+        $restored = new \DateTime($data['expireDateTime']);
+        static::assertGreaterThan(new \DateTime('now'), $restored, 'Stored expireDateTime must be in the future');
+    }
+
+    public function testValidCachedTokenIsReturnedWithoutReauth(): void
+    {
+        $cache = new ArrayAdapter();
+        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+
+        $credentials = $this->createCredentials();
+
+        $first = $resource->getToken($credentials);
+        $second = $resource->getToken($credentials);
+
+        static::assertSame(
+            $first->getAccessToken(),
+            $second->getAccessToken(),
+            'The same token must be returned on the second call without re-authenticating'
+        );
+    }
+
+    public function testExpiredCachedTokenTriggersReauth(): void
+    {
+        $cache = new ArrayAdapter();
+        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+
+        $credentials = $this->createCredentials();
+
+        $resource->getToken($credentials);
+
+        $cacheKey = self::CACHE_ID . Hasher::hash(ConstantsForTesting::VALID_API_KEY);
+        $item = $cache->getItem($cacheKey);
+
+        $data = \json_decode($item->get(), true);
+        $data['accessToken'] = 'stale-expired-token';
+        $data['expireDateTime'] = (new \DateTime('-3 hours', new \DateTimeZone('UTC')))
+            ->format(\DateTimeInterface::ATOM);
+
+        $item->set(\json_encode($data));
+        $cache->save($item);
+
+        $token = $resource->getToken($credentials);
+
+        static::assertSame(
+            CreateTokenResponseFixture::ACCESS_TOKEN,
+            $token->getAccessToken(),
+            'An expired cached token must be replaced with a fresh one'
+        );
+    }
+
+    private function createCredentials(): OAuthCredentials
+    {
+        $credentials = new OAuthCredentials();
+        $credentials->setApiKey(ConstantsForTesting::VALID_API_KEY);
+
+        return $credentials;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
`DateTime` objects serialize to `{}` via `json_encode`, so `expireDateTime` was lost when the token was cached and as a result, expired Zettle tokens were never refreshed.

### 2. What does this change do, exactly?
Fixes how the token expiry date is stored in the cache so it is correctly read back. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a Zettle sales channel.
2. Wait a few hours for the Zettle token to expire.
3. The token will not be refreshed automatically and must be refreshed manually.

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/SwagPayPal/issues/594

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
