### PR TITLE
fix: remove route attributes from decorators

### DIFF
--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
@@ -20,10 +20,8 @@ use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Attribute\Route;
 
 #[Package('checkout')]
-#[Route(defaults: ['_routeScope' => ['store-api']])]
 class ExpressCategoryRoute extends AbstractCategoryRoute
 {
     /**
@@ -43,7 +41,6 @@ class ExpressCategoryRoute extends AbstractCategoryRoute
         return $this->inner;
     }
 
-    #[Route(path: '/store-api/category/{navigationId}', name: 'store-api.category.detail', methods: ['GET', 'POST'])]
     public function load(string $navigationId, Request $request, SalesChannelContext $context): CategoryRouteResponse
     {
         $response = $this->inner->load($navigationId, $request, $context);

--- a/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
+++ b/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
@@ -28,10 +28,8 @@ use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Attribute\Route;
 
 #[Package('checkout')]
-#[Route(defaults: ['_routeScope' => ['store-api']])]
 class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
 {
     /**
@@ -57,7 +55,6 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
         return $this->decorated;
     }
 
-    #[Route(path: '/store-api/payment-method', name: 'store-api.payment.method', defaults: ['_entity' => 'payment_method'], methods: ['GET', 'POST'])]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): PaymentMethodRouteResponse
     {
         $response = $this->getDecorated()->load($request, $context, $criteria);


### PR DESCRIPTION
### 1. Why is this change necessary?

The phpstan pipeline on PR #659 fails only for the Shopware `trunk` matrix. The failing rule is `shopware.routeDecorator`, which now reports two existing decorated Store API routes that still define `#[Route]` attributes:

- `Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCategoryRoute`
- `Swag\PayPal\Checkout\SalesChannel\FilteredPaymentMethodRoute`

Decorators should not define or override route attributes because the core route definition must remain the single source of truth.

### 2. What does this change do, exactly?

Removes the class-level and method-level `#[Route]` attributes from both decorator classes and removes the now-unused `Route` imports.

