### PR TITLE
fix: PayPal Express rule-based shipping methods not switched on country changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.6.2
+- Fixes an issue, where the Express Checkout failed when the buyer changed the delivery country to one with rule-restricted shipping methods (shopware/shopware#16295).
+
 # 10.6.1
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)
 - Fixes an issue, where the express checkout shipping callback returned unsupported order fields.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.6.2
+- Behebt ein Problem, bei dem der Express Checkout fehlschlug, wenn der Käufer das Lieferland zu einem mit regelbasierten Versandarten änderte (shopware/shopware#16295).
+
 # 10.6.1
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)
 - Behebt ein Problem, bei dem die Antwort des Versand-Callbacks im Express Checkout nicht unterstützte Bestellfelder enthielt

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.6.1",
+    "version": "10.6.2",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,6 +115,24 @@ parameters:
 			path: src/Setting/SettingsController.php
 
 		-
+			message: '#^Call to method switch\(\) of internal class Shopware\\Storefront\\Checkout\\Shipping\\BlockedShippingMethodSwitcher from outside its root namespace Shopware\.$#'
+			identifier: method.internalClass
+			count: 1
+			path: src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+
+		-
+			message: '#^Parameter \$blockedShippingMethodSwitcher of method Swag\\PayPal\\Checkout\\ExpressCheckout\\Service\\ExpressShippingCallbackService\:\:__construct\(\) has typehint with internal class Shopware\\Storefront\\Checkout\\Shipping\\BlockedShippingMethodSwitcher\.$#'
+			identifier: parameter.internalClass
+			count: 1
+			path: src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+
+		-
+			message: '#^Property \$blockedShippingMethodSwitcher references internal class Shopware\\Storefront\\Checkout\\Shipping\\BlockedShippingMethodSwitcher in its type\.$#'
+			identifier: property.internalClass
+			count: 1
+			path: src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+
+		-
 			message: '#^Mixed variable in a `\$checkoutMethod\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
 			identifier: typePerfect.noMixedMethodCaller
 			count: 2

--- a/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
@@ -159,16 +159,16 @@ class ExpressCustomerService
             throw new MissingPayloadException($order->getId(), 'paymentSource.paypal');
         }
 
+        $firstName = $paypal->getName()->getGivenName();
+        $lastName = $paypal->getName()->getSurname();
+        $address = $paypal->getAddress();
+
         $shipping = $order->getPurchaseUnits()->first()?->getShipping();
-        if ($shipping) {
+        if ($shipping !== null) {
             $address = $shipping->getAddress();
             $names = \explode(' ', $shipping->getName()->getFullName());
             $lastName = \array_pop($names);
             $firstName = \implode(' ', $names);
-        } else {
-            $address = $paypal->getAddress();
-            $firstName = $paypal->getName()->getGivenName();
-            $lastName = $paypal->getName()->getSurname();
         }
 
         $countryCode = $address->getCountryCode();

--- a/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressShippingCallbackService.php
@@ -23,6 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Shopware\PayPalSDK\Struct\V2\OrderShippingCallback;
+use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressShippingCallbackException;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
@@ -42,6 +43,7 @@ class ExpressShippingCallbackService
         private readonly ShippingOptionsProvider $shippingOptionsProvider,
         private readonly AbstractContextSwitchRoute $contextSwitchRoute,
         private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
+        private readonly BlockedShippingMethodSwitcher $blockedShippingMethodSwitcher,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -60,15 +62,25 @@ class ExpressShippingCallbackService
             $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
         }
 
+        $replacement = $this->blockedShippingMethodSwitcher->switch($cart->getErrors(), $salesChannelContext);
+        if ($replacement->getId() !== $salesChannelContext->getShippingMethod()->getId()) {
+            $this->logger->debug('Shipping callback: selected shipping method blocked, switching to alternative', ['shippingMethodId' => $replacement->getId()]);
+            $salesChannelContext = clone $salesChannelContext;
+            $salesChannelContext->assign(['shippingMethod' => $replacement]);
+            $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, false, true);
+        }
+
+        $shippingOptions = $this->shippingOptionsProvider->getShippingOptions($cart, $salesChannelContext);
+
         $fullOrder = $this->orderBuilder->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());
         $order = new Order();
         $order->unset('intent');
         $order->setId($callback->getId());
         $order->setPurchaseUnits($fullOrder->getPurchaseUnits());
         $order->getPurchaseUnits()->first()?->setReferenceId((string) $callback->getPurchaseUnits()->first()?->getReferenceId());
