### PR TITLE
[6.6.x] fix: shipping callback payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)
+- Fixes an issue, where the express checkout shipping callback returned unsupported order fields.
 
 # 9.12.0
 - Added setting to disable the shipping callback for express checkouts.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)
+- Behebt ein Problem, bei dem die Antwort des Versand-Callbacks im Express Checkout nicht unterstützte Bestellfelder enthielt
 
 # 9.12.0
 - Fügt eine Einstellung hinzu, um den Versand-Callback für Express-Checkouts zu deaktivieren

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -60,8 +60,11 @@ class ExpressShippingCallbackService
             $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
         }
 
-        $order = $this->orderBuilder->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());
+        $fullOrder = $this->orderBuilder->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());
+        $order = new Order();
+        $order->unset('intent');
         $order->setId($callback->getId());
+        $order->setPurchaseUnits($fullOrder->getPurchaseUnits());
         $order->getPurchaseUnits()->first()?->setReferenceId((string) $callback->getPurchaseUnits()->first()?->getReferenceId());
         $order->getPurchaseUnits()->first()?->setShippingOptions($this->shippingOptionsProvider->getShippingOptions($cart, $salesChannelContext));
 

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressShippingCallbackRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressShippingCallbackRouteTest.php
@@ -19,6 +19,8 @@ use Swag\PayPal\Checkout\ExpressCheckout\ExpressShippingCallbackException;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressShippingCallbackRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService;
 use Swag\PayPal\RestApi\V2\Api\Order;
+use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit;
+use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnitCollection;
 use Swag\PayPal\RestApi\V2\Api\OrderShippingCallback;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -60,15 +62,25 @@ class ExpressShippingCallbackRouteTest extends TestCase
         $callback = (new OrderShippingCallback())->assign($payload);
         $request = new Request(request: $payload);
         $salesChannelContext = Generator::createSalesChannelContext();
+        $order = new Order();
+        $purchaseUnit = new PurchaseUnit();
+        $purchaseUnit->setReferenceId('default');
+        $order->unset('intent');
+        $order->setId('paypal-order-id');
+        $order->setPurchaseUnits(new PurchaseUnitCollection([$purchaseUnit]));
 
         $this->service
             ->expects(static::once())
             ->method('recalculateCart')
             ->with(static::equalTo($callback), $salesChannelContext)
-            ->willReturn(new Order());
+            ->willReturn($order);
 
         $response = $this->route->handleCallback($request, $salesChannelContext);
-        static::assertEquals(\json_encode(new Order()), $response->getContent());
+        $responsePayload = \json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        static::assertSame(['id', 'purchase_units'], \array_keys($responsePayload));
+        static::assertSame('paypal-order-id', $responsePayload['id']);
+        static::assertSame('default', $responsePayload['purchase_units'][0]['reference_id']);
 
         static::assertCount(1, $this->logger->getRecords());
         static::assertTrue($this->logger->hasDebug(['message' => 'Shipping callback received']));

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
@@ -96,7 +96,11 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
 
         $result = $service->recalculateCart($this->createCallback(), $salesChannelContext);
 
-        static::assertSame('paypal-order-id', $result->getId());
+        $serialized = \json_decode((string) \json_encode($result, \JSON_THROW_ON_ERROR), true, flags: \JSON_THROW_ON_ERROR);
+
+        static::assertSame(['id', 'purchase_units'], \array_keys($serialized));
+        static::assertSame('paypal-order-id', $serialized['id']);
+        static::assertSame('default', $serialized['purchase_units'][0]['reference_id']);
         static::assertCount(1, $result->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
     }
 

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTest.php
@@ -36,6 +36,7 @@ use Shopware\Core\Test\TestDefaults;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressShippingCallbackException;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService;
 use Swag\PayPal\RestApi\V2\Api\Common\Address;
+use Swag\PayPal\RestApi\V2\Api\Order;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnit\ShippingOption;
 use Swag\PayPal\RestApi\V2\Api\Order\PurchaseUnitCollection;
@@ -106,9 +107,8 @@ class ExpressShippingCallbackServiceTest extends TestCase
 
         $order = $this->service->recalculateCart($this->createCallback($country), $this->salesChannelContext);
 
