### PR TITLE
ci: drop run/acceptance label from Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,7 +16,6 @@ updates:
     labels:
       - 'dependencies'
       - 'javascript'
-      - 'run/acceptance'
 
   - package-ecosystem: npm
     directory: '/src/Resources/app/storefront'
@@ -31,7 +30,6 @@ updates:
     labels:
       - 'dependencies'
       - 'javascript'
-      - 'run/acceptance'
 
   - package-ecosystem: npm
     directory: '/tests/acceptance'
@@ -46,4 +44,3 @@ updates:
     labels:
       - 'dependencies'
       - 'javascript'
-      - 'run/acceptance'


### PR DESCRIPTION
## Summary

All currently open Dependabot PRs (#618, #619, #626, #627, #631, #642, #643) are stuck because their `check` summary job reports as failed. The common cause across all of them is the `acceptance` job:

- `.github/dependabot.yaml` applies the `run/acceptance` label to every Dependabot group.
- `.github/workflows/integration.yml` runs the playwright `acceptance` job whenever that label is present (or the trigger is not a pull request).
- The acceptance suite needs real PayPal sandbox credentials / the `acceptance-production` environment and is expensive and flaky for automated dependency bumps, so it consistently fails, which flips the required `check` job to failed.

The `check` job already declares `acceptance` as an allowed skip via `re-actors/alls-green` (`allowed-skips: '["acceptance"]'`). Removing the label from the Dependabot config is therefore enough: the `acceptance` job will be skipped for Dependabot PRs, `check` will turn green, and the PRs become mergeable.

Acceptance coverage for "real" code changes is unaffected — human-opened PRs can still be labeled `run/acceptance` manually when wanted.

Existing Dependabot PRs will need a rebase (`@dependabot rebase`) to pick up the new config and drop the label.

## Test plan

- [ ] Merge this PR
- [ ] Trigger `@dependabot rebase` on one of the open Dependabot PRs and confirm `acceptance` is skipped and `check` passes
- [ ] Repeat for the remaining Dependabot PRs and merge them

---
_Generated by [Claude Code](https://claude.ai/code/session_013b6Q5EdjR5XbU7PtNtf218)_