### PR TITLE
fix: phpstan deprecations (POS inventory)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -104,6 +104,14 @@ parameters:
                 - src/Pos/DataAbstractionLayer
                 - src/Reporting/DataAbstractionLayer
 
+        - # 6.8 deprecation - POS inventory sync still relies on available stock semantics
+            identifier: method.deprecated
+            message: '#Call to deprecated method (getAvailableStock|setAvailableStock)\(\) of class .*ProductEntity#'
+            paths:
+                - src/Pos/Sync/Inventory
+                - tests/Pos/Mock/Repositories/ProductRepoMock.php
+                - tests/Pos/Sync/Inventory
+
         - # Shopware trunk classifies these plugin tests as non-Unit by namespace
             identifier: shopware.unexpectedTestCovers
 


### PR DESCRIPTION
## Summary
- ignore the Shopware 6.8 `ProductEntity::getAvailableStock()` / `setAvailableStock()` deprecations for POS inventory sync paths

## Root Cause
The feature branch needed a `phpstan.neon.dist` adjustment for POS inventory code that still relies on available stock semantics. Keeping that suppression bundled with the shipping callback work would leave the pipeline fix blocked on an unrelated feature PR.
