### PR TITLE
feat: Filter agentic sales channel type

### DIFF
--- a/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/index.ts
+++ b/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/index.ts
@@ -1,14 +1,47 @@
 import template from './sw-sales-channel-modal-grid.html.twig';
 import './sw-sales-channel-modal-grid.scss';
-import { PAYPAL_POS_SALES_CHANNEL_TYPE_ID } from '../../../constant/swag-paypal.constant';
+import {
+    PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID,
+    PAYPAL_POS_SALES_CHANNEL_TYPE_ID,
+} from '../../../constant/swag-paypal.constant';
 
-// salesChannelTypes is from extended component - fake the existence of salesChannelTypes
-export default Shopware.Component.wrapComponentConfig<{ salesChannelTypes: TEntityCollection<'sales_channel_type'> }>({
+const { Criteria } = Shopware.Data;
+const { Defaults } = Shopware;
+
+type SalesChannelSearchContext = Parameters<TRepository<'sales_channel'>['searchIds']>[1];
+type SalesChannelTypeSearchContext = Parameters<TRepository<'sales_channel_type'>['search']>[1];
+
+type SalesChannelModalGrid = {
+    $super: (name: string) => unknown;
+    repositoryFactory: {
+        create: (entityName: 'sales_channel') => TRepository<'sales_channel'>;
+    };
+    salesChannelRepository: TRepository<'sales_channel'>;
+    salesChannelTypeRepository: TRepository<'sales_channel_type'>;
+    salesChannelTypes: TEntityCollection<'sales_channel_type'>;
+    hasUsDefaultCountryStorefrontSalesChannel: (context?: SalesChannelSearchContext) => Promise<boolean>;
+    usDefaultCountryStorefrontCriteria: () => TCriteria;
+    withPayPalAgenticCommerceFilter: (
+        repository: TRepository<'sales_channel_type'>,
+    ) => TRepository<'sales_channel_type'>;
+};
+
+export default Shopware.Component.wrapComponentConfig<SalesChannelModalGrid>({
     template,
 
     computed: {
         assetFilter() {
             return Shopware.Filter.getByName('asset');
+        },
+
+        salesChannelTypeRepository(): TRepository<'sales_channel_type'> {
+            const repository = this.$super('salesChannelTypeRepository') as TRepository<'sales_channel_type'>;
+
+            return this.withPayPalAgenticCommerceFilter(repository);
+        },
+
+        salesChannelRepository(): TRepository<'sales_channel'> {
+            return this.repositoryFactory.create('sales_channel');
         },
     },
 
@@ -17,6 +50,47 @@ export default Shopware.Component.wrapComponentConfig<{ salesChannelTypes: TEnti
             const salesChannelType = this.salesChannelTypes.find(type => type.id === salesChannelTypeId);
 
             return salesChannelType?.id === PAYPAL_POS_SALES_CHANNEL_TYPE_ID;
+        },
+
+        usDefaultCountryStorefrontCriteria(): TCriteria {
+            const criteria = new Criteria(1, 1);
+
+            criteria.addFilter(Criteria.equals('typeId', Defaults.storefrontSalesChannelTypeId));
+            criteria.addFilter(Criteria.equals('country.iso3', 'USA'));
+
+            return criteria;
+        },
+
+        async hasUsDefaultCountryStorefrontSalesChannel(context?: SalesChannelSearchContext): Promise<boolean> {
+            const usDefaultCountryStorefrontSalesChannels = await this.salesChannelRepository.searchIds(
+                this.usDefaultCountryStorefrontCriteria(),
+                context,
+            );
+
+            return usDefaultCountryStorefrontSalesChannels.total > 0;
+        },
+
+        withPayPalAgenticCommerceFilter(
+            repository: TRepository<'sales_channel_type'>,
+        ): TRepository<'sales_channel_type'> {
+            const filteredRepository = Object.create(repository) as TRepository<'sales_channel_type'>;
+
+            filteredRepository.search = async (criteria: TCriteria, context?: SalesChannelTypeSearchContext) => {
+                if (await this.hasUsDefaultCountryStorefrontSalesChannel(context)) {
+                    return repository.search(criteria, context);
+                }
+
+                const filteredCriteria = Criteria.fromCriteria(criteria);
+
+                // If no US sales channel exists, we will filter the agentic type
+                filteredCriteria.addFilter(Criteria.not('AND', [
+                    Criteria.equals('id', PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID),
+                ]));
+
+                return repository.search(filteredCriteria, context);
+            };
+
+            return filteredRepository;
         },
     },
 });

--- a/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/index.ts
+++ b/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/index.ts
@@ -73,11 +73,15 @@ export default Shopware.Component.wrapComponentConfig<SalesChannelModalGrid>({
         withPayPalAgenticCommerceFilter(
             repository: TRepository<'sales_channel_type'>,
         ): TRepository<'sales_channel_type'> {
-            const filteredRepository = Object.create(repository) as TRepository<'sales_channel_type'>;
+            const original = repository.search.bind(repository);
 
-            filteredRepository.search = async (criteria: TCriteria, context?: SalesChannelTypeSearchContext) => {
+            repository.search = async (
+                criteria: TCriteria,
+                context?: SalesChannelTypeSearchContext,
+                ...args: []
+            ) => {
                 if (await this.hasUsDefaultCountryStorefrontSalesChannel(context)) {
-                    return repository.search(criteria, context);
+                    return original(criteria, context, ...args);
                 }
 
                 const filteredCriteria = Criteria.fromCriteria(criteria);
@@ -87,10 +91,10 @@ export default Shopware.Component.wrapComponentConfig<SalesChannelModalGrid>({
                     Criteria.equals('id', PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID),
                 ]));
 
-                return repository.search(filteredCriteria, context);
+                return original(filteredCriteria, context, ...args);
             };
 
-            return filteredRepository;
+            return repository;
         },
     },
 });

