### PR TITLE
fix: get taxed cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 10.6.0
+- Fixes an issue, where PayPal order creation and express checkout flows did not use the taxed cart with tax provider processing
 - Added setting to disable the shipping callback for express checkouts.
 - Fixes an issue, where the shiiping callback required the store-api to be exposed.
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
 # 10.6.0
+- Behebt ein Problem, bei dem die PayPal-Bestellerstellung und Express-Checkout-Flows nicht den besteuerten Warenkorb mit Tax-Provider-Verarbeitung verwendet haben
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
 - Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte
 

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -70,7 +70,7 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
     {
         try {
             $this->logger->debug('Started');
-            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
+            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
 
             if ($this->cartPriceService->isZeroValueCart($cart)) {
                 throw new OrderZeroValueException();

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
@@ -90,7 +90,7 @@ class ExpressPrepareCheckoutRoute extends AbstractExpressPrepareCheckoutRoute
                 $salesChannelContext->getSalesChannel()->getId()
             );
 
-            $cart = $this->cartService->getCart($newSalesChannelContext->getToken(), $salesChannelContext);
+            $cart = $this->cartService->getCart($newSalesChannelContext->getToken(), $salesChannelContext, taxed: true);
 
             $expressCheckoutData = new ExpressCheckoutData($paypalOrderId);
             $cart->addExtension(self::PAYPAL_EXPRESS_CHECKOUT_CART_EXTENSION_ID, $expressCheckoutData);

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -8,7 +8,6 @@
 namespace Swag\PayPal\Checkout\ExpressCheckout\Service;
 
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -55,10 +54,10 @@ class ExpressShippingCallbackService
             $salesChannelContext = $this->switchSalesChannelContext($callback, $salesChannelContext);
 
             $this->logger->debug('Shipping callback: recalculating cart with new context');
-            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, false);
+            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, false, true);
         } else {
             $this->logger->debug('Shipping callback: use existing cart');
-            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
+            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
         }
 
         $order = $this->orderBuilder->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());

