### PR TITLE
fix: ACDC isAvailable without vaulting flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.6.1
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)
 - Fixes an issue, where the express checkout shipping callback returned unsupported order fields.
+- Fixes an issue, where ACDC was available for subscriptions without wallet vaulting
 
 # 10.6.0
 - Added setting to disable the shipping callback for express checkouts.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.6.1
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)
 - Behebt ein Problem, bei dem die Antwort des Versand-Callbacks im Express Checkout nicht unterstützte Bestellfelder enthielt
+- Behebt ein Problem, bei dem ACDC für Abonnements ohne Wallet-Vaulting verfügbar war
 
 # 10.6.0
 - Behebt ein Problem, bei dem PayPal-Webhooks mit einem `custom_id`-Payload ohne `orderTransactionId` eine Warnung wegen eines undefinierten Array-Keys ausloesen konnten

--- a/src/Util/Lifecycle/Method/ACDCMethodData.php
+++ b/src/Util/Lifecycle/Method/ACDCMethodData.php
@@ -63,6 +63,10 @@ class ACDCMethodData extends AbstractMethodData implements CheckoutDataMethodInt
 
     public function isAvailable(AvailabilityContext $availabilityContext): bool
     {
+        if ($availabilityContext->isSubscription()) {
+            return $this->container->get(SystemConfigService::class)->getBool(Settings::VAULTING_ENABLED_ACDC, $availabilityContext->getSalesChannelId());
+        }
+
         return true;
     }
 

--- a/tests/Util/Lifecycle/Method/ACDCMethodDataTest.php
+++ b/tests/Util/Lifecycle/Method/ACDCMethodDataTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Util\Lifecycle\Method;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Setting\Settings;
+use Swag\PayPal\Util\Availability\AvailabilityContext;
+use Swag\PayPal\Util\Lifecycle\Method\ACDCMethodData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout'), CoversClass(ACDCMethodData::class)]
+class ACDCMethodDataTest extends TestCase
+{
+    private ACDCMethodData $acdcMethodData;
+
+    private MockObject&ContainerInterface $container;
+
+    private MockObject&SystemConfigService $systemConfigService;
+
+    protected function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+
+        $this->container
+            ->method('get')
+            ->with(SystemConfigService::class)
+            ->willReturn($this->systemConfigService);
+
+        $this->acdcMethodData = new ACDCMethodData($this->container);
+    }
+
+    public function testIsAvailableReturnsTrueForNonSubscription(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => false,
+        ]);
+
+        $this->systemConfigService
+            ->expects($this->never())
+            ->method('getBool');
+
+        static::assertTrue($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+
+    public function testIsAvailableUsesVaultACDCSettingForSubscriptions(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => true,
+        ]);
+
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->with(Settings::VAULTING_ENABLED_ACDC, 'sales-channel-id')
+            ->willReturn(true);
+
+        static::assertTrue($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+
+    public function testIsAvailableReturnsFalseForSubscriptionsWithoutACDCVaulting(): void
+    {
+        $availabilityContext = new AvailabilityContext();
+        $availabilityContext->assign([
+            'salesChannelId' => 'sales-channel-id',
+            'subscription' => true,
+        ]);
+
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->with(Settings::VAULTING_ENABLED_ACDC, 'sales-channel-id')
+            ->willReturn(false);
+
+        static::assertFalse($this->acdcMethodData->isAvailable($availabilityContext));
+    }
+}


### PR DESCRIPTION
- trunk PR from: https://github.com/shopware/SwagPayPal/pull/636
- fixes https://github.com/shopware/shopware/issues/16243

For trunk `SubscriptionDiscountProcessor` has already bot tags
- 'shopware.cart.processor'
- 'subscription.cart.processor'