### PR TITLE
fix: missing order transaction ids in PayPal webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 10.6.0
+- Fixes an issue, where PayPal webhooks with a `custom_id` payload that does not contain an `orderTransactionId` could trigger an undefined array key warning
 - Added setting to disable the shipping callback for express checkouts.
 - Fixes an issue, where the shiiping callback required the store-api to be exposed.
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
 # 10.6.0
+- Behebt ein Problem, bei dem PayPal-Webhooks mit einem `custom_id`-Payload ohne `orderTransactionId` eine Warnung wegen eines undefinierten Array-Keys ausloesen konnten
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
 - Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte
 

--- a/src/Webhook/Handler/AbstractWebhookHandler.php
+++ b/src/Webhook/Handler/AbstractWebhookHandler.php
@@ -83,7 +83,7 @@ abstract class AbstractWebhookHandler implements WebhookHandler
         if (!\is_array($customIdArray)) {
             $orderTransactionId = $customId;
         } else {
-            $orderTransactionId = $customIdArray['orderTransactionId'];
+            $orderTransactionId = $customIdArray['orderTransactionId'] ?? null;
         }
 
         if ($orderTransactionId === null) {

--- a/tests/Webhook/Handler/AbstractWebhookHandlerTestCase.php
+++ b/tests/Webhook/Handler/AbstractWebhookHandlerTestCase.php
@@ -125,6 +125,16 @@ abstract class AbstractWebhookHandlerTestCase extends TestCase
         $this->webhookHandler->invoke($webhook, $context);
     }
 
+    protected function assertInvokeWithoutOrderTransactionIdInCustomId(string $resourceType): void
+    {
+        $webhook = $this->createWebhookV2WithoutOrderTransactionId($resourceType);
+        $context = Context::createDefaultContext();
+
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('Given webhook resource data does not contain needed custom ID');
+        $this->webhookHandler->invoke($webhook, $context);
+    }
+
     protected function createWebhookV1(?string $parentPayment = OrderTransactionRepoMock::WEBHOOK_PAYMENT_ID): Event
     {
         return (new Event())->assign(['resource' => ['parent_payment' => $parentPayment]]);
@@ -134,6 +144,21 @@ abstract class AbstractWebhookHandlerTestCase extends TestCase
     {
         $customId = \json_encode(['orderTransactionId' => $orderTransactionId]);
 
+        return $this->createWebhookV2WithCustomId($resourceType, $customId ?: '{}');
+    }
+
+    protected function createWebhookV2WithoutOrderTransactionId(string $resourceType): Event
+    {
+        return $this->createWebhookV2WithCustomId($resourceType, '{}');
+    }
+
+    /**
+     * @return AbstractWebhookHandler
+     */
+    abstract protected function createWebhookHandler();
+
+    private function createWebhookV2WithCustomId(string $resourceType, string $customId): Event
+    {
         $webhook = new Event();
         $webhook->assign(['resource_type' => $resourceType, 'resource_version' => '2.0', 'resource' => ['custom_id' => $customId]]);
         $resource = $webhook->getResource();
@@ -149,9 +174,4 @@ abstract class AbstractWebhookHandlerTestCase extends TestCase
 
         return $webhook;
     }
-
-    /**
-     * @return AbstractWebhookHandler
-     */
-    abstract protected function createWebhookHandler();
 }

--- a/tests/Webhook/Handler/CaptureCompletedTest.php
+++ b/tests/Webhook/Handler/CaptureCompletedTest.php
@@ -52,6 +52,11 @@ class CaptureCompletedTest extends AbstractWebhookHandlerTestCase
         $this->assertInvokeWithoutCustomId(Event::RESOURCE_TYPE_CAPTURE);
     }
 
+    public function testInvokeWithoutOrderTransactionIdInCustomId(): void
+    {
+        $this->assertInvokeWithoutOrderTransactionIdInCustomId(Event::RESOURCE_TYPE_CAPTURE);
+    }
+
     public function testInvokeWithoutTransaction(): void
     {
         $orderTransactionId = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?

PayPal webhooks can arrive with a `custom_id` payload that does not contain an `orderTransactionId`. In that case, the current handler reads the array key directly and triggers an undefined array key warning. This fills production logs for webhooks that Shopware cannot associate with an order transaction anyway.

### 2. What does this change do, exactly?

It guards the `orderTransactionId` lookup in `AbstractWebhookHandler::getOrderTransactionV2` with a null fallback so missing values go through the existing invalid-id error path instead of triggering a PHP warning. It also adds regression coverage for webhook payloads where `custom_id` is present but does not contain an `orderTransactionId`, and documents the fix in the plugin changelogs.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure a shop with SwagPayPal.
2. Send a PayPal webhook whose `custom_id` payload does not contain an `orderTransactionId`.
3. Let the webhook reach `AbstractWebhookHandler::getOrderTransactionV2`.
4. Observe that the previous implementation triggers an undefined array key warning instead of treating the payload as invalid.

### 4. Please link to the relevant issues (if any).

- fixes https://github.com/shopware/shopware/issues/15687

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.