--- a/src/Checkout/SalesChannel/CreateOrderRoute.php
+++ b/src/Checkout/SalesChannel/CreateOrderRoute.php
@@ -139,7 +139,7 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         SalesChannelContext $salesChannelContext,
         Request $request,
     ): Order {
-        $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
+        $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
 
         $requestDataBag = new RequestDataBag($request->request->all());
 

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\ExpressCheckout\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
+use Swag\PayPal\Checkout\Exception\OrderZeroValueException;
+use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCreateOrderRoute;
+use Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ExpressCreateOrderRoute::class)]
+class ExpressCreateOrderRouteTaxedCartTest extends TestCase
+{
+    public function testCreatePaymentLoadsTaxedCartThroughCartLoadRoute(): void
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext
+            ->method('getToken')
+            ->willReturn('express-token');
+
+        $cart = new Cart('express-token');
+
+        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
+        $taxProviderProcessor
+            ->expects($this->once())
+            ->method('process')
+            ->with($cart, $salesChannelContext);
+
+        $cartPriceService = $this->createMock(CartPriceService::class);
+        $cartPriceService
+            ->expects($this->once())
+            ->method('isZeroValueCart')
+            ->with($cart)
+            ->willReturn(true);
+
+        $route = new ExpressCreateOrderRoute(
+            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createMock(PayPalOrderBuilder::class),
+            $this->createMock(OrderResource::class),
+            $cartPriceService,
+            $this->createMock(SystemConfigService::class),
+            $this->createMock(RouterInterface::class),
+            new NullLogger(),
+        );
+
+        static::expectException(OrderZeroValueException::class);
+
+        $route->createPayPalOrder(new Request(), $salesChannelContext);
+    }
+
+    private function createTaxedCartService(
+        Cart $cart,
+        SalesChannelContext $salesChannelContext,
+        TaxProviderProcessor $taxProviderProcessor,
+    ): CartService {
+        $persister = $this->createMock(AbstractCartPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('load')
+            ->with($cart->getToken(), $salesChannelContext)
+            ->willReturn($cart);
+
+        $calculator = $this->createMock(CartCalculator::class);
+        $calculator
+            ->expects($this->once())
+            ->method('calculate')
+            ->with($cart, $salesChannelContext)
+            ->willReturn($cart);
+
+        return new CartService(
+            $persister,
+            $this->createMock(EventDispatcherInterface::class),
+            $calculator,
+            new CartLoadRoute(
+                $persister,
+                $this->createMock(CartFactory::class),
+                $calculator,
+                $taxProviderProcessor,
+            ),
+            $this->createMock(AbstractCartDeleteRoute::class),
+            $this->createMock(AbstractCartItemAddRoute::class),
+            $this->createMock(AbstractCartItemUpdateRoute::class),
+            $this->createMock(AbstractCartItemRemoveRoute::class),
+            $this->createMock(AbstractCartOrderRoute::class),
+            $this->createMock(CartFactory::class),
+        );
+    }
+}

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\ExpressCheckout\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\PayPalSDK\Struct\V2\Order;
+use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutData;
+use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute;
+use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ExpressPrepareCheckoutRoute::class)]
+class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
+{
+    public function testPrepareLoadsTaxedCartThroughCartLoadRoute(): void
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId('sales-channel-id');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext
+            ->method('getSalesChannel')
+            ->willReturn($salesChannel);
+
+        $newToken = 'new-context-token';
+        $cart = new Cart($newToken);
+
+        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
+        $taxProviderProcessor
+            ->expects($this->once())
+            ->method('process')
+            ->with($cart, $salesChannelContext);
+
+        $newSalesChannelContext = $this->createMock(SalesChannelContext::class);
+        $newSalesChannelContext
+            ->method('getToken')
+            ->willReturn($newToken);
+
+        $expressCustomerService = $this->createMock(ExpressCustomerService::class);
+        $expressCustomerService
+            ->expects($this->once())
+            ->method('loginCustomer')
+            ->willReturn($newToken);
+
+        $salesChannelContextFactory = $this->createMock(AbstractSalesChannelContextFactory::class);
+        $salesChannelContextFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($newToken, $salesChannel->getId())
+            ->willReturn($newSalesChannelContext);
+
+        $orderResource = $this->createMock(OrderResource::class);
+        $orderResource
+            ->expects($this->once())
+            ->method('get')
+            ->with('paypal-order-id', $salesChannel->getId())
+            ->willReturn(new Order());
+
+        $route = new ExpressPrepareCheckoutRoute(
+            $expressCustomerService,
+            $salesChannelContextFactory,
+            $orderResource,
+            $this->createTaxedCartService($cart, $salesChannelContext, $newSalesChannelContext, $taxProviderProcessor),
+            new NullLogger(),
+        );
+
+        $response = $route->prepareCheckout($salesChannelContext, new Request([], [
+            ExpressPrepareCheckoutRoute::PAYPAL_REQUEST_PARAMETER_TOKEN => 'paypal-order-id',
+        ]));
+
+        static::assertSame($newToken, $response->getToken());
+        static::assertInstanceOf(
+            ExpressCheckoutData::class,
+            $cart->getExtension(ExpressPrepareCheckoutRoute::PAYPAL_EXPRESS_CHECKOUT_CART_EXTENSION_ID)
+        );
+    }
+
+    private function createTaxedCartService(
+        Cart $cart,
+        SalesChannelContext $salesChannelContext,
+        SalesChannelContext $newSalesChannelContext,
+        TaxProviderProcessor $taxProviderProcessor,
+    ): CartService {
+        $persister = $this->createMock(AbstractCartPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('load')
+            ->with($cart->getToken(), $salesChannelContext)
+            ->willReturn($cart);
+        $persister
+            ->expects($this->once())
+            ->method('save')
+            ->with($cart, $newSalesChannelContext);
+
+        $calculator = $this->createMock(CartCalculator::class);
+        $calculator
+            ->expects($this->exactly(2))
+            ->method('calculate')
+            ->willReturn($cart);
+
+        return new CartService(
+            $persister,
+            $this->createMock(EventDispatcherInterface::class),
+            $calculator,
+            new CartLoadRoute(
+                $persister,
+                $this->createMock(CartFactory::class),
+                $calculator,
+                $taxProviderProcessor,
+            ),
+            $this->createMock(AbstractCartDeleteRoute::class),
+            $this->createMock(AbstractCartItemAddRoute::class),
+            $this->createMock(AbstractCartItemUpdateRoute::class),
+            $this->createMock(AbstractCartItemRemoveRoute::class),
+            $this->createMock(AbstractCartOrderRoute::class),
+            $this->createMock(CartFactory::class),
+        );
+    }
+}

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
@@ -1,0 +1,194 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\ExpressCheckout\Service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
+use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\PayPalSDK\Struct\V2\Common\Address;
+use Shopware\PayPalSDK\Struct\V2\Order;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\ShippingOption;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\ShippingOptionCollection;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnitCollection;
+use Shopware\PayPalSDK\Struct\V2\OrderShippingCallback;
+use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService;
+use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ExpressShippingCallbackService::class)]
+class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
+{
+    public function testCalculationWithoutChangesLoadsTaxedCartThroughCartLoadRoute(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+        $cart = new Cart('shipping-token');
+
+        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
+        $taxProviderProcessor
+            ->expects($this->once())
+            ->method('process')
+            ->with($cart, $salesChannelContext);
+
+        $order = new Order();
+        $order->setPurchaseUnits(new PurchaseUnitCollection([new PurchaseUnit()]));
+
+        $orderBuilder = $this->createMock(AbstractOrderBuilder::class);
+        $orderBuilder
+            ->expects($this->once())
+            ->method('getOrderFromCart')
+            ->with($cart, $salesChannelContext, static::isInstanceOf(RequestDataBag::class))
+            ->willReturn($order);
+
+        $shippingOption = new ShippingOption();
+        $shippingOption->setId($salesChannelContext->getShippingMethod()->getId());
+        $shippingOption->setLabel('Standard');
+
+        $shippingOptionsProvider = $this->createMock(ShippingOptionsProvider::class);
+        $shippingOptionsProvider
+            ->expects($this->once())
+            ->method('getShippingOptions')
+            ->with($cart, $salesChannelContext)
+            ->willReturn(new ShippingOptionCollection([$shippingOption]));
+
+        $service = new ExpressShippingCallbackService(
+            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createMock(SalesChannelRepository::class),
+            $orderBuilder,
+            $shippingOptionsProvider,
+            $this->createMock(AbstractContextSwitchRoute::class),
+            $this->createMock(AbstractSalesChannelContextFactory::class),
+            new NullLogger(),
+        );
+
+        $result = $service->recalculateCart($this->createCallback(), $salesChannelContext);
+
+        static::assertSame('paypal-order-id', $result->getId());
+        static::assertCount(1, $result->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
+    }
+
+    private function createSalesChannelContext(): SalesChannelContext
+    {
+        $country = new CountryEntity();
+        $country->setId('country-id');
+        $country->setIso('DE');
+
+        $state = new CountryStateEntity();
+        $state->setId('state-id');
+        $state->setCountryId($country->getId());
+        $state->setCountry($country);
+        $state->setShortCode('BE');
+
+        $address = new CustomerAddressEntity();
+        $address->setId('address-id');
+        $address->setCountryId($country->getId());
+        $address->setCountry($country);
+        $address->setCountryStateId($state->getId());
+        $address->setCountryState($state);
+
+        $shippingMethod = new ShippingMethodEntity();
+        $shippingMethod->setId('shipping-method-id');
+        $shippingMethod->setName('Standard');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext
+            ->method('getToken')
+            ->willReturn('shipping-token');
+        $salesChannelContext
+            ->method('getShippingLocation')
+            ->willReturn(ShippingLocation::createFromAddress($address));
+        $salesChannelContext
+            ->method('getShippingMethod')
+            ->willReturn($shippingMethod);
+
+        return $salesChannelContext;
+    }
+
+    private function createCallback(): OrderShippingCallback
+    {
+        $address = new Address();
+        $address->setCountryCode('DE');
+        $address->setAdminArea1('BE');
+
+        $purchaseUnit = new PurchaseUnit();
+        $purchaseUnit->setReferenceId('default');
+
+        $callback = new OrderShippingCallback();
+        $callback->setId('paypal-order-id');
+        $callback->setShippingAddress($address);
+        $callback->setPurchaseUnits(new PurchaseUnitCollection([$purchaseUnit]));
+
+        return $callback;
+    }
+
+    private function createTaxedCartService(
+        Cart $cart,
+        SalesChannelContext $salesChannelContext,
+        TaxProviderProcessor $taxProviderProcessor,
+    ): CartService {
+        $persister = $this->createMock(AbstractCartPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('load')
+            ->with($cart->getToken(), $salesChannelContext)
+            ->willReturn($cart);
+
+        $calculator = $this->createMock(CartCalculator::class);
+        $calculator
+            ->expects($this->once())
+            ->method('calculate')
+            ->with($cart, $salesChannelContext)
+            ->willReturn($cart);
+
+        return new CartService(
+            $persister,
+            $this->createMock(EventDispatcherInterface::class),
+            $calculator,
+            new CartLoadRoute(
+                $persister,
+                $this->createMock(CartFactory::class),
+                $calculator,
+                $taxProviderProcessor,
+            ),
+            $this->createMock(AbstractCartDeleteRoute::class),
+            $this->createMock(AbstractCartItemAddRoute::class),
+            $this->createMock(AbstractCartItemUpdateRoute::class),
+            $this->createMock(AbstractCartItemRemoveRoute::class),
+            $this->createMock(AbstractCartOrderRoute::class),
+            $this->createMock(CartFactory::class),
+        );
+    }
+}

--- a/tests/Checkout/SalesChannel/CreateOrderRouteTaxedCartTest.php
+++ b/tests/Checkout/SalesChannel/CreateOrderRouteTaxedCartTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
+use Shopware\Core\Checkout\Payment\Cart\AbstractPaymentTransactionStructFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\SalesChannel\CreateOrderRoute;
+use Swag\PayPal\OrdersApi\Builder\ACDCOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\ApplePayOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\GooglePayOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\VenmoOrderBuilder;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CreateOrderRoute::class)]
+class CreateOrderRouteTaxedCartTest extends TestCase
+{
+    public function testCreatePaymentLoadsTaxedCartThroughCartLoadRoute(): void
+    {
+        $customer = new CustomerEntity();
+        $customer->setId('customer-id');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext
+            ->method('getCustomer')
+            ->willReturn($customer);
+        $salesChannelContext
+            ->method('getToken')
+            ->willReturn('create-order-token');
+
+        $cart = new Cart('create-order-token');
+
+        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
+        $taxProviderProcessor
+            ->expects($this->once())
+            ->method('process')
+            ->with($cart, $salesChannelContext);
+
+        $exception = new \RuntimeException('stop after taxed cart load');
+
+        $payPalOrderBuilder = $this->createMock(PayPalOrderBuilder::class);
+        $payPalOrderBuilder
+            ->expects($this->once())
+            ->method('getOrderFromCart')
+            ->with($cart, $salesChannelContext, static::isInstanceOf(RequestDataBag::class))
+            ->willThrowException($exception);
+
+        $route = new CreateOrderRoute(
+            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createMock(EntityRepository::class),
+            $payPalOrderBuilder,
+            $this->createMock(ACDCOrderBuilder::class),
+            $this->createMock(ApplePayOrderBuilder::class),
+            $this->createMock(GooglePayOrderBuilder::class),
+            $this->createMock(VenmoOrderBuilder::class),
+            $this->createMock(OrderResource::class),
+            new NullLogger(),
+            $this->createMock(AbstractPaymentTransactionStructFactory::class),
+            $this->createMock(AbstractSetPaymentOrderRoute::class),
+        );
+
+        static::expectExceptionObject($exception);
+
+        $route->createPayPalOrder($salesChannelContext, new Request());
+    }
+
+    private function createTaxedCartService(
+        Cart $cart,
+        SalesChannelContext $salesChannelContext,
+        TaxProviderProcessor $taxProviderProcessor,
+    ): CartService {
+        $persister = $this->createMock(AbstractCartPersister::class);
+        $persister
+            ->expects($this->once())
+            ->method('load')
+            ->with($cart->getToken(), $salesChannelContext)
+            ->willReturn($cart);
+
+        $calculator = $this->createMock(CartCalculator::class);
+        $calculator
+            ->expects($this->once())
+            ->method('calculate')
+            ->with($cart, $salesChannelContext)
+            ->willReturn($cart);
+
+        return new CartService(
+            $persister,
+            $this->createMock(EventDispatcherInterface::class),
+            $calculator,
+            new CartLoadRoute(
+                $persister,
+                $this->createMock(CartFactory::class),
+                $calculator,
+                $taxProviderProcessor,
+            ),
+            $this->createMock(AbstractCartDeleteRoute::class),
+            $this->createMock(AbstractCartItemAddRoute::class),
+            $this->createMock(AbstractCartItemUpdateRoute::class),
+            $this->createMock(AbstractCartItemRemoveRoute::class),
+            $this->createMock(AbstractCartOrderRoute::class),
+            $this->createMock(CartFactory::class),
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

PayPal order creation and express checkout flows need to load the cart with tax provider processing enabled so the generated PayPal order uses the taxed cart data.

### 2. What does this change do, exactly?

- passes `taxed: true` when loading the cart in the PayPal create-order and express checkout flows
- adds focused unit tests for the affected routes and services to assert that `TaxProviderProcessor::process()` is triggered via `CartLoadRoute`

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure a tax provider.
2. Trigger one of the PayPal cart-based flows for order creation or express checkout.
3. Observe that the cart was loaded without tax provider processing.
4. With this change, the cart is loaded as taxed and the new tests cover that behaviour.

### 4. Please link to the relevant issues (if any).

- fixes: https://github.com/shopware/SwagPayPal/issues/522

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
