### PR TITLE
fix: express shipping cost discrepancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.6.3
+- Fixes an issue, where shipping const discrepancies could cause the express checkout with shipping callback enabled to fail
+
 # 10.6.2
 - Fixes an issue, where stale authorization webhooks could cancel unrelated order transactions
 - Fixes an issue, where the Express Checkout failed when the buyer changed the delivery country to one with rule-restricted shipping methods (shopware/shopware#16295).

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.6.3
+- Behebt ein Problem, bei dem Versandkosten Diskrepanzen den Express Checkout mit aktivem Versand-Callback fehlschlagen lies
+
 # 10.6.2
 - Behebt ein Problem, bei dem veraltete Authorisations-Webhooks den Zahlungsstatus auf Abgebrochen setzen konnte
 - Behebt ein Problem, bei dem der Express Checkout fehlschlug, wenn der Käufer das Lieferland zu einem mit regelbasierten Versandarten änderte (shopware/shopware#16295).

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.6.2",
+    "version": "10.6.3",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
+++ b/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
@@ -48,10 +48,8 @@ class ShippingOptionsProvider
         $option->setLabel((string) $shippingMethod->getTranslation('name'));
 
         if ($salesChannelContext->getShippingMethod()->getId() === $shippingMethod->getId()) {
-            $value = $this->priceFormatter->formatPrice(
-                $cart->getShippingCosts()->getTotalPrice(),
-                $salesChannelContext->getCurrency()->getIsoCode(),
-            );
+            $currencyCode = $salesChannelContext->getCurrency()->getIsoCode();
+            $value = $this->priceFormatter->formatPrice($cart->getShippingCosts()->getTotalPrice(), $currencyCode);
 
             $amount = new Money();
             $amount->setValue($value);

--- a/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
+++ b/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
@@ -48,17 +48,17 @@ class ShippingOptionsProvider
         $option->setLabel((string) $shippingMethod->getTranslation('name'));
 
         if ($salesChannelContext->getShippingMethod()->getId() === $shippingMethod->getId()) {
+            $value = $this->priceFormatter->formatPrice(
+                $cart->getShippingCosts()->getTotalPrice(),
+                $salesChannelContext->getCurrency()->getIsoCode(),
+            );
+
+            $amount = new Money();
+            $amount->setValue($value);
+            $amount->setCurrencyCode($currencyCode);
+
+            $option->setAmount($amount);
             $option->setSelected(true);
-
-            if ($shippingCosts = $cart->getDeliveries()->first()?->getShippingCosts()) {
-                $currencyCode = $salesChannelContext->getCurrency()->getIsoCode();
-
-                $amount = new Money();
-                $amount->setValue($this->priceFormatter->formatPrice($shippingCosts->getTotalPrice(), $currencyCode));
-                $amount->setCurrencyCode($currencyCode);
-
-                $option->setAmount($amount);
-            }
         }
 
         return $option;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Carts can have multiple deliveries and if used, it can cause shipping cost discrepancies between the shipping cost provided via breakdown and shipping options provided.
This can only happen in express checkouts with the shipping callback enabled.

### 2. What does this change do, exactly?
Use the same (and correct) shipping costs as the purchase unit provider

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