-        static::assertSame('paypal-order-id', $order->getId());
-        static::assertSame('default', $order->getPurchaseUnits()->first()?->getReferenceId());
-        static::assertCount(2, $order->getPurchaseUnits()->first()->getShippingOptions() ?? []);
+        $this->assertMinimalOrderPayload($order);
+        static::assertCount(2, $order->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
         static::assertNotSame($cart, $this->getCart());
 
         $this->assertContextParameters([
@@ -127,9 +127,8 @@ class ExpressShippingCallbackServiceTest extends TestCase
 
         $order = $this->service->recalculateCart($this->createCallback($country), $this->salesChannelContext);
 
-        static::assertSame('paypal-order-id', $order->getId());
-        static::assertSame('default', $order->getPurchaseUnits()->first()?->getReferenceId());
-        static::assertCount(2, $order->getPurchaseUnits()->first()->getShippingOptions() ?? []);
+        $this->assertMinimalOrderPayload($order);
+        static::assertCount(2, $order->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
         static::assertNotSame($cart, $this->getCart());
 
         $this->assertContextParameters([
@@ -145,9 +144,8 @@ class ExpressShippingCallbackServiceTest extends TestCase
 
         $order = $this->service->recalculateCart($this->createCallback($country, $shippingMethod->getId()), $this->salesChannelContext);
 
-        static::assertSame('paypal-order-id', $order->getId());
-        static::assertSame('default', $order->getPurchaseUnits()->first()?->getReferenceId());
-        static::assertCount(2, $order->getPurchaseUnits()->first()->getShippingOptions() ?? []);
+        $this->assertMinimalOrderPayload($order);
+        static::assertCount(2, $order->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
         static::assertNotSame($cart, $this->getCart());
 
         $this->assertContextParameters([
@@ -161,9 +159,8 @@ class ExpressShippingCallbackServiceTest extends TestCase
         $country = $this->getCountry('DE');
         $order = $this->service->recalculateCart($this->createCallback($country), $this->salesChannelContext);
 
-        static::assertSame('paypal-order-id', $order->getId());
-        static::assertSame('default', $order->getPurchaseUnits()->first()?->getReferenceId());
-        static::assertCount(2, $order->getPurchaseUnits()->first()->getShippingOptions() ?? []);
+        $this->assertMinimalOrderPayload($order);
+        static::assertCount(2, $order->getPurchaseUnits()->first()?->getShippingOptions() ?? []);
         static::assertSame($cart, $this->getCart());
 
         $this->assertContextParameters([
@@ -226,6 +223,15 @@ class ExpressShippingCallbackServiceTest extends TestCase
         $params = static::getContainer()->get(SalesChannelContextPersister::class)->load($this->ids->get('token'), TestDefaults::SALES_CHANNEL);
 
         static::assertEquals($expectedParams, \array_intersect_key($expectedParams, $params));
+    }
+
+    private function assertMinimalOrderPayload(Order $order): void
+    {
+        $serialized = \json_decode((string) \json_encode($order, \JSON_THROW_ON_ERROR), true, flags: \JSON_THROW_ON_ERROR);
+
+        static::assertSame(['id', 'purchase_units'], \array_keys($serialized));
+        static::assertSame('paypal-order-id', $serialized['id']);
+        static::assertSame('default', $serialized['purchase_units'][0]['reference_id']);
     }
 
     private function createCallback(


### PR DESCRIPTION
### 1. Why is this change necessary?
PayPal Express checkout can fail with `SHIPPING_ADDRESS_CALLBACK_ERROR` because the shipping callback response contains unsupported order fields.

### 2. What does this change do, exactly?
It limits the shipping callback response to the supported `id` and `purchase_units` fields while preserving the recalculated shipping options and reference ID. The backport also carries the regression tests and changelog entries.

### 3. Describe each step to reproduce the issue or behaviour.
1. Start a PayPal Express checkout
2. Trigger the shipping callback, for example by changing the shipping address or shipping option in the PayPal flow
3. PayPal redirects to the generic error page instead of continuing the checkout

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/SwagPayPal/issues/634

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
