### PR TITLE
fix: silent checkout failure on expired PayPal order session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where the checkout silently failed when a buyer returned after the PayPal Order lifetime (~3h) had elapsed. The transaction is now routed to the canceled state so the buyer can retry the payment from the edit-order page.
+
 # 10.6.2
 - Fixes an issue, where the Express Checkout failed when the buyer changed the delivery country to one with rule-restricted shipping methods (shopware/shopware#16295).
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem der Checkout still fehlschlug, wenn ein Käufer nach Ablauf der PayPal-Order-Lebensdauer (~3h) zurückkehrte. Die Transaktion wird nun als abgebrochen markiert, sodass der Bezahlvorgang über die Edit-Order-Seite erneut gestartet werden kann.
+
 # 10.6.2
 - Behebt ein Problem, bei dem der Express Checkout fehlschlug, wenn der Käufer das Lieferland zu einem mit regelbasierten Versandarten änderte (shopware/shopware#16295).
 

--- a/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
+++ b/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
@@ -32,6 +32,7 @@ use Swag\PayPal\Checkout\Payment\Service\OrderPatchService;
 use Swag\PayPal\Checkout\Payment\Service\TransactionDataService;
 use Swag\PayPal\Checkout\Payment\Service\VaultTokenService;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
+use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\PartnerAttributionId;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
@@ -158,9 +159,23 @@ abstract class AbstractPaymentMethodHandler extends AbstractPaymentHandler
             );
         }
 
+        try {
+            $paypalOrder = $this->orderResource->get($paypalOrderId, $order->getSalesChannelId());
+        } catch (PayPalApiException $exception) {
+            if (!$exception->is(PayPalApiException::ERROR_CODE_RESOURCE_NOT_FOUND)) {
+                throw $exception;
+            }
+
+            throw PaymentException::customerCanceled(
+                $transaction->getOrderTransactionId(),
+                'PayPal order session expired (RESOURCE_NOT_FOUND).',
+                $exception,
+            );
+        }
+
         $this->executeOrder(
             $transaction,
-            $this->orderResource->get($paypalOrderId, $order->getSalesChannelId()),
+            $paypalOrder,
             $order,
             $orderTransaction,
             $context,

--- a/tests/Checkout/Payment/PayPalPaymentHandlerTest.php
+++ b/tests/Checkout/Payment/PayPalPaymentHandlerTest.php
@@ -71,6 +71,7 @@ class PayPalPaymentHandlerTest extends TestCase
     public const PAYPAL_PATCH_THROWS_EXCEPTION = 'invalidId';
     public const PAYPAL_ORDER_ID_DUPLICATE_ORDER_NUMBER = 'paypalOrderIdDuplicateOrderNumber';
     public const PAYPAL_ORDER_ID_INSTRUMENT_DECLINED = 'paypalOrderIdInstrumentDeclined';
+    public const PAYPAL_ORDER_ID_EXPIRED_SESSION = 'paypalOrderIdExpiredSession';
     private const TEST_CUSTOMER_STREET = 'Street 1';
     private const TEST_CUSTOMER_FIRST_NAME = 'FirstName';
     private const TEST_CUSTOMER_LAST_NAME = 'LastName';
@@ -236,6 +237,20 @@ class PayPalPaymentHandlerTest extends TestCase
         $this->expectExceptionMessage('The error "UNPROCESSABLE_ENTITY" occurred with the following message: The requested action could not be completed, was semantically incorrect, or failed business validation. | [INSTRUMENT_DECLINED] The instrument presented was either declined by the processor or bank, or it can\'t be used for this payment.');
 
         $this->assertFinalizeRequest(self::PAYPAL_ORDER_ID_INSTRUMENT_DECLINED);
+    }
+
+    public function testFinalizePayPalOrderExpiredSessionIsCustomerCanceled(): void
+    {
+        try {
+            $this->assertFinalizeRequest(self::PAYPAL_ORDER_ID_EXPIRED_SESSION);
+            self::fail('Expected PaymentException for expired PayPal session.');
+        } catch (PaymentException $thrown) {
+            self::assertSame(
+                PaymentException::PAYMENT_CUSTOMER_CANCELED_EXTERNAL,
+                $thrown->getErrorCode(),
+                'Expired PayPal sessions must be routed to the canceled state so the buyer can retry from edit-order.',
+            );
+        }
     }
 
     public function testFinalizePayPalOrderPatchOrderNumber(): void

