### PR TITLE
fix: inventory stock deprecations

### DIFF
--- a/src/Pos/Sync/Inventory/Calculator/RemoteCalculator.php
+++ b/src/Pos/Sync/Inventory/Calculator/RemoteCalculator.php
@@ -13,6 +13,7 @@ use Swag\PayPal\Pos\Api\Inventory\BulkChanges\ProductChange;
 use Swag\PayPal\Pos\Api\Inventory\BulkChanges\ProductChange\VariantChange;
 use Swag\PayPal\Pos\Api\Service\Converter\UuidConverter;
 use Swag\PayPal\Pos\Sync\Context\InventoryContext;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 
 #[Package('checkout')]
 class RemoteCalculator
@@ -31,7 +32,7 @@ class RemoteCalculator
         ProductEntity $productEntity,
         InventoryContext $inventoryContext,
     ): ?ProductChange {
-        $currentStock = $productEntity->getAvailableStock();
+        $currentStock = ProductStockAccessor::get($productEntity);
         $previousStock = $inventoryContext->getLocalInventory($productEntity);
 
         $isTracked = $inventoryContext->isTracked($productEntity);
@@ -40,7 +41,7 @@ class RemoteCalculator
             $previousStock = $inventoryContext->getSingleRemoteInventory($productEntity, true);
         }
 
