### PR TITLE
PayPal: respect `Retry-After` for shipping tracking rate limits

### DIFF
--- a/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
+++ b/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
@@ -19,6 +19,7 @@ use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Shipping\Tracker\Item;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Shipping\Tracker\ItemCollection;
 use Shopware\PayPalSDK\Struct\V2\Order\Tracker;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Swag\PayPal\RestApi\Exception\RetryAfterPayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\SwagPayPal;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -64,6 +65,8 @@ class ShippingInformationMessageHandler
 
         try {
             $order = $this->orderResource->get($orderId, $salesChannelId);
+        } catch (RetryAfterPayPalApiException $e) {
+            $this->throwRecoverableOnRateLimit($e);
         } catch (PayPalApiException $e) {
             if ($e->is(PayPalApiException::ERROR_CODE_RESOURCE_NOT_FOUND)) {
                 $this->logger->warning(
@@ -77,8 +80,6 @@ class ShippingInformationMessageHandler
 
                 return;
             }
-
-            $this->throwRecoverableOnRateLimit($e);
 
             throw $e;
         }
@@ -101,6 +102,8 @@ class ShippingInformationMessageHandler
 
             try {
                 $this->orderResource->addTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
+            } catch (RetryAfterPayPalApiException $e) {
+                $this->throwRecoverableOnRateLimit($e);
             } catch (PayPalApiException $e) {
                 $this->handleInvalidCarrierException($e, $tracker, $shippingMethodName);
 
@@ -109,10 +112,8 @@ class ShippingInformationMessageHandler
 
                 try {
                     $this->orderResource->addTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
-                } catch (PayPalApiException $e) {
+                } catch (RetryAfterPayPalApiException $e) {
                     $this->throwRecoverableOnRateLimit($e);
-
-                    throw $e;
                 }
             }
         }
@@ -129,10 +130,8 @@ class ShippingInformationMessageHandler
 
             try {
                 $this->orderResource->removeTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
-            } catch (PayPalApiException $e) {
+            } catch (RetryAfterPayPalApiException $e) {
                 $this->throwRecoverableOnRateLimit($e);
-
-                throw $e;
             }
         }
 