--- a/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.ts
+++ b/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.ts
@@ -1,0 +1,125 @@
+import EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
+import SwSalesChannelModalGridExtension from '.';
+import { PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID } from '../../../constant/swag-paypal.constant';
+
+const { Criteria } = Shopware.Data;
+
+type SalesChannelModalGridTestContext = {
+    $super: jest.Mock;
+    salesChannelRepository: Pick<TRepository<'sales_channel'>, 'searchIds'>;
+    usDefaultCountryStorefrontCriteria: () => TCriteria;
+    hasUsDefaultCountryStorefrontSalesChannel: (context?: Parameters<TRepository<'sales_channel'>['searchIds']>[1]) => Promise<boolean>;
+    withPayPalAgenticCommerceFilter: (
+        repository: TRepository<'sales_channel_type'>,
+    ) => TRepository<'sales_channel_type'>;
+};
+
+type SalesChannelModalGridMethods = Omit<SalesChannelModalGridTestContext, '$super' | 'salesChannelRepository'>;
+
+type SalesChannelModalGridComputed = {
+    salesChannelTypeRepository: (this: SalesChannelModalGridTestContext) => TRepository<'sales_channel_type'>;
+};
+
+const componentMethods = SwSalesChannelModalGridExtension.methods as SalesChannelModalGridMethods;
+const componentComputed = SwSalesChannelModalGridExtension.computed as SalesChannelModalGridComputed;
+
+function createSalesChannelType(id: string): TEntity<'sales_channel_type'> {
+    return {
+        id,
+        translated: {
+            name: id,
+            description: id,
+        },
+    } as TEntity<'sales_channel_type'>;
+}
+
+function createSalesChannelTypes(): TEntityCollection<'sales_channel_type'> {
+    return new EntityCollection<'sales_channel_type'>(
+        '/sales-channel-type',
+        'sales_channel_type',
+        Shopware.Context.api,
+        null,
+        [
+            createSalesChannelType(Shopware.Defaults.storefrontSalesChannelTypeId),
+            createSalesChannelType(Shopware.Defaults.agenticCommerceTypeId),
+            createSalesChannelType(PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID),
+        ],
+        3,
+    );
+}
+
+function createComponent(hasUsDefaultCountryStorefrontSalesChannel: boolean) {
+    const salesChannelTypes = createSalesChannelTypes();
+    const salesChannelTypeSearch = jest.fn().mockResolvedValue(salesChannelTypes);
+    const salesChannelTypeRepository = {
+        search: salesChannelTypeSearch,
+    } as Pick<TRepository<'sales_channel_type'>, 'search'>;
+    const salesChannelSearchIds = jest.fn().mockResolvedValue({
+        data: hasUsDefaultCountryStorefrontSalesChannel ? ['us-storefront-sales-channel-id'] : [],
+        total: hasUsDefaultCountryStorefrontSalesChannel ? 1 : 0,
+    });
+
+    return {
+        component: {
+            $super: jest.fn(() => salesChannelTypeRepository),
+            salesChannelRepository: {
+                searchIds: salesChannelSearchIds,
+            },
+            usDefaultCountryStorefrontCriteria: componentMethods.usDefaultCountryStorefrontCriteria,
+            hasUsDefaultCountryStorefrontSalesChannel: componentMethods.hasUsDefaultCountryStorefrontSalesChannel,
+            withPayPalAgenticCommerceFilter: componentMethods.withPayPalAgenticCommerceFilter,
+        } as SalesChannelModalGridTestContext,
+        salesChannelTypeSearch,
+        salesChannelSearchIds,
+    };
+}
+
+describe('sw-sales-channel-modal-grid', () => {
+    it('should call the original sales channel type repository and show PayPal Agentic Commerce when a USA storefront exists', async () => {
+        const { component, salesChannelTypeSearch } = createComponent(true);
+
+        const repository = componentComputed.salesChannelTypeRepository.call(component);
+        const criteria = new Criteria(1, 500);
+        const result = await repository.search(criteria, Shopware.Context.api);
+
+        expect(component.$super).toHaveBeenCalledWith('salesChannelTypeRepository');
+        expect(salesChannelTypeSearch).toHaveBeenCalledWith(criteria, Shopware.Context.api);
+        expect(result.has(PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID)).toBe(true);
+        expect(result.has(Shopware.Defaults.agenticCommerceTypeId)).toBe(true);
+        expect(result.total).toBe(3);
+    });
+
+    it('should add one filter for PayPal Agentic Commerce without a storefront with USA as default country', async () => {
+        const { component, salesChannelTypeSearch } = createComponent(false);
+
+        const repository = componentComputed.salesChannelTypeRepository.call(component);
+        const criteria = new Criteria(1, 500);
+
+        await repository.search(criteria, Shopware.Context.api);
+
+        const filteredCriteria = salesChannelTypeSearch.mock.calls[0][0] as TCriteria;
+
+        expect(filteredCriteria).not.toBe(criteria);
+        expect(criteria.filters).toEqual([]);
+        expect(filteredCriteria.filters).toEqual([
+            Criteria.not('AND', [
+                Criteria.equals('id', PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID),
+            ]),
+        ]);
+    });
+
+    it('should look for storefronts with USA as default country', async () => {
+        const { component, salesChannelSearchIds } = createComponent(true);
+
+        const repository = componentComputed.salesChannelTypeRepository.call(component);
+
+        await repository.search(new Criteria(1, 500), Shopware.Context.api);
+
+        const criteria = salesChannelSearchIds.mock.calls[0][0] as TCriteria;
+
+        expect(criteria.filters).toEqual([
+            Criteria.equals('typeId', Shopware.Defaults.storefrontSalesChannelTypeId),
+            Criteria.equals('country.iso3', 'USA'),
+        ]);
+    });
+});