-        $order->getPurchaseUnits()->first()?->setShippingOptions($this->shippingOptionsProvider->getShippingOptions($cart, $salesChannelContext));
+        $order->getPurchaseUnits()->first()?->setShippingOptions($shippingOptions);
 
-        if ((int) $order->getPurchaseUnits()->first()?->getShippingOptions()?->count() === 0) {
+        if ($shippingOptions->count() === 0) {
             $this->logger->debug('Shipping callback: no shipping methods available', ['order' => $order]);
             throw ExpressShippingCallbackException::addressError($callback);
         }

--- a/src/Resources/config/services/express_checkout.xml
+++ b/src/Resources/config/services/express_checkout.xml
@@ -52,6 +52,7 @@
             <argument type="service" id="Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
+            <argument type="service" id="Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher"/>
             <argument type="service" id="monolog.logger.paypal"/>
         </service>
 

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
@@ -40,6 +40,7 @@ use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\ShippingOption;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\ShippingOptionCollection;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnitCollection;
 use Shopware\PayPalSDK\Struct\V2\OrderShippingCallback;
+use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
@@ -84,6 +85,11 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
             ->with($cart, $salesChannelContext)
             ->willReturn(new ShippingOptionCollection([$shippingOption]));
 
+        $blockedShippingMethodSwitcher = $this->createMock(BlockedShippingMethodSwitcher::class);
+        $blockedShippingMethodSwitcher
+            ->method('switch')
+            ->willReturn($salesChannelContext->getShippingMethod());
+
         $service = new ExpressShippingCallbackService(
             $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
             $this->createMock(SalesChannelRepository::class),
@@ -91,6 +97,7 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
             $shippingOptionsProvider,
             $this->createMock(AbstractContextSwitchRoute::class),
             $this->createMock(AbstractSalesChannelContextFactory::class),
+            $blockedShippingMethodSwitcher,
             new NullLogger(),
         );
 

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTest.php
@@ -166,19 +166,26 @@ class ExpressShippingCallbackServiceTest extends TestCase
         ]);
     }
 
-    public function testCalculationThrowsMethodNotAvailable(): void
+    public function testCalculationSwitchesToFirstAvailableWhenSelectedShippingMethodIsBlocked(): void
     {
-        $shippingMethod = $this->getShippingMethod('shipping_express');
+        $blocked = $this->getShippingMethod('shipping_express');
         static::getContainer()->get('shipping_method.repository')->update([[
-            'id' => $shippingMethod->getId(),
+            'id' => $blocked->getId(),
             'availabilityRule' => self::BLOCK_AVAILABLITITY_RULE,
         ]], $this->salesChannelContext->getContext());
 
-        static::expectException(ExpressShippingCallbackException::class);
-        static::expectExceptionMessage('Shipping method "Express" not available');
-
         $country = $this->getCountry('DE');
-        $this->service->recalculateCart($this->createCallback($country, $shippingMethod->getId()), $this->salesChannelContext);
+        $order = $this->service->recalculateCart($this->createCallback($country, $blocked->getId()), $this->salesChannelContext);
+
+        $this->assertMinimalOrderPayload($order);
+
+        $shippingOptions = $order->getPurchaseUnits()->first()?->getShippingOptions();
+        static::assertNotNull($shippingOptions);
+        static::assertGreaterThan(0, $shippingOptions->count());
+
+        $selected = $shippingOptions->filter(static fn (ShippingOption $option) => $option->isSelected())->first();
+        static::assertNotNull($selected, 'Auto-switched shipping method should be marked as selected');
+        static::assertNotSame($blocked->getId(), $selected->getId(), 'Blocked shipping method must not be re-selected');
     }
 
     public function testCalculationThrowsAddressError(): void


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


When the buyer changes the delivery country in the PayPal Express popup, the shipping callback switched the sales channel context to the new country but kept the previously selected shipping method ID. If that method was restricted by a country rule, the cart picked up a ShippingMethodBlockedError and the callback hard-failed with `EXPRESS_SHIPPING_CALLBACK_METHOD_UNAVAILABLE` -  even when another shipping method was available for the new country

### 2. What does this change do, exactly?

After the context switch, if the cart now has a ShippingMethodBlockedError and ShippingOptionsProvider returns an available alternative, switch the context to the first available method and recalculate the cart so PayPal sees a valid selection

Also guard ExpressCustomerService::getAddressData against Shipping::$name being uninitialized — PayPal occasionally returns a Shipping struct without a name (e.g., in local-development mode), which caused a TypeError on the typed property access


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- relates https://github.com/shopware/shopware/issues/16295
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