@@ -146,8 +145,6 @@ class ShippingInformationMessageHandler
 
     private function handleInvalidCarrierException(PayPalApiException $e, Tracker &$tracker, string $shippingMethodName): void
     {
-        $this->throwRecoverableOnRateLimit($e);
-
         if ($e->is(PayPalApiException::ISSUE_INVALID_PARAMETER_VALUE) && \str_contains($e->getMessage(), '(/carrier)')) {
             $this->logger->error('Carrier "{carrier}" of shipping method "{methodName}" is not supported by PayPal.', [
                 'carrier' => $tracker->getCarrier(),
@@ -161,12 +158,8 @@ class ShippingInformationMessageHandler
         }
     }
 
-    private function throwRecoverableOnRateLimit(PayPalApiException $e): void
+    private function throwRecoverableOnRateLimit(RetryAfterPayPalApiException $e): never
     {
-        if (!$e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED)) {
-            return;
-        }
-
         throw new RecoverableMessageHandlingException(
             $e->getMessage(),
             previous: $e,

--- a/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
+++ b/src/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandler.php
@@ -22,6 +22,7 @@ use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\SwagPayPal;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 
 /**
  * @internal
@@ -30,6 +31,8 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 class ShippingInformationMessageHandler
 {
+    private const DEFAULT_RATE_LIMIT_RETRY_DELAY = 60000;
+
     public function __construct(
         private readonly EntityRepository $orderDeliveryRepository,
         private readonly OrderResource $orderResource,
@@ -75,6 +78,8 @@ class ShippingInformationMessageHandler
                 return;
             }
 
+            $this->throwRecoverableOnRateLimit($e);
+
             throw $e;
         }
 
@@ -102,7 +107,13 @@ class ShippingInformationMessageHandler
                 $carrierOtherName = $carrier;
                 $carrier = Tracker::CARRIER_OTHER;
 
-                $this->orderResource->addTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
+                try {
+                    $this->orderResource->addTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
+                } catch (PayPalApiException $e) {
+                    $this->throwRecoverableOnRateLimit($e);
+
+                    throw $e;
+                }
             }
         }
 
@@ -116,7 +127,13 @@ class ShippingInformationMessageHandler
         foreach ($removedTrackingCodes as $trackingCode) {
             $tracker = $this->createTracker($trackingCode, $captureId, $carrier, $carrierOtherName, $itemCollection);
 
-            $this->orderResource->removeTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
+            try {
+                $this->orderResource->removeTracker($tracker, $orderId, $salesChannelId, $partnerAttributionId);
+            } catch (PayPalApiException $e) {
+                $this->throwRecoverableOnRateLimit($e);
+
+                throw $e;
+            }
         }
 
         if (\count($removedTrackingCodes) > 0) {
@@ -129,6 +146,8 @@ class ShippingInformationMessageHandler
 
     private function handleInvalidCarrierException(PayPalApiException $e, Tracker &$tracker, string $shippingMethodName): void
     {
+        $this->throwRecoverableOnRateLimit($e);
+
         if ($e->is(PayPalApiException::ISSUE_INVALID_PARAMETER_VALUE) && \str_contains($e->getMessage(), '(/carrier)')) {
             $this->logger->error('Carrier "{carrier}" of shipping method "{methodName}" is not supported by PayPal.', [
                 'carrier' => $tracker->getCarrier(),
@@ -140,6 +159,19 @@ class ShippingInformationMessageHandler
         } else {
             throw $e;
         }
+    }
+
+    private function throwRecoverableOnRateLimit(PayPalApiException $e): void
+    {
+        if (!$e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED)) {
+            return;
+        }
+
+        throw new RecoverableMessageHandlingException(
+            $e->getMessage(),
+            previous: $e,
+            retryDelay: $e->getRetryDelay() ?? self::DEFAULT_RATE_LIMIT_RETRY_DELAY,
+        );
     }
 
     /**

--- a/src/RestApi/Exception/PayPalApiException.php
+++ b/src/RestApi/Exception/PayPalApiException.php
@@ -35,7 +35,6 @@ class PayPalApiException extends PaymentException
         string $message,
         int $payPalApiStatusCode = Response::HTTP_INTERNAL_SERVER_ERROR,
         private ?string $issue = null,
-        private ?int $retryDelay = null,
     ) {
         parent::__construct(
             $payPalApiStatusCode,
@@ -66,14 +65,6 @@ class PayPalApiException extends PaymentException
     }
 
     /**
-     * @return int|null - Retry delay in milliseconds
-     */
-    public function getRetryDelay(): ?int
-    {
-        return $this->retryDelay;
-    }
-
-    /**
      * Is error code or issue one of the given codes/issues?
      *
      * @param self::ERROR_CODE_*|self::ISSUE_*|string $codes
@@ -85,7 +76,22 @@ class PayPalApiException extends PaymentException
             || \in_array($this->name, $codes, true);
     }
 
-    public static function from(ApiException $e, ?string $retryAfter = null): self
+    public static function from(ApiException $e): self
+    {
+        ['message' => $message, 'issue' => $issue] = self::extractMessageAndIssue($e);
+
+        return new self(
+            $e->getErrorCode(),
+            $message,
+            $e->getStatusCode(),
+            $issue,
+        );
+    }
+
+    /**
+     * @return array{message: string, issue: string|null}
+     */
+    protected static function extractMessageAndIssue(ApiException $e): array
     {
         $message = $e->getReason();
         $issue = null;
@@ -96,34 +102,9 @@ class PayPalApiException extends PaymentException
             $issue = \array_slice($e->getDetails()->getIssues(), -1)[0] ?? null;
         }
 
-        return new self(
-            $e->getErrorCode(),
-            $message,
-            $e->getStatusCode(),
-            $issue,
-            self::parseRetryDelay($retryAfter),
-        );
-    }
-
-    private static function parseRetryDelay(?string $retryAfter): ?int
-    {
-        if ($retryAfter === null || ($retryAfter = \trim($retryAfter)) === '') {
-            return null;
-        }
-
-        if (\ctype_digit($retryAfter)) {
-            $retryDelay = (int) $retryAfter * 1000;
-
-            return $retryDelay > 0 ? $retryDelay : null;
-        }
-
-        $retryAt = \strtotime($retryAfter);
-        if ($retryAt === false) {
-            return null;
-        }
-
-        $retryDelay = ($retryAt - \time()) * 1000;
-
-        return $retryDelay > 0 ? $retryDelay : null;
+        return [
+            'message' => $message,
+            'issue' => $issue,
+        ];
     }
 }

--- a/src/RestApi/Exception/PayPalApiException.php
+++ b/src/RestApi/Exception/PayPalApiException.php
@@ -18,6 +18,7 @@ class PayPalApiException extends PaymentException
 {
     public const ERROR_CODE_INVALID_CREDENTIALS = 'INVALID_CREDENTIALS';
     public const ERROR_CODE_DUPLICATE_ORDER_NUMBER = 'DUPLICATE_TRANSACTION';
+    public const ERROR_CODE_RATE_LIMIT_REACHED = 'RATE_LIMIT_REACHED';
     public const ERROR_CODE_RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND';
 
     public const ISSUE_NOT_AVAILABLE = 'NOT_AVAILABLE';
@@ -34,6 +35,7 @@ class PayPalApiException extends PaymentException
         string $message,
         int $payPalApiStatusCode = Response::HTTP_INTERNAL_SERVER_ERROR,
         private ?string $issue = null,
+        private ?int $retryDelay = null,
     ) {
         parent::__construct(
             $payPalApiStatusCode,
@@ -64,6 +66,14 @@ class PayPalApiException extends PaymentException
     }
 
     /**
+     * @return int|null - Retry delay in milliseconds
+     */
+    public function getRetryDelay(): ?int
+    {
+        return $this->retryDelay;
+    }
+
+    /**
      * Is error code or issue one of the given codes/issues?
      *
      * @param self::ERROR_CODE_*|self::ISSUE_*|string $codes
@@ -75,7 +85,7 @@ class PayPalApiException extends PaymentException
             || \in_array($this->name, $codes, true);
     }
 
-    public static function from(ApiException $e): self
+    public static function from(ApiException $e, ?string $retryAfter = null): self
     {
         $message = $e->getReason();
         $issue = null;
@@ -91,6 +101,29 @@ class PayPalApiException extends PaymentException
             $message,
             $e->getStatusCode(),
             $issue,
+            self::parseRetryDelay($retryAfter),
         );
+    }
+
+    private static function parseRetryDelay(?string $retryAfter): ?int
+    {
+        if ($retryAfter === null || ($retryAfter = \trim($retryAfter)) === '') {
+            return null;
+        }
+
+        if (\ctype_digit($retryAfter)) {
+            $retryDelay = (int) $retryAfter * 1000;
+
+            return $retryDelay > 0 ? $retryDelay : null;
+        }
+
+        $retryAt = \strtotime($retryAfter);
+        if ($retryAt === false) {
+            return null;
+        }
+
+        $retryDelay = ($retryAt - \time()) * 1000;
+
+        return $retryDelay > 0 ? $retryDelay : null;
     }
 }

--- a/src/RestApi/Exception/RetryAfterPayPalApiException.php
+++ b/src/RestApi/Exception/RetryAfterPayPalApiException.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\RestApi\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\PayPalSDK\Exception\ApiException;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class RetryAfterPayPalApiException extends PayPalApiException
+{
+    public function __construct(
+        string $name,
+        string $message,
+        int $payPalApiStatusCode,
+        ?string $issue,
+        private readonly ?int $retryDelay,
+    ) {
+        parent::__construct($name, $message, $payPalApiStatusCode, $issue);
+    }
+
+    /**
+     * @return int|null - Retry delay in milliseconds
+     */
+    public function getRetryDelay(): ?int
+    {
+        return $this->retryDelay;
+    }
+
+    public static function from(ApiException $e, ?string $retryAfter = null): self
+    {
+        ['message' => $message, 'issue' => $issue] = parent::extractMessageAndIssue($e);
+
+        return new self(
+            $e->getErrorCode(),
+            $message,
+            $e->getStatusCode(),
+            $issue,
+            self::parseRetryDelay($retryAfter),
+        );
+    }
+
+    private static function parseRetryDelay(?string $retryAfter): ?int
+    {
+        if ($retryAfter === null || ($retryAfter = \trim($retryAfter)) === '') {
+            return null;
+        }
+
+        if (\ctype_digit($retryAfter)) {
+            $retryDelay = (int) $retryAfter * 1000;
+
+            return $retryDelay > 0 ? $retryDelay : null;
+        }
+
+        $retryAt = \strtotime($retryAfter);
+        if ($retryAt === false) {
+            return null;
+        }
+
+        $retryDelay = ($retryAt - \time()) * 1000;
+
+        return $retryDelay > 0 ? $retryDelay : null;
+    }
+}

--- a/src/RestApi/RequestService.php
+++ b/src/RestApi/RequestService.php
@@ -9,7 +9,6 @@ namespace Swag\PayPal\RestApi;
 
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\PayPalSDK\Contract\RequestServiceInterface;
 use Shopware\PayPalSDK\Exception\ApiException;
 use Shopware\PayPalSDK\RequestService as SDKRequestService;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
@@ -18,7 +17,7 @@ use Swag\PayPal\RestApi\Exception\PayPalApiException;
  * Wrap ApiExceptions into PayPalApiExceptions
  */
 #[Package('checkout')]
-class RequestService extends SDKRequestService implements RequestServiceInterface
+class RequestService extends SDKRequestService
 {
     /**
      * @throws PayPalApiException
@@ -28,7 +27,7 @@ class RequestService extends SDKRequestService implements RequestServiceInterfac
         try {
             return parent::handleResponse($response);
         } catch (ApiException $e) {
-            throw PayPalApiException::from($e);
+            throw PayPalApiException::from($e, $response->getHeaderLine('Retry-After') ?: null);
         }
     }
 }

--- a/src/RestApi/RequestService.php
+++ b/src/RestApi/RequestService.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Exception\ApiException;
 use Shopware\PayPalSDK\RequestService as SDKRequestService;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Swag\PayPal\RestApi\Exception\RetryAfterPayPalApiException;
 
 /**
  * Wrap ApiExceptions into PayPalApiExceptions
@@ -27,7 +28,11 @@ class RequestService extends SDKRequestService
         try {
             return parent::handleResponse($response);
         } catch (ApiException $e) {
-            throw PayPalApiException::from($e, $response->getHeaderLine('Retry-After') ?: null);
+            if ($e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED)) {
+                throw RetryAfterPayPalApiException::from($e, $response->getHeaderLine('Retry-After') ?: null);
+            }
+
+            throw PayPalApiException::from($e);
         }
     }
 }

--- a/tests/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandlerTest.php
+++ b/tests/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandlerTest.php
@@ -33,6 +33,7 @@ use Swag\PayPal\Checkout\Order\Shipping\MessageQueue\ShippingInformationMessageH
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\SwagPayPal;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 
 /**
  * @internal
@@ -380,6 +381,87 @@ class ShippingInformationMessageHandlerTest extends TestCase
             ->method('warning');
 
         ($this->handler)(new ShippingInformationMessage('order-delivery-id'));
+    }
+
+    public function testRateLimitedGetThrowsRecoverableExceptionWithRetryDelay(): void
+    {
+        $orderDelivery = self::createOrderDelivery(self::createOrder(), trackingCodes: ['code-a']);
+        $payPalException = new PayPalApiException(
+            PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED,
+            'RATE_LIMIT_REACHED',
+            retryDelay: 120000,
+        );
+
+        $this->orderDeliveryRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn(self::createSearchResult($orderDelivery));
+
+        $this->orderResource
+            ->expects($this->once())
+            ->method('get')
+            ->willThrowException($payPalException);
+
+        $this->orderResource
+            ->expects($this->never())
+            ->method('removeTracker');
+
+        $this->orderResource
+            ->expects($this->never())
+            ->method('addTracker');
+
+        $this->logger
+            ->expects($this->never())
+            ->method('warning');
+
+        try {
+            ($this->handler)(new ShippingInformationMessage('order-delivery-id'));
+            static::fail('Expected recoverable exception was not thrown.');
+        } catch (RecoverableMessageHandlingException $e) {
+            static::assertSame(120000, $e->getRetryDelay());
+            static::assertSame($payPalException, $e->getPrevious());
+        }
+    }
+
+    public function testRateLimitedAddTrackerThrowsRecoverableExceptionWithDefaultRetryDelay(): void
+    {
+        $orderDelivery = self::createOrderDelivery(self::createOrder(), trackingCodes: ['code-a']);
+        $payPalOrder = self::createPayPalOrder();
+        $payPalException = new PayPalApiException(
+            PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED,
+            'RATE_LIMIT_REACHED',
+        );
+
+        $this->orderDeliveryRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn(self::createSearchResult($orderDelivery));
+
+        $this->orderResource
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($payPalOrder);
+
+        $this->orderResource
+            ->expects($this->once())
+            ->method('addTracker')
+            ->willThrowException($payPalException);
+
+        $this->orderResource
+            ->expects($this->never())
+            ->method('removeTracker');
+
+        $this->logger
+            ->expects($this->never())
+            ->method('error');
+
+        try {
+            ($this->handler)(new ShippingInformationMessage('order-delivery-id'));
+            static::fail('Expected recoverable exception was not thrown.');
+        } catch (RecoverableMessageHandlingException $e) {
+            static::assertSame(60000, $e->getRetryDelay());
+            static::assertSame($payPalException, $e->getPrevious());
+        }
     }
 
     private static function createPayPalOrder(

--- a/tests/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandlerTest.php
+++ b/tests/Checkout/Order/Shipping/MessageQueue/ShippingInformationMessageHandlerTest.php
@@ -31,6 +31,7 @@ use Shopware\PayPalSDK\Struct\V2\Order\Tracker;
 use Swag\PayPal\Checkout\Order\Shipping\MessageQueue\ShippingInformationMessage;
 use Swag\PayPal\Checkout\Order\Shipping\MessageQueue\ShippingInformationMessageHandler;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Swag\PayPal\RestApi\Exception\RetryAfterPayPalApiException;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\SwagPayPal;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
@@ -386,10 +387,12 @@ class ShippingInformationMessageHandlerTest extends TestCase
     public function testRateLimitedGetThrowsRecoverableExceptionWithRetryDelay(): void
     {
         $orderDelivery = self::createOrderDelivery(self::createOrder(), trackingCodes: ['code-a']);
-        $payPalException = new PayPalApiException(
+        $payPalException = new RetryAfterPayPalApiException(
             PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED,
             'RATE_LIMIT_REACHED',
-            retryDelay: 120000,
+            429,
+            null,
+            120000,
         );
 
         $this->orderDeliveryRepository
@@ -427,9 +430,12 @@ class ShippingInformationMessageHandlerTest extends TestCase
     {
         $orderDelivery = self::createOrderDelivery(self::createOrder(), trackingCodes: ['code-a']);
         $payPalOrder = self::createPayPalOrder();
-        $payPalException = new PayPalApiException(
+        $payPalException = new RetryAfterPayPalApiException(
             PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED,
             'RATE_LIMIT_REACHED',
+            429,
+            null,
+            null,
         );
 
         $this->orderDeliveryRepository

--- a/tests/RestApi/RequestServiceTest.php
+++ b/tests/RestApi/RequestServiceTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Swag\PayPal\RestApi\Exception\RetryAfterPayPalApiException;
 use Swag\PayPal\RestApi\RequestService;
 
 /**
@@ -38,6 +39,7 @@ class RequestServiceTest extends TestCase
             $requestService->handleResponse($response);
             static::fail('Expected PayPalApiException was not thrown.');
         } catch (PayPalApiException $e) {
+            static::assertInstanceOf(RetryAfterPayPalApiException::class, $e);
             static::assertTrue($e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED));
             static::assertSame(120000, $e->getRetryDelay());
         }
@@ -61,6 +63,7 @@ class RequestServiceTest extends TestCase
             $requestService->handleResponse($response);
             static::fail('Expected PayPalApiException was not thrown.');
         } catch (PayPalApiException $e) {
+            static::assertInstanceOf(RetryAfterPayPalApiException::class, $e);
             static::assertTrue($e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED));
             static::assertNotNull($e->getRetryDelay());
             static::assertGreaterThanOrEqual(110000, $e->getRetryDelay());

--- a/tests/RestApi/RequestServiceTest.php
+++ b/tests/RestApi/RequestServiceTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\RestApi;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Swag\PayPal\RestApi\RequestService;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(RequestService::class)]
+class RequestServiceTest extends TestCase
+{
+    public function testHandleResponseAddsRetryDelayFromRetryAfterHeader(): void
+    {
+        $response = new Response(
+            429,
+            ['Retry-After' => '120'],
+            \json_encode([
+                'name' => 'RATE_LIMIT_REACHED',
+                'message' => 'Rate limit reached',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $requestService = new RequestService();
+
+        try {
+            $requestService->handleResponse($response);
+            static::fail('Expected PayPalApiException was not thrown.');
+        } catch (PayPalApiException $e) {
+            static::assertTrue($e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED));
+            static::assertSame(120000, $e->getRetryDelay());
+        }
+    }
+
+    public function testHandleResponseAddsRetryDelayFromRetryAfterDateHeader(): void
+    {
+        $retryAt = new \DateTimeImmutable('+2 minutes');
+        $response = new Response(
+            429,
+            ['Retry-After' => $retryAt->format(\DateTimeInterface::RFC7231)],
+            \json_encode([
+                'name' => 'RATE_LIMIT_REACHED',
+                'message' => 'Rate limit reached',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $requestService = new RequestService();
+
+        try {
+            $requestService->handleResponse($response);
+            static::fail('Expected PayPalApiException was not thrown.');
+        } catch (PayPalApiException $e) {
+            static::assertTrue($e->is(PayPalApiException::ERROR_CODE_RATE_LIMIT_REACHED));
+            static::assertNotNull($e->getRetryDelay());
+            static::assertGreaterThanOrEqual(110000, $e->getRetryDelay());
+            static::assertLessThanOrEqual(120000, $e->getRetryDelay());
+        }
+    }
+}


### PR DESCRIPTION
- fixes: https://github.com/shopware/shopware/issues/14491

**Problem**

PayPal shipping tracking sync can receive 429 rate-limit responses with a Retry-After header. Retrying immediately, or only using the default Messenger backoff, can exhaust retries too early and move otherwise recoverable shipping sync messages into the failure flow.

**Why this matters**

For bulk delivery updates, PayPal may explicitly tell us when the next retry should happen. The async shipping sync should respect that delay while still keeping the normal Messenger retry limit.

**Implementation**

The SDK-provided retry timestamp is now transferred onto PayPalApiException.

A dedicated retry strategy for the async transport adjusts the waiting time for ShippingInformationMessage when a PayPal retry delay is available.

The strategy decorates Symfony’s default multiplier retry strategy, so existing behavior such as max_retries, exponential backoff, and failure transport handling still applies.

RecoverableMessageHandlingException is not used because it bypasses the normal max-retry decision in some Messenger flows and is not consistently supported by all queue transports. Decorating the retry strategy lets us apply Retry-After only as the delay calculation while preserving Messenger’s regular retry lifecycle.