-        $difference = (int) $currentStock - (int) $previousStock;
+        $difference = $currentStock - (int) $previousStock;
 
         if ($difference === 0 && $isTracked) {
             return null;

--- a/src/Pos/Sync/Inventory/ProductStockAccessor.php
+++ b/src/Pos/Sync/Inventory/ProductStockAccessor.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Pos\Sync\Inventory;
+
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class ProductStockAccessor
+{
+    public static function get(ProductEntity $product): int
+    {
+        if (Feature::isActive('v6.8.0.0')) {
+            return $product->getStock();
+        }
+
+        /** @phpstan-ignore method.deprecated */
+        return (int) $product->getAvailableStock();
+    }
+
+    public static function set(ProductEntity $product, int $stock): void
+    {
+        if (Feature::isActive('v6.8.0.0')) {
+            $product->setStock($stock);
+
+            return;
+        }
+
+        /** @phpstan-ignore method.deprecated */
+        $product->setAvailableStock($stock);
+    }
+}

--- a/src/Pos/Sync/Inventory/RemoteUpdater.php
+++ b/src/Pos/Sync/Inventory/RemoteUpdater.php
@@ -54,7 +54,7 @@ class RemoteUpdater
 
             $remoteChanges->addProductChange($productChange);
 
-            $changeAmount = (int) $productEntity->getAvailableStock() - (int) $inventoryContext->getLocalInventory($productEntity);
+            $changeAmount = ProductStockAccessor::get($productEntity) - (int) $inventoryContext->getLocalInventory($productEntity);
             $productEntity->addExtension(StockChange::STOCK_CHANGE_EXTENSION, new StockChange($changeAmount));
 
             $changedProducts->add($productEntity);

--- a/tests/Pos/Mock/Repositories/ProductRepoMock.php
+++ b/tests/Pos/Mock/Repositories/ProductRepoMock.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 
 /**
  * @internal
@@ -35,7 +36,7 @@ class ProductRepoMock extends AbstractRepoMock
         $entity->setUniqueIdentifier($this->getUniqueIdentifier($entity));
         $entity->setName($name);
         $entity->setStock($stock);
-        $entity->setAvailableStock($availableStock);
+        ProductStockAccessor::set($entity, $availableStock);
         $this->entityCollection->add($entity);
 
         return $entity;

--- a/tests/Pos/Sync/Inventory/InventoryContextFactoryTest.php
+++ b/tests/Pos/Sync/Inventory/InventoryContextFactoryTest.php
@@ -19,6 +19,7 @@ use Swag\PayPal\Pos\Api\Inventory\Status\Variant;
 use Swag\PayPal\Pos\Api\Service\Converter\UuidConverter;
 use Swag\PayPal\Pos\Resource\InventoryResource;
 use Swag\PayPal\Pos\Sync\Context\InventoryContextFactory;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 use Swag\PayPal\Test\Pos\Mock\Repositories\PosInventoryRepoMock;
 
 /**
@@ -74,7 +75,7 @@ class InventoryContextFactoryTest extends TestCase
         $variant->assign([
             'productUuid' => $uuidConverter->convertUuidToV1((string) $product->getParentId()),
             'variantUuid' => $uuidConverter->convertUuidToV1($product->getId()),
-            'balance' => (string) $product->getAvailableStock(),
+            'balance' => (string) ProductStockAccessor::get($product),
         ]);
         $status->addVariant($variant);
         $status->assign(['trackedProducts' => [$uuidConverter->convertUuidToV1((string) $product->getParentId())]]);
@@ -83,7 +84,7 @@ class InventoryContextFactoryTest extends TestCase
 
         $inventoryContext = $this->inventoryContextFactory->getContext($this->salesChannel);
 
-        static::assertSame($product->getAvailableStock(), $inventoryContext->getSingleRemoteInventory($product));
+        static::assertSame(ProductStockAccessor::get($product), $inventoryContext->getSingleRemoteInventory($product));
     }
 
     public function testPosInventorySingle(): void
@@ -95,7 +96,7 @@ class InventoryContextFactoryTest extends TestCase
         $variant->assign([
             'productUuid' => $uuidConverter->convertUuidToV1($product->getId()),
             'variantUuid' => $uuidConverter->convertUuidToV1($uuidConverter->incrementUuid($product->getId())),
-            'balance' => (string) $product->getAvailableStock(),
+            'balance' => (string) ProductStockAccessor::get($product),
         ]);
         $status->addVariant($variant);
         $status->assign(['trackedProducts' => [$uuidConverter->convertUuidToV1($product->getId())]]);
@@ -104,7 +105,7 @@ class InventoryContextFactoryTest extends TestCase
 
         $inventoryContext = $this->inventoryContextFactory->getContext($this->salesChannel);
 
-        static::assertSame($product->getAvailableStock(), $inventoryContext->getSingleRemoteInventory($product));
+        static::assertSame(ProductStockAccessor::get($product), $inventoryContext->getSingleRemoteInventory($product));
     }
 
     public function testPosInventoryUntracked(): void
@@ -116,7 +117,7 @@ class InventoryContextFactoryTest extends TestCase
             [
                 'productUuid' => $uuidConverter->convertUuidToV1((string) $product->getParentId()),
                 'variantUuid' => $uuidConverter->convertUuidToV1($product->getId()),
-                'balance' => (string) $product->getAvailableStock(),
+                'balance' => (string) ProductStockAccessor::get($product),
             ],
         ]]);
 
@@ -130,15 +131,15 @@ class InventoryContextFactoryTest extends TestCase
     public function testLocalInventory(): void
     {
         $singleProduct = $this->getSingleProduct();
-        $this->inventoryRepository->createMockEntity($singleProduct, TestDefaults::SALES_CHANNEL, (int) $singleProduct->getAvailableStock());
+        $this->inventoryRepository->createMockEntity($singleProduct, TestDefaults::SALES_CHANNEL, ProductStockAccessor::get($singleProduct));
         $variantProduct = $this->getVariantProduct();
-        $this->inventoryRepository->createMockEntity($variantProduct, TestDefaults::SALES_CHANNEL, (int) $variantProduct->getAvailableStock() + 2);
+        $this->inventoryRepository->createMockEntity($variantProduct, TestDefaults::SALES_CHANNEL, ProductStockAccessor::get($variantProduct) + 2);
 
         $inventoryContext = $this->inventoryContextFactory->getContext($this->salesChannel);
         $this->inventoryContextFactory->updateLocal($inventoryContext);
 
-        static::assertSame($singleProduct->getAvailableStock(), $inventoryContext->getLocalInventory($singleProduct));
-        static::assertSame((int) $variantProduct->getAvailableStock() + 2, $inventoryContext->getLocalInventory($variantProduct));
+        static::assertSame(ProductStockAccessor::get($singleProduct), $inventoryContext->getLocalInventory($singleProduct));
+        static::assertSame(ProductStockAccessor::get($variantProduct) + 2, $inventoryContext->getLocalInventory($variantProduct));
     }
 
     public function testLocalInventoryEmpty(): void
@@ -156,9 +157,9 @@ class InventoryContextFactoryTest extends TestCase
         $inventoryContext = $this->inventoryContextFactory->getContext($this->salesChannel);
         static::assertNull($inventoryContext->getLocalInventory($singleProduct));
 
-        $this->inventoryRepository->createMockEntity($singleProduct, TestDefaults::SALES_CHANNEL, (int) $singleProduct->getAvailableStock());
+        $this->inventoryRepository->createMockEntity($singleProduct, TestDefaults::SALES_CHANNEL, ProductStockAccessor::get($singleProduct));
         $this->inventoryContextFactory->updateLocal($inventoryContext);
-        static::assertSame($singleProduct->getAvailableStock(), $inventoryContext->getLocalInventory($singleProduct));
+        static::assertSame(ProductStockAccessor::get($singleProduct), $inventoryContext->getLocalInventory($singleProduct));
     }
 
     private function getPosLocations(): array

--- a/tests/Pos/Sync/Inventory/InventoryTrait.php
+++ b/tests/Pos/Sync/Inventory/InventoryTrait.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Test\Pos\Sync\Inventory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 use Swag\PayPal\Test\Pos\Helper\SalesChannelTrait;
 
 /**
@@ -38,7 +39,7 @@ trait InventoryTrait
         $product->setVersionId('7c1da595-2b4c-4c25-afa7-8dcf5d3adca0');
         $product->setParentId('3f5fa7e700714b2082e6c63ab14206da');
         $product->setStock(1);
-        $product->setAvailableStock(1);
+        ProductStockAccessor::set($product, 1);
 
         return $product;
     }
@@ -49,7 +50,7 @@ trait InventoryTrait
         $product->setId('1846c887e4174fde9009d9d7d6eae238');
         $product->setVersionId('7c1da595-2b4c-4c25-afa7-8dcf5d3adca0');
         $product->setStock(3);
-        $product->setAvailableStock(2);
+        ProductStockAccessor::set($product, 2);
 
         return $product;
     }

--- a/tests/Pos/Sync/Inventory/RemoteUpdaterTest.php
+++ b/tests/Pos/Sync/Inventory/RemoteUpdaterTest.php
@@ -23,6 +23,7 @@ use Swag\PayPal\Pos\Api\Inventory\Status\Variant;
 use Swag\PayPal\Pos\Api\Service\Converter\UuidConverter;
 use Swag\PayPal\Pos\Resource\InventoryResource;
 use Swag\PayPal\Pos\Sync\Inventory\Calculator\RemoteCalculator;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 use Swag\PayPal\Pos\Sync\Inventory\RemoteUpdater;
 
 /**
@@ -54,7 +55,7 @@ class RemoteUpdaterTest extends TestCase
     public function testUpdateRemoteInventoryVariant(int $localInventory, int $newLocalInventory, int $change): void
     {
         $product = $this->getVariantProduct();
-        $product->setAvailableStock($newLocalInventory);
+        ProductStockAccessor::set($product, $newLocalInventory);
 
         $inventoryContext = $this->createInventoryContext($product, $localInventory, 0);
 
@@ -89,7 +90,7 @@ class RemoteUpdaterTest extends TestCase
     public function testUpdateRemoteInventorySingle(int $localInventory, int $newLocalInventory, int $change): void
     {
         $product = $this->getSingleProduct();
-        $product->setAvailableStock($newLocalInventory);
+        ProductStockAccessor::set($product, $newLocalInventory);
 
         $inventoryContext = $this->createInventoryContext($product, $localInventory, 0);
 
@@ -130,7 +131,7 @@ class RemoteUpdaterTest extends TestCase
     public function testUpdateRemoteInventoryWithError(): void
     {
         $product = $this->getSingleProduct();
-        $product->setAvailableStock(2);
+        ProductStockAccessor::set($product, 2);
 
         $inventoryContext = $this->createInventoryContext($product, 1, 0);
 

--- a/tests/Pos/Sync/Inventory/UpdaterTrait.php
+++ b/tests/Pos/Sync/Inventory/UpdaterTrait.php
@@ -18,6 +18,7 @@ use Swag\PayPal\Pos\Api\Service\Converter\UuidConverter;
 use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelInventoryCollection;
 use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelInventoryEntity;
 use Swag\PayPal\Pos\Sync\Context\InventoryContext;
+use Swag\PayPal\Pos\Sync\Inventory\ProductStockAccessor;
 
 /**
  * @internal
@@ -44,7 +45,7 @@ trait UpdaterTrait
         $product->setVersionId('7c1da595-2b4c-4c25-afa7-8dcf5d3adca0');
         $product->setChildCount(2);
         $product->setStock(1);
-        $product->setAvailableStock(1);
+        ProductStockAccessor::set($product, 1);
 
         return $product;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
This change fixes current broken pipeline and PHPStan errors caused by deprecations of inventory stock 

### 2. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
