### PR TITLE
fix: visual POS issues

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal-pos/component/swag-paypal-pos-boolean-radio/swag-paypal-pos-boolean-radio.scss
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/component/swag-paypal-pos-boolean-radio/swag-paypal-pos-boolean-radio.scss
@@ -15,6 +15,11 @@
         }
     }
 
+    &.sw-field--radio .sw-field__radio-option-label {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
     .sw-field__radio-option-checked {
         background-color: transparentize($color-shopware-brand-500, 0.95);
         border: 1px solid $color-shopware-brand-500;

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-disconnect/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-disconnect/index.js
@@ -105,7 +105,7 @@ Component.register('swag-paypal-pos-wizard-connection-disconnect', {
                     key: 'next',
                     label: this.$t('swag-paypal-pos.wizard.connectionDisconnect.disconnectButton'),
                     position: 'right',
-                    variant: 'danger',
+                    variant: 'critical',
                     action: this.onDisconnect,
                     disabled: this.isFetchingInformation,
                 },
@@ -128,7 +128,7 @@ Component.register('swag-paypal-pos-wizard-connection-disconnect', {
                 Shopware.Utils.EventBus.emit('sw-sales-channel-detail-sales-channel-change');
 
                 this.$emit('recreate-sales-channel');
-                this.forceUpdate();
+                this.updateButtons();
 
                 this.$router.push({ name: 'swag.paypal.pos.wizard.connection' });
             }).catch(() => {
@@ -138,6 +138,9 @@ Component.register('swag-paypal-pos-wizard-connection-disconnect', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
             this.updateButtons();

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-disconnect/swag-paypal-pos-wizard-connection-disconnect.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-disconnect/swag-paypal-pos-wizard-connection-disconnect.html.twig
@@ -30,7 +30,7 @@
                              position-identifier="swag-paypal-pos-wizard-connection-disconnect-user"
                              :isLoading="isFetchingInformation">
                         <sw-container class="swag-paypal-pos-wizard-connection-disconnect__user-container"
-                                      columns="30px auto 150px"
+                                      columns="30px auto"
                                       align="center"
                                       gap="30px">
 

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-success/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection-success/index.js
@@ -125,6 +125,9 @@ Component.register('swag-paypal-pos-wizard-connection-success', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
             this.updateButtons();

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection/index.js
@@ -102,6 +102,9 @@ Component.register('swag-paypal-pos-wizard-connection', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
             this.updateButtons();

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection/swag-paypal-pos-wizard-connection.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-connection/swag-paypal-pos-wizard-connection.html.twig
@@ -14,7 +14,7 @@
         required
         :label="$t('swag-paypal-pos.authentication.labelApiKey')"
         :placeholder="$t('swag-paypal-pos.authentication.placeholderApiKey')"
-        @update:modelValue="forceUpdate"
+        @update:modelValue="updateButtons"
     />
     {% endblock %}
 

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-customization/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-customization/index.js
@@ -108,6 +108,9 @@ Component.register('swag-paypal-pos-wizard-customization', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
             this.$nextTick().then(() => {
@@ -120,7 +123,6 @@ Component.register('swag-paypal-pos-wizard-customization', {
             this.salesChannel.languages.push({
                 id: this.salesChannel.languageId,
             });
-            this.$forceUpdate();
         },
 
         toggleLoadingState(state) {

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-customization/swag-paypal-pos-wizard-customization.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-customization/swag-paypal-pos-wizard-customization.html.twig
@@ -10,7 +10,7 @@
                 required
                 :label="$t('swag-paypal-pos.wizard.customization.salesChannelLabel')"
                 :placeholder="$t('sw-sales-channel.detail.placeholderName')"
-                @update:model-value="forceUpdate" />
+                @update:model-value="updateButtons" />
         {% endblock %}
 
         {% block swag_paypal_pos_wizard_customization_language %}
@@ -30,7 +30,7 @@
                 :label="$t('swag-paypal-pos.wizard.customization.labelDomain')"
                 :placeholder="$t('swag-paypal-pos.wizard.customization.placeholderDomain')"
                 :model-value="salesChannel.extensions.paypalPosSalesChannel.mediaDomain"
-                @update:model-value="forceUpdate" />
+                @update:model-value="updateButtons" />
         {% endblock %}
 
         {% block swag_paypal_pos_wizard_connection_success_disclaimer %}

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-product-selection/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-product-selection/index.js
@@ -104,9 +104,12 @@ Component.register('swag-paypal-pos-wizard-product-selection', {
 
         updateClone() {
             this.$emit('update-clone-sales-channel', null);
-            this.forceUpdate();
+            this.updateButtons();
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
             this.updateButtons();

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-product-selection/swag-paypal-pos-wizard-product-selection.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-product-selection/swag-paypal-pos-wizard-product-selection.html.twig
@@ -24,7 +24,7 @@
                     :criteria="salesChannelCriteria"
                     :disabled="!hasClone"
                     :label="$t('swag-paypal-pos.wizard.productSelection.labelSelect')"
-                    @update:value="forceUpdate" />
+                    @update:value="updateButtons" />
         {% endblock %}
     </div>
 {% endblock %}

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-sync-library/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-sync-library/index.js
@@ -106,6 +106,9 @@ Component.register('swag-paypal-pos-wizard-sync-library', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
         },

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-sync-prices/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard-sync-prices/index.js
@@ -90,6 +90,9 @@ Component.register('swag-paypal-pos-wizard-sync-prices', {
             });
         },
 
+        /**
+         * @deprecated tag:v11.0.0 - will be removed without replacement
+         */
         forceUpdate() {
             this.$forceUpdate();
         },

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard/index.js
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard/index.js
@@ -101,6 +101,10 @@ Component.extend('swag-paypal-pos-wizard', 'sw-first-run-wizard-modal', {
 
             return params.reverse().join(' | ');
         },
+
+        posSalesChannel() {
+            return this.salesChannel?.extensions?.paypalPosSalesChannel;
+        },
     },
 
     watch: {
@@ -216,7 +220,7 @@ Component.extend('swag-paypal-pos-wizard', 'sw-first-run-wizard-modal', {
 
                 this.createNotificationError({
                     message: this.$t('sw-sales-channel.detail.messageSaveError', 0, {
-                        name: this.salesChannel.name || this.placeholder(this.salesChannel, 'name'),
+                        name: this.salesChannel.translated.name || this.salesChannel.name || this.placeholder(this.salesChannel, 'name'),
                     }),
                 });
             });
@@ -249,22 +253,22 @@ Component.extend('swag-paypal-pos-wizard', 'sw-first-run-wizard-modal', {
             });
         },
 
-        createNewSalesChannel() {
+        async createNewSalesChannel() {
             if (Context.api.languageId !== Context.api.systemLanguageId) {
                 Context.api.languageId = Context.api.systemLanguageId;
             }
 
             this.previousApiKey = null;
-            this.salesChannel = this.salesChannelRepository.create(Context.api);
-            this.salesChannel.typeId = PAYPAL_POS_SALES_CHANNEL_TYPE_ID;
-            this.salesChannel.name = this.$t('swag-paypal-pos.wizard.salesChannelPrototypeName');
-            this.salesChannel.active = false;
+            const salesChannel = this.salesChannelRepository.create(Context.api);
+            salesChannel.typeId = PAYPAL_POS_SALES_CHANNEL_TYPE_ID;
+            salesChannel.name = this.$t('swag-paypal-pos.wizard.salesChannelPrototypeName');
+            salesChannel.active = false;
 
-            this.salesChannel.extensions.paypalPosSalesChannel
+            salesChannel.extensions.paypalPosSalesChannel
                 = this.paypalPosSalesChannelRepository.create(Context.api);
 
             Object.assign(
-                this.salesChannel.extensions.paypalPosSalesChannel,
+                salesChannel.extensions.paypalPosSalesChannel,
                 {
                     mediaDomain: '',
                     apiKey: '',
@@ -275,19 +279,21 @@ Component.extend('swag-paypal-pos-wizard', 'sw-first-run-wizard-modal', {
                 },
             );
 
-            this.salesChannelService.generateKey().then((response) => {
-                this.salesChannel.accessKey = response.accessKey;
-            }).catch(() => {
+            try {
+                salesChannel.accessKey = (await this.salesChannelService.generateKey()).accessKey;
+            } catch {
                 this.createNotificationError({
                     message: this.$t('sw-sales-channel.detail.messageAPIError'),
                 });
-            });
+            }
+
+            this.salesChannel = salesChannel;
         },
 
         loadSalesChannel() {
             const salesChannelId = this.$route.params.id || this.salesChannel.id;
             if (!salesChannelId) {
-                return new Promise((resolve) => { resolve(); });
+                return Promise.resolve();
             }
 
             this.isLoading = true;

--- a/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard/swag-paypal-pos-wizard.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-pos/page/wizard/swag-paypal-pos-wizard/swag-paypal-pos-wizard.html.twig
@@ -28,23 +28,24 @@
 
                         {% block swag_paypal_pos_wizard_modal_content_page %}
                             <div class="swag-paypal-pos-wizard__page">
-                                    <router-view
-                                        v-slot="{ Component }"
-                                    >
-                                        <component
-                                            :is="Component"
-                                            :salesChannel="salesChannel"
-                                            :cloneSalesChannelId="cloneSalesChannelId"
-                                            :saveSalesChannel="save"
-                                            :isLoading="isLoading"
-                                            @buttons-update="updateButtons"
-                                            @frw-set-title="setTitle"
-                                            @frw-finish="onFinishWizard"
-                                            @toggle-loading="toggleLoading"
-                                            @recreate-sales-channel="createNewSalesChannel"
-                                            @update-clone-sales-channel="updateCloneSalesChannel"
-                                        />
-                                    </router-view>
+                                <router-view
+                                    v-if="posSalesChannel"
+                                    v-slot="{ Component }"
+                                >
+                                    <component
+                                        :is="Component"
+                                        :salesChannel="salesChannel"
+                                        :cloneSalesChannelId="cloneSalesChannelId"
+                                        :saveSalesChannel="save"
+                                        :isLoading="isLoading"
+                                        @buttons-update="updateButtons"
+                                        @frw-set-title="setTitle"
+                                        @frw-finish="onFinishWizard"
+                                        @toggle-loading="toggleLoading"
+                                        @recreate-sales-channel="createNewSalesChannel"
+                                        @update-clone-sales-channel="updateCloneSalesChannel"
+                                    />
+                                </router-view>
                             </div>
                         {% endblock %}
                     </sw-container>


### PR DESCRIPTION
### 1. Why is this change necessary?
POS / Zettle has a lot of visual issues. We can fix some of them, so it's `a lot - 1`.

### 2. What does this change do, exactly?
- Multi-Line radio boxes
- issues when re-entering the wizard
- broken layout of Zettle disconnect wizard step
- console errors because of not yet loaded issues
- hacks for Vue2 missing reactivity removed / deprecated (`$forceUpdate`)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
