### PR TITLE
fix: correct broken Rufus

### DIFF
--- a/src/Pos/Api/Authentication/OAuthCredentials.php
+++ b/src/Pos/Api/Authentication/OAuthCredentials.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\Pos\Api\Authentication;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 
 #[Package('checkout')]
 class OAuthCredentials
@@ -22,5 +23,10 @@ class OAuthCredentials
     public function setApiKey(string $apiKey): void
     {
         $this->apiKey = $apiKey;
+    }
+
+    public function getCacheKey(): string
+    {
+        return Hasher::hash(['apiKey' => $this->apiKey]);
     }
 }

--- a/src/Pos/Resource/TokenResource.php
+++ b/src/Pos/Resource/TokenResource.php
@@ -9,7 +9,6 @@ namespace Swag\PayPal\Pos\Resource;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Hasher;
 use Swag\PayPal\Pos\Api\Authentication\OAuthCredentials;
 use Swag\PayPal\Pos\Api\Authentication\Token;
 use Swag\PayPal\Pos\Client\TokenClientFactory;
@@ -36,7 +35,7 @@ class TokenResource
 
     public function getToken(OAuthCredentials $credentials): Token
     {
-        $cacheId = Hasher::hash($credentials->getApiKey());
+        $cacheId = $credentials->getCacheKey();
         $token = $this->getTokenFromCache($cacheId);
         if ($token === null || !$this->isTokenValid($token)) {
             $tokenClient = $this->tokenClientFactory->createTokenClient();

--- a/tests/Pos/Resource/TokenResourceTest.php
+++ b/tests/Pos/Resource/TokenResourceTest.php
@@ -9,7 +9,6 @@ namespace Swag\PayPal\Test\Pos\Resource;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Hasher;
 use Swag\PayPal\Pos\Api\Authentication\OAuthCredentials;
 use Swag\PayPal\Pos\Resource\TokenResource;
 use Swag\PayPal\Test\Pos\ConstantsForTesting;
@@ -29,10 +28,11 @@ class TokenResourceTest extends TestCase
     {
         $cache = new ArrayAdapter();
         $resource = new TokenResource($cache, new TokenClientFactoryMock());
+        $credentials = $this->createCredentials();
 
-        $resource->getToken($this->createCredentials());
+        $resource->getToken($credentials);
 
-        $cacheKey = self::CACHE_ID . Hasher::hash(ConstantsForTesting::VALID_API_KEY);
+        $cacheKey = self::CACHE_ID . $credentials->getCacheKey();
         $raw = $cache->getItem($cacheKey)->get();
         static::assertIsString($raw);
 
@@ -73,7 +73,7 @@ class TokenResourceTest extends TestCase
 
         $resource->getToken($credentials);
 
-        $cacheKey = self::CACHE_ID . Hasher::hash(ConstantsForTesting::VALID_API_KEY);
+        $cacheKey = self::CACHE_ID . $credentials->getCacheKey();
         $item = $cache->getItem($cacheKey);
 
         $data = \json_decode($item->get(), true);


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, Rufus is broken due to this change:
[https://github.com/shopware/SwagPayPal/commit/c479a9d079aa53d1e8757ea15eedc4fa19a24d7f](https://github.com/shopware/SwagPayPal/commit/c479a9d079aa53d1e8757ea15eedc4fa19a24d7f)

The change also breaks the following parts in Rufus:
[https://github.com/shopware/Rufus/blob/trunk/src/Core/PayPal/Pos/Resource/SaasTokenResource.php#L34](https://github.com/shopware/Rufus/blob/trunk/src/Core/PayPal/Pos/Resource/SaasTokenResource.php#L34)
→ [https://github.com/shopware/Rufus/blob/trunk/src/Core/PayPal/Pos/Api/SaasOAuthCredentials.php#L35-L38](https://github.com/shopware/Rufus/blob/trunk/src/Core/PayPal/Pos/Api/SaasOAuthCredentials.php#L35-L38) 💥

It’s necessary because `TokenResource` was using `getApiKey()` just to build a cache key, but in Rufus that method is intentionally forbidden and throws an exception.

### 2. What does this change do, exactly?
It moves cache-key generation out of `TokenResource` and into `OAuthCredentials`.
So instead of `TokenResource` calling `getApiKey()` directly, it now asks the credentials for a safe `getCacheKey()`.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