--- a/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.ts
+++ b/src/Resources/app/administration/src/module/extension/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.ts
@@ -69,21 +69,25 @@ function createComponent(hasUsDefaultCountryStorefrontSalesChannel: boolean) {
             hasUsDefaultCountryStorefrontSalesChannel: componentMethods.hasUsDefaultCountryStorefrontSalesChannel,
             withPayPalAgenticCommerceFilter: componentMethods.withPayPalAgenticCommerceFilter,
         } as SalesChannelModalGridTestContext,
+        salesChannelTypeRepository,
         salesChannelTypeSearch,
         salesChannelSearchIds,
     };
 }
 
 describe('sw-sales-channel-modal-grid', () => {
-    it('should call the original sales channel type repository and show PayPal Agentic Commerce when a USA storefront exists', async () => {
-        const { component, salesChannelTypeSearch } = createComponent(true);
+    it('should decorate the original sales channel type repository and show PayPal Agentic Commerce when a USA storefront exists', async () => {
+        const { component, salesChannelTypeRepository, salesChannelTypeSearch } = createComponent(true);
 
         const repository = componentComputed.salesChannelTypeRepository.call(component);
         const criteria = new Criteria(1, 500);
         const result = await repository.search(criteria, Shopware.Context.api);
 
         expect(component.$super).toHaveBeenCalledWith('salesChannelTypeRepository');
+        expect(repository).toBe(salesChannelTypeRepository);
+        expect(repository.search).not.toBe(salesChannelTypeSearch);
         expect(salesChannelTypeSearch).toHaveBeenCalledWith(criteria, Shopware.Context.api);
+        expect(salesChannelTypeSearch.mock.contexts[0]).toBe(salesChannelTypeRepository);
         expect(result.has(PAYPAL_AGENTIC_COMMERCE_SALES_CHANNEL_TYPE_ID)).toBe(true);
         expect(result.has(Shopware.Defaults.agenticCommerceTypeId)).toBe(true);
         expect(result.total).toBe(3);


### PR DESCRIPTION
- Hide the PayPal Agentic Commerce sales channel type in the add-sales-channel modal unless a Storefront sales channel with default country USA exists.
- Keep the original sales-channel-type repository behavior by calling $super(...) and only adding an extra Criteria filter when the US Storefront prerequisite is missing.
- Add Admin Jest coverage for both paths: unchanged original Criteria when eligible, filtered Criteria when not eligible.