### PR TITLE
fix: restore fallback snippets with translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Fixes an issue, where German and English storefront snippets were missing when translations for other locales were installed (shopware/SwagPayPal#662)
+- Fixes an issue, where bundled storefront snippets were missing when translations for other locales were installed (shopware/SwagPayPal#662)
 
 # 10.6.1
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where German and English storefront snippets were missing when translations for other locales were installed (shopware/SwagPayPal#662)
+
 # 10.6.1
 - Fixes an issue, where declined PayPal payments were still shown as refundable in the Administration (shopware/SwagPayPal#547)
 - Fixes an issue, where the express checkout shipping callback returned unsupported order fields.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,5 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
-- Behebt ein Problem, bei dem deutsche und englische Storefront-Snippets fehlten, wenn Übersetzungen für andere Sprachen installiert waren (shopware/SwagPayPal#662)
+- Behebt ein Problem, bei dem mitgelieferte Storefront-Snippets fehlten, wenn Übersetzungen für andere Sprachen installiert waren (shopware/SwagPayPal#662)
 
 # 10.6.1
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem deutsche und englische Storefront-Snippets fehlten, wenn Übersetzungen für andere Sprachen installiert waren (shopware/SwagPayPal#662)
+
 # 10.6.1
 - Behebt ein Problem, bei dem abgelehnte PayPal-Zahlungen in der Administration weiterhin als erstattungsfähig angezeigt wurden (shopware/SwagPayPal#547)
 - Behebt ein Problem, bei dem die Antwort des Versand-Callbacks im Express Checkout nicht unterstützte Bestellfelder enthielt

--- a/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
+++ b/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
@@ -29,17 +29,6 @@ class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
         'de' => 'de-DE',
     ];
 
-    private const DEFAULT_SNIPPETS = [
-        'en-GB' => [
-            'name' => 'paypal.en',
-            'file' => 'paypal.en.json',
-        ],
-        'de-DE' => [
-            'name' => 'paypal.de',
-            'file' => 'paypal.de.json',
-        ],
-    ];
-
     public function __construct(
         private readonly SnippetFileLoaderInterface $inner,
     ) {
@@ -68,20 +57,53 @@ class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
             return;
         }
 
-        foreach (self::DEFAULT_SNIPPETS as $iso => $snippet) {
+        foreach ($this->getBundledPayPalSnippetFiles() as $iso => $snippet) {
             if ($this->hasPayPalSnippetForIso($snippetFileCollection, $iso)) {
                 continue;
             }
 
             $snippetFileCollection->add(new GenericSnippetFile(
                 $snippet['name'],
-                __DIR__ . '/../../../Resources/snippet/' . $snippet['file'],
+                $snippet['path'],
                 $iso,
                 'shopware AG',
                 false,
                 self::PLUGIN_NAME,
             ));
         }
+    }
+
+    /**
+     * @return array<string, array{name: string, path: string}>
+     */
+    private function getBundledPayPalSnippetFiles(): array
+    {
+        $snippetFiles = [];
+        $paths = \glob($this->getSnippetDirectory() . '/paypal.*.json') ?: [];
+
+        \sort($paths);
+
+        foreach ($paths as $path) {
+            $name = \basename($path, '.json');
+            $nameParts = \explode('.', $name);
+
+            if (\count($nameParts) !== 2) {
+                continue;
+            }
+
+            $iso = self::ISO_MAP[$nameParts[1]] ?? $nameParts[1];
+            $snippetFiles[$iso] = [
+                'name' => $name,
+                'path' => $path,
+            ];
+        }
+
+        return $snippetFiles;
+    }
+
+    private function getSnippetDirectory(): string
+    {
+        return \dirname(__DIR__, 3) . '/Resources/snippet';
     }
 
     private function hasPayPalTranslationSnippet(SnippetFileCollection $snippetFileCollection): bool
@@ -120,6 +142,7 @@ class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
     {
         $path = \str_replace('\\', '/', $snippetFile->getPath());
 
+        // Shopware translation files are stored by plugin, e.g. translations/de-DE/Plugins/SwagPayPal/Storefront.
         return $snippetFile->getTechnicalName() === self::TRANSLATION_TECHNICAL_NAME
             && \str_contains($path, '/Plugins/' . self::PLUGIN_NAME . '/');
     }

--- a/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
+++ b/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\Storefront\Framework\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Files\AbstractSnippetFile;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Files\SnippetFileLoaderInterface;
@@ -20,9 +21,23 @@ use Shopware\Core\System\Snippet\Files\SnippetFileLoaderInterface;
 #[Package('checkout')]
 class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
 {
+    private const PLUGIN_NAME = 'SwagPayPal';
+    private const TRANSLATION_TECHNICAL_NAME = 'Plugins';
+
     private const ISO_MAP = [
         'en' => 'en-GB',
         'de' => 'de-DE',
+    ];
+
+    private const DEFAULT_SNIPPETS = [
+        'en-GB' => [
+            'name' => 'paypal.en',
+            'file' => 'paypal.en.json',
+        ],
+        'de-DE' => [
+            'name' => 'paypal.de',
+            'file' => 'paypal.de.json',
+        ],
     ];
 
     public function __construct(
@@ -48,5 +63,64 @@ class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
                 $snippetFile->getTechnicalName(),
             ));
         }
+
+        if (!$this->hasPayPalTranslationSnippet($snippetFileCollection)) {
+            return;
+        }
+
+        foreach (self::DEFAULT_SNIPPETS as $iso => $snippet) {
+            if ($this->hasPayPalSnippetForIso($snippetFileCollection, $iso)) {
+                continue;
+            }
+
+            $snippetFileCollection->add(new GenericSnippetFile(
+                $snippet['name'],
+                __DIR__ . '/../../../Resources/snippet/' . $snippet['file'],
+                $iso,
+                'shopware AG',
+                false,
+                self::PLUGIN_NAME,
+            ));
+        }
+    }
+
+    private function hasPayPalTranslationSnippet(SnippetFileCollection $snippetFileCollection): bool
+    {
+        foreach ($snippetFileCollection as $snippetFile) {
+            if ($this->isPayPalTranslationSnippet($snippetFile)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasPayPalSnippetForIso(SnippetFileCollection $snippetFileCollection, string $iso): bool
+    {
+        foreach ($snippetFileCollection as $snippetFile) {
+            if ($snippetFile->getIso() !== $iso) {
+                continue;
+            }
+
+            if ($this->isPayPalBundledSnippet($snippetFile) || $this->isPayPalTranslationSnippet($snippetFile)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPayPalBundledSnippet(AbstractSnippetFile $snippetFile): bool
+    {
+        return $snippetFile->getTechnicalName() === self::PLUGIN_NAME
+            && \str_starts_with($snippetFile->getName(), 'paypal.');
+    }
+
+    private function isPayPalTranslationSnippet(AbstractSnippetFile $snippetFile): bool
+    {
+        $path = \str_replace('\\', '/', $snippetFile->getPath());
+
+        return $snippetFile->getTechnicalName() === self::TRANSLATION_TECHNICAL_NAME
+            && \str_contains($path, '/Plugins/' . self::PLUGIN_NAME . '/');
     }
 }

--- a/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
+++ b/src/Storefront/Framework/Snippet/SnippetFileLoaderDecorator.php
@@ -12,6 +12,7 @@ use Shopware\Core\System\Snippet\Files\AbstractSnippetFile;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Files\SnippetFileLoaderInterface;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @deprecated tag:v11.0.0 - Will be removed without replacement if minimum version is >=6.7.3.0
@@ -79,11 +80,15 @@ class SnippetFileLoaderDecorator implements SnippetFileLoaderInterface
     private function getBundledPayPalSnippetFiles(): array
     {
         $snippetFiles = [];
-        $paths = \glob($this->getSnippetDirectory() . '/paypal.*.json') ?: [];
+        $finder = new Finder();
+        $finder->files()
+            ->in($this->getSnippetDirectory())
+            ->name('paypal.*.json')
+            ->depth('== 0')
+            ->sortByName();
 
-        \sort($paths);
-
-        foreach ($paths as $path) {
+        foreach ($finder as $file) {
+            $path = $file->getPathname();
             $name = \basename($path, '.json');
             $nameParts = \explode('.', $name);
 

--- a/tests/Storefront/Snippet/SnippetFileLoaderDecoratorTest.php
+++ b/tests/Storefront/Snippet/SnippetFileLoaderDecoratorTest.php
@@ -93,6 +93,76 @@ class SnippetFileLoaderDecoratorTest extends TestCase
         static::assertEquals($expected, $collection);
     }
 
+    public function testAddsDefaultSnippetsIfOnlyUnrelatedLocaleTranslationExists(): void
+    {
+        $collection = new SnippetFileCollection([
+            new GenericSnippetFile(
+                'storefront',
+                'translation/locale/fr-FR/Plugins/SwagPayPal/storefront.json',
+                'fr-FR',
+                'Shopware',
+                false,
+                'Plugins',
+            ),
+        ]);
+
+        $this->inner
+            ->expects($this->once())
+            ->method('loadSnippetFilesIntoCollection')
+            ->with($collection);
+
+        $this->decorator->loadSnippetFilesIntoCollection($collection);
+
+        $enFiles = $collection->getSnippetFilesByIso('en-GB');
+        $deFiles = $collection->getSnippetFilesByIso('de-DE');
+
+        static::assertCount(1, $enFiles);
+        static::assertCount(1, $deFiles);
+        static::assertSame('paypal.en', $enFiles[0]->getName());
+        static::assertSame('paypal.de', $deFiles[0]->getName());
+        static::assertSame('SwagPayPal', $enFiles[0]->getTechnicalName());
+        static::assertSame('SwagPayPal', $deFiles[0]->getTechnicalName());
+    }
+
+    public function testDoesNotAddDefaultSnippetIfSameLocaleTranslationExists(): void
+    {
+        $collection = new SnippetFileCollection([
+            new GenericSnippetFile(
+                'storefront',
+                'translation/locale/fr-FR/Plugins/SwagPayPal/storefront.json',
+                'fr-FR',
+                'Shopware',
+                false,
+                'Plugins',
+            ),
+            new GenericSnippetFile(
+                'storefront',
+                'translation/locale/de-DE/Plugins/SwagPayPal/storefront.json',
+                'de-DE',
+                'Shopware',
+                false,
+                'Plugins',
+            ),
+        ]);
+
+        $this->inner
+            ->expects($this->once())
+            ->method('loadSnippetFilesIntoCollection')
+            ->with($collection);
+
+        $this->decorator->loadSnippetFilesIntoCollection($collection);
+
+        $enFiles = $collection->getSnippetFilesByIso('en-GB');
+        $deFiles = $collection->getSnippetFilesByIso('de-DE');
+
+        static::assertCount(1, $enFiles);
+        static::assertCount(1, $deFiles);
+        static::assertSame('paypal.en', $enFiles[0]->getName());
+        static::assertSame('SwagPayPal', $enFiles[0]->getTechnicalName());
+        static::assertSame('storefront', $deFiles[0]->getName());
+        static::assertSame('Plugins', $deFiles[0]->getTechnicalName());
+    }
+
     public static function dataProviderNonMatchingSnippetFiles(): \Generator
     {
         yield 'wrong technical name' => [new GenericSnippetFile(


### PR DESCRIPTION
### 1. Why is this change necessary?
Please see https://github.com/shopware/SwagPayPal/issues/662

### 2. What does this change do, exactly?
Ensures bundled DE and EN storefront snippets are still registered when Shopware translations for another locale are installed.

### 3. Describe each step to reproduce the issue or behaviour.
- Use the paypal plugin and configure embedded credit card form in checkout
- use another language through the translation-feature like for example french
- go to the checkout in French --> field names are translated correctly
- go to the checkout in German/English --> field names are technical translation strings

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/SwagPayPal/issues/662

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
