### PR TITLE
[6.5.x] feat: shipping express toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.11.0
+- Added setting to disable the shipping callback for express checkouts.
+- Fixes an issue, where the shiiping callback required the store-api to be exposed.
+
 # 8.10.0
 - Added Austria to the countries where Pay Later is available
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
+# 8.11.0
+- Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren
+- Behebt ein Problem, bei dem der Versand-Callback die Offenlegung der Store-API erforderte
+
 # 8.10.0
 - Fügt Österreich zu den Ländern hinzu, in denen „Später bezahlen“ verfügbar ist
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "8.10.0",
+    "version": "8.11.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
+++ b/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
@@ -307,7 +307,7 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
 
     public function mapShippingCallbackContextToken(ControllerEvent $event): void
     {
-        if ($event->getRequest()->attributes->get('_route') !== 'store-api.paypal.express.shipping_callback') {
+        if (!\in_array($event->getRequest()->attributes->get('_route'), ['store-api.paypal.express.shipping_callback', 'frontend.paypal.express.shipping_callback'], true)) {
             return;
         }
 

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\TokenResponse;
@@ -75,10 +76,16 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
                 $experienceContext->setUserAction(ApplicationContext::USER_ACTION_CONTINUE);
 
                 // Configure shipping callback for dynamic price recalculation
-                if (!$this->systemConfigService->getBool(Settings::IS_LOCAL_ENVIRONMENT, $salesChannelContext->getSalesChannelId())) {
+                if (!$this->systemConfigService->getBool(Settings::IS_LOCAL_ENVIRONMENT, $salesChannelContext->getSalesChannelId()) && $this->systemConfigService->getBool(Settings::ECS_SHIPPING_CALLBACK_ENABLED, $salesChannelContext->getSalesChannelId())) {
+                    $isStorefront = \in_array(
+                        'storefront',
+                        $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
+                        true,
+                    );
+
                     $callbackConfig = new OrderUpdateCallbackConfig();
                     $callbackUrl = $this->router->generate(
-                        'store-api.paypal.express.shipping_callback',
+                        $isStorefront ? 'frontend.paypal.express.shipping_callback' : 'store-api.paypal.express.shipping_callback',
                         ['salesChannelId' => $salesChannelContext->getSalesChannelId(), 'token' => $salesChannelContext->getToken()],
                         UrlGeneratorInterface::ABSOLUTE_URL,
                     );

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -68,6 +68,7 @@ class ExpressShippingCallbackService
 
         if ((int) $order->getPurchaseUnits()->first()?->getShippingOptions()?->count() === 0) {
             $this->logger->debug('Shipping callback: no shipping methods available', ['order' => $order]);
+
             throw ExpressShippingCallbackException::addressError($callback);
         }
 
@@ -114,6 +115,7 @@ class ExpressShippingCallbackService
         $country = $this->countryRepository->search($criteria, $salesChannelContext)->getEntities()->first();
         if (!$country) {
             $this->logger->debug('Shipping callback: country not available');
+
             throw ExpressShippingCallbackException::countryError($callback);
         }
 

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -67,10 +67,12 @@ class ExpressShippingCallbackService
         $order->getPurchaseUnits()->first()?->setShippingOptions($this->shippingOptionsProvider->getShippingOptions($cart, $salesChannelContext));
 
         if ((int) $order->getPurchaseUnits()->first()?->getShippingOptions()?->count() === 0) {
+            $this->logger->debug('Shipping callback: no shipping methods available', ['order' => $order]);
             throw ExpressShippingCallbackException::addressError($callback);
         }
 
         if ($error = $cart->getErrors()->filterInstance(ShippingMethodBlockedError::class)->first()) {
+            $this->logger->debug('Shipping callback: selected shipping method blocked', ['order' => $order]);
             /** @var ShippingMethodBlockedError $error */
             throw ExpressShippingCallbackException::methodUnavailable($callback, $error);
         }
@@ -111,6 +113,7 @@ class ExpressShippingCallbackService
 
         $country = $this->countryRepository->search($criteria, $salesChannelContext)->getEntities()->first();
         if (!$country) {
+            $this->logger->debug('Shipping callback: country not available');
             throw ExpressShippingCallbackException::countryError($callback);
         }
 

--- a/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-express/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-express/index.ts
@@ -101,6 +101,25 @@ export default Shopware.Component.wrapComponentConfig({
 
             return criteria;
         },
+
+        ecsShippingCallbackSettingDisabled(): boolean {
+            return this.renderSettingsDisabled || !!this.actualConfigData['SwagPayPal.settings.isLocalEnvironment'];
+        },
+
+        ecsShippingCallbackSettingTooltip(): { message: string; showOnDisabledElements?: boolean; disabled?: boolean } {
+            if (this.actualConfigData['SwagPayPal.settings.isLocalEnvironment']) {
+                return {
+                    message: this.$t('swag-paypal.settingForm.express.ecsShippingCallbackEnabled.tooltipDisabled'),
+                    showOnDisabledElements: true,
+                    disabled: false,
+                };
+            }
+
+            return {
+                message: '',
+                disabled: true,
+            };
+        },
     },
 
     watch: {

--- a/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-express/swag-paypal-express.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-express/swag-paypal-express.html.twig
@@ -237,6 +237,27 @@
             </template>
         </swag-paypal-inherit-wrapper>
         {% endblock %}
+
+        {% block swag_paypal_content_card_channel_config_express_settings_shipping_callback_enabled %}
+        <swag-paypal-inherit-wrapper
+            v-bind="{ actualConfigData, allConfigs, selectedSalesChannelId }"
+            path="SwagPayPal.settings.ecsShippingCallbackEnabled"
+        >
+            <template #content="props">
+                <sw-switch-field
+                    v-tooltip="ecsShippingCallbackSettingTooltip"
+                    name="SwagPayPal.settings.ecsShippingCallbackEnabled"
+                    bordered
+                    :mapInheritance="props"
+                    :label="$tc('swag-paypal.settingForm.express.ecsShippingCallbackEnabled.label')"
+                    :helpText="$tc('swag-paypal.settingForm.express.ecsShippingCallbackEnabled.helpText')"
+                    :disabled="props.isInherited || ecsShippingCallbackSettingDisabled"
+                    :value="props.currentValue"
+                    @update:value="props.updateCurrentValue"
+                />
+            </template>
+        </swag-paypal-inherit-wrapper>
+        {% endblock %}
     </div>
     {% endblock %}
 </sw-card>

--- a/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-webhook/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-webhook/index.ts
@@ -5,6 +5,7 @@ import './swag-paypal-webhook.scss';
 const STATUS_WEBHOOK_MISSING = 'missing';
 const STATUS_WEBHOOK_INVALID = 'invalid';
 const STATUS_WEBHOOK_VALID = 'valid';
+const STATUS_WEBHOOK_DISABLED = 'disabled';
 
 export default Shopware.Component.wrapComponentConfig({
     template,
@@ -68,6 +69,21 @@ export default Shopware.Component.wrapComponentConfig({
         allowRefresh(): boolean {
             return [STATUS_WEBHOOK_INVALID, STATUS_WEBHOOK_MISSING]
                 .includes(this.webhookStatus ?? '');
+        },
+
+        refreshTooltip(): { message: string; showOnDisabledElements?: boolean; disabled?: boolean } {
+            if (this.webhookStatus === STATUS_WEBHOOK_DISABLED) {
+                return {
+                    message: this.$t('swag-paypal.webhook.tooltipDisabled'),
+                    showOnDisabledElements: true,
+                    disabled: false,
+                };
+            }
+
+            return {
+                message: '',
+                disabled: true,
+            };
         },
     },
 

--- a/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-webhook/swag-paypal-webhook.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-webhook/swag-paypal-webhook.html.twig
@@ -32,6 +32,7 @@
 
     {% block swag_paypal_webhook_refresh_button %}
     <sw-button
+        v-tooltip="refreshTooltip"
         class="swag-paypal-webhook__refresh-button"
         variant=""
         :disabled="isLoading || isRefreshing || isFetchingStatus || !allowRefresh || !acl.can('swag_paypal.editor')"

--- a/src/Resources/app/administration/src/module/swag-paypal/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/swag-paypal/snippet/de-DE.json
@@ -54,9 +54,11 @@
             "unknown": "Laden...",
             "missing": "Fehlend",
             "invalid": "Registriert, aber mit abweichender Domain",
-            "valid": "Gültig"
+            "valid": "Gültig",
+            "disabled": "Deaktiviert"
           },
-          "infoText": "Der Webhook dient dazu, den Status einer Transaktion asynchron zu aktualisieren. Falsch registrierte Webhooks, z.B. auf einem anderen oder nicht öffentlich zugänglichen Server, können zu unbestätigten Transaktionen führen, unabhängig davon, ob die Transaktion von PayPal verarbeitet wurde."
+          "infoText": "Der Webhook dient dazu, den Status einer Transaktion asynchron zu aktualisieren. Falsch registrierte Webhooks, z.B. auf einem anderen oder nicht öffentlich zugänglichen Server, können zu unbestätigten Transaktionen führen, unabhängig davon, ob die Transaktion von PayPal verarbeitet wurde.",
+          "tooltipDisabled": "Der Webhook kann nicht aktualisiert werden, da \"Lokale Entwicklungsumgebung\" aktiviert ist"
         },
         "cross-border": {
             "cardTitle": "Später bezahlen - Länderübergreifende Nachrichten",
@@ -301,6 +303,11 @@
                 "ecsShowPayLater": {
                     "label": "'Später Bezahlen' neben dem 'PayPal Checkout'-Button anzeigen",
                     "helpText": "Die Schaltfläche 'Später Bezahlen' wird auf denselben Seiten und im selben Design wie die Schaltfläche 'Direkt zu PayPal' angezeigt."
+                },
+                "ecsShippingCallbackEnabled": {
+                    "label": "Versandarten im PayPal-Dialog auswählbar",
+                    "helpText": "Wenn diese Option aktiviert ist, wird während des Express-Dialogs ein Callback implementiert, um die Versandkosten basierend auf der vom Kunden ausgewählten Versandart zu aktualisieren.",
+                    "tooltipDisabled": "Der Shipping Callback kann nicht aktiviert werden, da \"Lokale Entwicklungsumgebung\" aktiviert ist"
                 }
             },
             "installment": {

--- a/src/Resources/app/administration/src/module/swag-paypal/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/swag-paypal/snippet/en-GB.json
@@ -54,9 +54,11 @@
             "unknown": "Loading...",
             "missing": "Not registered",
             "invalid": "Registered, but possible domain mismatch",
-            "valid": "Registered"
+            "valid": "Registered",
+            "disabled": "Disabled"
           },
-          "infoText": "The webhook is used for updating the status of a transaction asynchronously. Incorrectly registered webhooks, e.g. on a different or not publicly available server, may result in unconfirmed transactions, regardless whether the transaction has been processed by PayPal."
+          "infoText": "The webhook is used for updating the status of a transaction asynchronously. Incorrectly registered webhooks, e.g. on a different or not publicly available server, may result in unconfirmed transactions, regardless whether the transaction has been processed by PayPal.",
+          "tooltipDisabled": "Webhook can not be refreshed as \"Local development environment\" is active"
         },
         "cross-border": {
           "cardTitle": "Pay Later cross-border messaging",
@@ -301,6 +303,11 @@
                 "ecsShowPayLater": {
                     "label": "Display 'Pay Later' button next to the 'PayPal Checkout' button",
                     "helpText": "The 'Pay Later' button will be displayed on the same pages and in the same design as the 'PayPal Checkout' button."
+                },
+                "ecsShippingCallbackEnabled": {
+                    "label": "Shipping method choice in PayPal dialog",
+                    "helpText": "If this option is active, a callback will be implemented during Express dialog to update the shipping costs based on the shipping method selected by the customer.",
+                    "tooltipDisabled": "The shipping callback can not be enabled as \"Local development environment\" is active"
                 }
             },
             "installment": {

--- a/src/Resources/app/administration/src/types/system-config.ts
+++ b/src/Resources/app/administration/src/types/system-config.ts
@@ -31,6 +31,7 @@ export declare type SystemConfig = {
     'SwagPayPal.settings.ecsButtonLanguageIso'?: string | null;
 
     'SwagPayPal.settings.ecsShowPayLater'?: boolean;
+    'SwagPayPal.settings.ecsShippingCallbackEnabled'?: boolean;
     'SwagPayPal.settings.spbButtonColor'?: typeof BUTTON_COLORS[number];
     'SwagPayPal.settings.spbButtonShape'?: typeof BUTTON_SHAPES[number];
     'SwagPayPal.settings.spbButtonLanguageIso'?: string | null;
@@ -99,6 +100,7 @@ export const SystemConfigDefinition: Record<keyof SystemConfig, 'string' | 'bool
     'SwagPayPal.settings.ecsButtonLanguageIso': 'string',
 
     'SwagPayPal.settings.ecsShowPayLater': 'boolean',
+    'SwagPayPal.settings.ecsShippingCallbackEnabled': 'boolean',
     'SwagPayPal.settings.spbButtonColor': 'string',
     'SwagPayPal.settings.spbButtonShape': 'string',
     'SwagPayPal.settings.spbButtonLanguageIso': 'string',

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="Swag\PayPal\Checkout\PUI\SalesChannel\PUIPaymentInstructionsRoute"/>
             <argument type="service" id="Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute"/>
             <argument type="service" id="Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCreateOrderRoute"/>
+            <argument type="service" id="Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressShippingCallbackRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartDeleteRoute"/>
             <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\ClearVaultRoute"/>

--- a/src/Setting/Settings.php
+++ b/src/Setting/Settings.php
@@ -42,6 +42,7 @@ final class Settings
     public const ECS_BUTTON_LANGUAGE_ISO = self::SYSTEM_CONFIG_DOMAIN . 'ecsButtonLanguageIso';
 
     public const ECS_SHOW_PAY_LATER = self::SYSTEM_CONFIG_DOMAIN . 'ecsShowPayLater';
+    public const ECS_SHIPPING_CALLBACK_ENABLED = self::SYSTEM_CONFIG_DOMAIN . 'ecsShippingCallbackEnabled';
     public const SPB_BUTTON_COLOR = self::SYSTEM_CONFIG_DOMAIN . 'spbButtonColor';
     public const SPB_BUTTON_SHAPE = self::SYSTEM_CONFIG_DOMAIN . 'spbButtonShape';
     public const SPB_BUTTON_LANGUAGE_ISO = self::SYSTEM_CONFIG_DOMAIN . 'spbButtonLanguageIso';
@@ -95,6 +96,7 @@ final class Settings
         self::ECS_BUTTON_COLOR => 'gold',
         self::ECS_BUTTON_SHAPE => 'sharp',
         self::ECS_SHOW_PAY_LATER => true,
+        self::ECS_SHIPPING_CALLBACK_ENABLED => true,
         self::SPB_CHECKOUT_ENABLED => true,
         self::SPB_ALTERNATIVE_PAYMENT_METHODS_ENABLED => false,
         self::SPB_BUTTON_COLOR => 'gold',

--- a/src/Storefront/Controller/PayPalController.php
+++ b/src/Storefront/Controller/PayPalController.php
@@ -24,6 +24,7 @@ use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Framework\AffiliateTracking\AffiliateTrackingListener;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressPrepareCheckoutRoute;
+use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressShippingCallbackRoute;
 use Swag\PayPal\Checkout\PUI\SalesChannel\AbstractPUIPaymentInstructionsRoute;
 use Swag\PayPal\Checkout\PUI\SalesChannel\PUIPaymentInstructionsResponse;
 use Swag\PayPal\Checkout\SalesChannel\AbstractClearVaultRoute;
@@ -54,6 +55,7 @@ class PayPalController extends StorefrontController
         private readonly AbstractPUIPaymentInstructionsRoute $puiPaymentInstructionsRoute,
         private readonly AbstractExpressPrepareCheckoutRoute $expressPrepareCheckoutRoute,
         private readonly AbstractExpressCreateOrderRoute $expressCreateOrderRoute,
+        private readonly AbstractExpressShippingCallbackRoute $expressShippingCallbackRoute,
         private readonly AbstractContextSwitchRoute $contextSwitchRoute,
         private readonly AbstractCartDeleteRoute $cartDeleteRoute,
         private readonly AbstractClearVaultRoute $clearVaultRoute,
@@ -119,6 +121,12 @@ class PayPalController extends StorefrontController
         }
 
         return new NoContentResponse();
+    }
+
+    #[Route(path: '/paypal/express/shipping-callback/{salesChannelId}/{token}', name: 'frontend.paypal.express.shipping_callback', methods: ['POST'], defaults: ['csrf_protected' => false])]
+    public function expressShippingCallback(Request $request, SalesChannelContext $context): Response
+    {
+        return $this->expressShippingCallbackRoute->handleCallback($request, $context);
     }
 
     #[Route(path: '/paypal/vault/clear', name: 'frontend.paypal.vault.clear', methods: ['GET'], defaults: ['XmlHttpRequest' => true, 'csrf_protected' => false])]

--- a/src/Util/Lifecycle/Update.php
+++ b/src/Util/Lifecycle/Update.php
@@ -180,6 +180,10 @@ class Update
         if (\version_compare($updateContext->getCurrentPluginVersion(), '8.9.0', '<')) {
             $this->updateTo890($updateContext->getContext());
         }
+
+        if (\version_compare($updateContext->getCurrentPluginVersion(), '10.6.0', '<')) {
+            $this->updateTo1060();
+        }
     }
 
     private function updateTo130(): void
@@ -559,5 +563,10 @@ class Update
     private function updateTo890(Context $context): void
     {
         $this->paymentMethodInstaller->updateAllMedia($context);
+    }
+
+    private function updateTo1060(): void
+    {
+        $this->systemConfig->set(Settings::ECS_SHIPPING_CALLBACK_ENABLED, true);
     }
 }

--- a/src/Webhook/WebhookService.php
+++ b/src/Webhook/WebhookService.php
@@ -34,6 +34,7 @@ class WebhookService implements WebhookServiceInterface
     public const STATUS_WEBHOOK_MISSING = 'missing';
     public const STATUS_WEBHOOK_INVALID = 'invalid';
     public const STATUS_WEBHOOK_VALID = 'valid';
+    public const STATUS_WEBHOOK_DISABLED = 'disabled';
 
     private WebhookResource $webhookResource;
 
@@ -60,6 +61,10 @@ class WebhookService implements WebhookServiceInterface
 
     public function getStatus(?string $salesChannelId): string
     {
+        if ($this->systemConfigService->getBool(Settings::IS_LOCAL_ENVIRONMENT, $salesChannelId)) {
+            return self::STATUS_WEBHOOK_DISABLED;
+        }
+
         $webhookId = $this->systemConfigService->getString(Settings::WEBHOOK_ID, $salesChannelId);
         if ($webhookId === '') {
             return self::STATUS_WEBHOOK_MISSING;

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTest.php
@@ -14,6 +14,7 @@ use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\PlatformRequest;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\Payment\Service\VaultTokenService;
 use Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder;
@@ -21,6 +22,7 @@ use Swag\PayPal\OrdersApi\Builder\Util\AddressProvider;
 use Swag\PayPal\OrdersApi\Builder\Util\AmountProvider;
 use Swag\PayPal\OrdersApi\Builder\Util\ItemListProvider;
 use Swag\PayPal\OrdersApi\Builder\Util\PurchaseUnitProvider;
+use Swag\PayPal\RestApi\V2\Api\Order;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Test\Helper\CheckoutRouteTrait;
@@ -45,9 +47,12 @@ class ExpressCreateOrderRouteTest extends TestCase
 
     private TestHandler $logger;
 
+    private PayPalClientFactoryMock $clientFactory;
+
     protected function setUp(): void
     {
         $this->logger = new TestHandler();
+        $this->clientFactory = new PayPalClientFactoryMock(new NullLogger());
     }
 
     public function testCreatePayment(): void
@@ -70,11 +75,11 @@ class ExpressCreateOrderRouteTest extends TestCase
         static::assertSame(CreateOrderCapture::ID, $response->getToken());
     }
 
-    public function testCreateWithoutShippingCallback(): void
+    public function testCreateWithLocalEnvironmentActive(): void
     {
         $salesChannelContext = $this->getSalesChannelContext();
 
-        $response = $this->createRoute(true)->createPayPalOrder(new Request(), $salesChannelContext);
+        $response = $this->createRoute([Settings::IS_LOCAL_ENVIRONMENT => true])->createPayPalOrder(new Request(), $salesChannelContext);
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame(CreateOrderCapture::ID, $response->getToken());
@@ -82,12 +87,81 @@ class ExpressCreateOrderRouteTest extends TestCase
         static::assertTrue($this->logger->hasDebug(['message' => 'Skipped shipping callback due to being disabled in system config']));
     }
 
-    private function createRoute(bool $callbacksDisabled = false): ExpressCreateOrderRoute
+    public function testCreateWithShippingCallbackDisabled(): void
     {
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $response = $this->createRoute([Settings::ECS_SHIPPING_CALLBACK_ENABLED => false])->createPayPalOrder(new Request(), $salesChannelContext);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(CreateOrderCapture::ID, $response->getToken());
+
+        static::assertTrue($this->logger->hasDebug('Skipped shipping callback due to being disabled in system config'));
+    }
+
+    public function testCreateShippingCallbackStoreApi(): void
+    {
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects(static::once())
+            ->method('generate')
+            ->with('store-api.paypal.express.shipping_callback')
+            ->willReturn('generatedUrl');
+
+        $response = $this->createRoute([], $router)->createPayPalOrder(new Request(), $salesChannelContext);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(CreateOrderCapture::ID, $response->getToken());
+
+        $data = $this->clientFactory->getClient()->getData();
+        $order = (new Order())->assign($data);
+
+        $experienceContext = $order->getPaymentSource()?->getPaypal()?->getExperienceContext();
+        static::assertNotNull($experienceContext);
+        static::assertNotNull($experienceContext->getOrderUpdateCallbackConfig());
+    }
+
+    public function testCreateShippingCallbackStorefront(): void
+    {
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects(static::once())
+            ->method('generate')
+            ->with('frontend.paypal.express.shipping_callback')
+            ->willReturn('generatedUrl');
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['storefront']);
+
+        $response = $this->createRoute([], $router)->createPayPalOrder($request, $salesChannelContext);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(CreateOrderCapture::ID, $response->getToken());
+
+        $data = $this->clientFactory->getClient()->getData();
+        $order = (new Order())->assign($data);
+
+        $experienceContext = $order->getPaymentSource()?->getPaypal()?->getExperienceContext();
+        static::assertNotNull($experienceContext);
+        static::assertNotNull($experienceContext->getOrderUpdateCallbackConfig());
+    }
+
+    /**
+     * @param array<string, mixed> $systemConfigSettings
+     */
+    private function createRoute(
+        array $systemConfigSettings = [],
+        ?RouterInterface $router = null,
+    ): ExpressCreateOrderRoute {
         $systemConfig = $this->createSystemConfigServiceMock([
             Settings::CLIENT_ID => 'testClientId',
             Settings::CLIENT_SECRET => 'testClientSecret',
-            Settings::IS_LOCAL_ENVIRONMENT => $callbacksDisabled,
+            Settings::ECS_SHIPPING_CALLBACK_ENABLED => true,
+            ...$systemConfigSettings,
         ]);
 
         $priceFormatter = new PriceFormatter();
@@ -108,9 +182,9 @@ class ExpressCreateOrderRouteTest extends TestCase
         return new ExpressCreateOrderRoute(
             $this->getContainer()->get(CartService::class),
             $paypalOrderBuilder,
-            new OrderResource(new PayPalClientFactoryMock(new NullLogger())),
+            new OrderResource($this->clientFactory),
             $systemConfig,
-            $this->createMock(RouterInterface::class),
+            $router ?? $this->createMock(RouterInterface::class),
             new Logger('test', [$this->logger]),
         );
     }

--- a/tests/Mock/PayPal/Client/GuzzleClientMock.php
+++ b/tests/Mock/PayPal/Client/GuzzleClientMock.php
@@ -397,6 +397,10 @@ class GuzzleClientMock implements ClientInterface
             throw new \RuntimeException('No fixture defined for POST ' . $resourceUri);
         }
 
+        if ($data) {
+            $this->data = \json_decode(\json_encode($data, \JSON_THROW_ON_ERROR), true, \JSON_THROW_ON_ERROR);
+        }
+
         return $this->ensureValidJson($response);
     }
 

--- a/tests/OpenAPISchemaTest.php
+++ b/tests/OpenAPISchemaTest.php
@@ -40,6 +40,7 @@ class OpenAPISchemaTest extends TestCase
         '\\' . PayPalController::class . '::expressPrepareCheckout',
         '\\' . PayPalController::class . '::expressCreateOrder',
         '\\' . PayPalController::class . '::expressPrepareCart',
+        '\\' . PayPalController::class . '::expressShippingCallback',
         '\\' . PayPalController::class . '::clearVault',
 
         // Decoration, covered by platform

--- a/tests/Storefront/Controller/PayPalControllerTest.php
+++ b/tests/Storefront/Controller/PayPalControllerTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressPrepareCheckoutRoute;
+use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressShippingCallbackRoute;
 use Swag\PayPal\Checkout\PUI\SalesChannel\AbstractPUIPaymentInstructionsRoute;
 use Swag\PayPal\Checkout\SalesChannel\AbstractClearVaultRoute;
 use Swag\PayPal\Checkout\SalesChannel\AbstractCreateOrderRoute;
@@ -57,6 +58,7 @@ class PayPalControllerTest extends TestCase
                 $this->createMock(AbstractPUIPaymentInstructionsRoute::class),
                 $this->createMock(AbstractExpressPrepareCheckoutRoute::class),
                 $this->createMock(AbstractExpressCreateOrderRoute::class),
+                $this->createMock(AbstractExpressShippingCallbackRoute::class),
                 $this->createMock(AbstractContextSwitchRoute::class),
                 $this->createMock(AbstractCartDeleteRoute::class),
                 $this->createMock(AbstractClearVaultRoute::class),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
There are some troubles with the shipping callback we implemented.
You only can disable it implicitly and it needs the store-api to be exposed.

### 2. What does this change do, exactly?
- Add a dedicated setting for the shipping callback
- Add a proxy storefront route so the store-api doesn't need to be exposed
- Disable settings based on "Local environment" active incl. tooltips
- Fix reloading the webhook status on settings save

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