--- a/tests/Mock/PayPalSDK/MockRequestHandler.php
+++ b/tests/Mock/PayPalSDK/MockRequestHandler.php
@@ -191,6 +191,10 @@ class MockRequestHandler
                 return $this->createResponse(SymResponse::HTTP_OK, $orderCapture);
             }
 
+            if (\mb_strpos($resourceUri, PayPalPaymentHandlerTest::PAYPAL_ORDER_ID_EXPIRED_SESSION) !== false) {
+                return $this->createClientExceptionResourceNotFound();
+            }
+
             if (\mb_substr($resourceUri, -17) === GetOrderAuthorization::ID) {
                 return $this->createResponse(SymResponse::HTTP_OK, GetOrderAuthorization::get());
             }
@@ -516,6 +520,21 @@ class MockRequestHandler
                 ],
             ],
             'message' => 'The requested action could not be completed, was semantically incorrect, or failed business validation.',
+        ]);
+    }
+
+    private function createClientExceptionResourceNotFound(): Response
+    {
+        return $this->createResponse(SymResponse::HTTP_NOT_FOUND, [
+            'name' => 'RESOURCE_NOT_FOUND',
+            'details' => [
+                [
+                    'location' => 'path',
+                    'issue' => 'INVALID_RESOURCE_ID',
+                    'description' => 'The specified resource does not exist.',
+                ],
+            ],
+            'message' => 'The specified resource does not exist.',
         ]);
     }
 


### PR DESCRIPTION
# SwagPayPal expired-session finalize fix

### 1. Why is this change necessary?

A PayPal Order is valid for ~3 hours (hard PayPal-side limit). Buyers who return to the merchant after that window hold a `paypal_order_id` PayPal no longer recognises. The finalize-time `OrderResource::get` returns HTTP 404 `RESOURCE_NOT_FOUND`, the generic `catch` in `AbstractPaymentMethodHandler::finalize` wraps it into `PaymentException::asyncFinalizeInterrupted`, and the transaction transitions to *failed*. The buyer is dropped on a generic checkout error with no retry path; the cart is effectively dead.

Observed at a production merchant as a measurable PayPal conversion drop (~2–3 pp) over two billing periods.

### 2. What does this change do, exactly?

`src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php::finalize`:

- Wraps `OrderResource::get($paypalOrderId, $order->getSalesChannelId())` in `try/catch`.
- On `PayPalApiException` with `ERROR_CODE_RESOURCE_NOT_FOUND`, throws `PaymentException::customerCanceled` with the original exception as `previous`. Any other `PayPalApiException` is re-thrown unchanged.

Shopware core (`PaymentService::finalizeTransaction`) recognises the canceled error code and transitions the transaction to *canceled* (recoverable). The buyer is redirected to `frontend.account.edit-order.page`, where the PayPal button mints a fresh order on display. One extra click replaces a dead checkout.

The fix follows the existing precedent of `OrderExecuteService::captureOrAuthorizeOrder`, which already translates `ISSUE_DUPLICATE_INVOICE_ID` into a recovery action — same pattern, extended to the expired-session case.

Tests added:

- `tests/Checkout/Payment/PayPalPaymentHandlerTest::testFinalizePayPalOrderExpiredSessionIsCustomerCanceled` plus the matching `PAYPAL_ORDER_ID_EXPIRED_SESSION` constant, following the existing `assertFinalizeRequest` pattern.
- `tests/Mock/PayPalSDK/MockRequestHandler`: new `createClientExceptionResourceNotFound` helper alongside the other `createClientException*` helpers, plus a dispatcher branch returning HTTP 404 `RESOURCE_NOT_FOUND` for the expired-session order id.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a product to the cart and proceed to checkout.
2. Select PayPal as the payment method, confirm — the Smart Payment Button redirects to PayPal.
3. Approve the payment on PayPal but pause/leave the browser tab inactive for >3 hours.
4. Open the merchant return URL (still carrying the now-expired `paypal_order_id`/`token` query parameter).
5. **Before this change**: `OrderResource::get` returns 404, finalize throws `asyncFinalizeInterrupted`, transaction state is *failed*, buyer sees a generic checkout error.
6. **After this change**: finalize throws `customerCanceled`, transaction state is *canceled*, buyer is redirected to `frontend.account.edit-order.page` with the cart intact and the PayPal button initialised for a fresh order.

Automated reproduction: the new test exercises the path via the existing fixture infrastructure.

### 4. Please link to the relevant issues (if any).

No upstream GitHub issue exists. Reported by a merchant via internal channels.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
