### PR TITLE
[6.6.x] fix: use subscription cart service for subscription route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 9.12.1
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)
+- Fixes an issue, where subscription PayPal order creation did not use the subscription cart service and ACDC was available for subscriptions without wallet vaulting
 
 # 9.12.0
 - Added setting to disable the shipping callback for express checkouts.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 9.12.1
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)
+- Behebt ein Problem, bei dem die PayPal-Bestellerstellung für Abonnements nicht den Subscription-Cart-Service verwendet hat und ACDC für Abonnements ohne Wallet-Vaulting verfügbar war
 
 # 9.12.0
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren

--- a/src/Checkout/SalesChannel/CreateOrderRoute.php
+++ b/src/Checkout/SalesChannel/CreateOrderRoute.php
@@ -57,6 +57,7 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         private readonly OrderResource $orderResource,
         private readonly LoggerInterface $logger,
         private readonly AbstractPaymentTransactionStructFactory $paymentTransactionStructFactory,
+        private readonly ?CartService $subscriptionCartService = null,
     ) {
     }
 
@@ -102,6 +103,8 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         try {
             $requestDataBag = new RequestDataBag($request->request->all());
             $requestDataBag->set(AbstractOrderBuilder::PRELIMINARY_ATTRIBUTE, true);
+            $requestDataBag->set('_subscriptionCart', $request->attributes->getBoolean('_subscriptionCart'));
+
             $this->logger->debug('Started', ['request' => $requestDataBag->all()]);
             $customer = $salesChannelContext->getCustomer();
             if ($customer === null) {
@@ -138,7 +141,17 @@ class CreateOrderRoute extends AbstractCreateOrderRoute
         SalesChannelContext $salesChannelContext,
         RequestDataBag $requestDataBag,
     ): Order {
-        $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
+        if ($requestDataBag->getBoolean('_subscriptionCart')) {
+            if ($this->subscriptionCartService === null) {
+                throw new \RuntimeException('Subscription cart service is not available');
+            }
+
+            $cartService = $this->subscriptionCartService;
+        } else {
+            $cartService = $this->cartService;
+        }
+
+        $cart = $cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
 
         return $orderBuilder->getOrderFromCart($cart, $salesChannelContext, $requestDataBag);
     }

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -45,6 +45,7 @@
             <argument type="service" id="Swag\PayPal\RestApi\V2\Resource\OrderResource"/>
             <argument type="service" id="monolog.logger.paypal"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStructFactory"/>
+            <argument type="service" id="subscription.cart.service" on-invalid="null"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute" public="true">

--- a/src/Util/Lifecycle/Method/ACDCMethodData.php
+++ b/src/Util/Lifecycle/Method/ACDCMethodData.php
@@ -63,6 +63,10 @@ class ACDCMethodData extends AbstractMethodData implements CheckoutDataMethodInt
 
     public function isAvailable(AvailabilityContext $availabilityContext): bool
     {
+        if ($availabilityContext->isSubscription()) {
+            return $this->container->get(SystemConfigService::class)->getBool(Settings::VAULTING_ENABLED_ACDC, $availabilityContext->getSalesChannelId());
+        }
+
         return true;
     }
 

--- a/tests/Checkout/SalesChannel/CreateOrderRouteCartServiceTest.php
+++ b/tests/Checkout/SalesChannel/CreateOrderRouteCartServiceTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStructFactory;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
+use Swag\PayPal\Checkout\SalesChannel\CreateOrderRoute;
+use Swag\PayPal\OrdersApi\Builder\ACDCOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\ApplePayOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\GooglePayOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder;
+use Swag\PayPal\OrdersApi\Builder\VenmoOrderBuilder;
+use Swag\PayPal\RestApi\V2\Api\Order;
+use Swag\PayPal\RestApi\V2\Resource\OrderResource;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('checkout'), CoversClass(CreateOrderRoute::class)]
+class CreateOrderRouteCartServiceTest extends TestCase
+{
+    public function testCreatePaymentUsesSubscriptionCartServiceForSubscriptionRequests(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+        $cart = new Cart($salesChannelContext->getToken());
+
+        $defaultCartService = $this->createMock(CartService::class);
+        $defaultCartService
+            ->expects(static::never())
+            ->method('getCart');
+
+        $subscriptionCartService = $this->createMock(CartService::class);
+        $subscriptionCartService
+            ->expects(static::once())
+            ->method('getCart')
+            ->with($salesChannelContext->getToken(), $salesChannelContext, true, true)
+            ->willReturn($cart);
+
+        $response = $this->createRoute($defaultCartService, $subscriptionCartService)->createPayPalOrder(
+            $salesChannelContext,
+            new Request([], [], ['_subscriptionCart' => true])
+        );
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame('paypal-order-id', $response->getToken());
+    }
+
+    public function testCreatePaymentThrowsExceptionWithoutSubscriptionCartService(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+
+        $defaultCartService = $this->createMock(CartService::class);
+        $defaultCartService
+            ->expects(static::never())
+            ->method('getCart');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Subscription cart service is not available');
+
+        $this->createRoute($defaultCartService, expectsOrderBuilderCall: false)->createPayPalOrder(
+            $salesChannelContext,
+            new Request([], [], ['_subscriptionCart' => true])
+        );
+    }
+
+    private function createRoute(
+        CartService $cartService,
+        ?CartService $subscriptionCartService = null,
+        bool $expectsOrderBuilderCall = true,
+    ): CreateOrderRoute {
+        $order = new Order();
+        $paypalOrder = new Order();
+        $paypalOrder->setId('paypal-order-id');
+
+        $payPalOrderBuilder = $this->getMockBuilder(PayPalOrderBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getOrderFromCart'])
+            ->getMock();
+        $payPalOrderBuilder
+            ->expects($expectsOrderBuilderCall ? static::once() : static::never())
+            ->method('getOrderFromCart')
+            ->with(static::isInstanceOf(Cart::class), static::isInstanceOf(SalesChannelContext::class), static::isInstanceOf(RequestDataBag::class))
+            ->willReturn($order);
+
+        $orderResource = $this->createMock(OrderResource::class);
+        $orderResource
+            ->expects($expectsOrderBuilderCall ? static::once() : static::never())
+            ->method('create')
+            ->with($order, static::anything(), static::anything())
+            ->willReturn($paypalOrder);
+
+        return new CreateOrderRoute(
+            $cartService,
+            $this->createMock(EntityRepository::class),
+            $payPalOrderBuilder,
+            $this->createMock(ACDCOrderBuilder::class),
+            $this->createMock(ApplePayOrderBuilder::class),
+            $this->createMock(GooglePayOrderBuilder::class),
+            $this->createMock(VenmoOrderBuilder::class),
+            $orderResource,
+            new NullLogger(),
+            new PaymentTransactionStructFactory(),
+            $subscriptionCartService,
+        );
+    }
+
+    private function createSalesChannelContext(): SalesChannelContext
+    {
+        $customer = (new CustomerEntity())->assign(['id' => 'customer-id']);
+
+        return Generator::createSalesChannelContext(
+            baseContext: Context::createDefaultContext(),
+            customer: $customer,
+            token: 'test-token',
+        );
+    }
+}

--- a/tests/Util/Lifecycle/Method/ACDCMethodDataTest.php
+++ b/tests/Util/Lifecycle/Method/ACDCMethodDataTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Util\Lifecycle\Method;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Setting\Settings;
+use Swag\PayPal\Util\Availability\AvailabilityContext;
+use Swag\PayPal\Util\Lifecycle\Method\ACDCMethodData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout'), CoversClass(ACDCMethodData::class)]
+class ACDCMethodDataTest extends TestCase
+{
+    private ACDCMethodData $acdcMethodData;
+
+    private MockObject&ContainerInterface $container;
+
+    private MockObject&SystemConfigService $systemConfigService;
+
+    protected function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+
+        $this->container
+            ->method('get')
+            ->with(SystemConfigService::class)
+            ->willReturn($this->systemConfigService);
+
+        $this->acdcMethodData = new ACDCMethodData($this->container);
+    }
+
+    public function testIsAvailableReturnsTrueForNonSubscription(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => false,
+        ]);
+
+        $this->systemConfigService
+            ->expects(static::never())
+            ->method('getBool');
+
+        static::assertTrue($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+
+    public function testIsAvailableUsesVaultACDCSettingForSubscriptions(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => true,
+        ]);
+
+        $this->systemConfigService
+            ->expects(static::once())
+            ->method('getBool')
+            ->with(Settings::VAULTING_ENABLED_ACDC, 'sales-channel-id')
+            ->willReturn(true);
+
+        static::assertTrue($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+
+    public function testIsAvailableReturnsFalseForSubscriptionsWithoutACDCVaulting(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => true,
+        ]);
+
+        $this->systemConfigService
+            ->expects(static::once())
+            ->method('getBool')
+            ->with(Settings::VAULTING_ENABLED_ACDC, 'sales-channel-id')
+            ->willReturn(false);
+
+        static::assertFalse($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+}


### PR DESCRIPTION
## Description
- fixes https://github.com/shopware/shopware/issues/16243

### Problem

Subscription create-order requests in SwagPayPal were still loading the default cart service. That means the subscription checkout flow could build the PayPal order from the wrong cart state instead of the subscription cart. In addition, ACDC remained available for subscription contexts even when ACDC vaulting was disabled, which is not suitable for recurring payments.
