### PR TITLE
fix: express shipping net prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 10.6.4
+- Fixes an issue, where net prices could cause the express checkout with shipping callback enabled to fail
+
 # 10.6.3
-- Fixes an issue, where shipping const discrepancies could cause the express checkout with shipping callback enabled to fail
+- Fixes an issue, where shipping cost discrepancies could cause the express checkout with shipping callback enabled to fail
 
 # 10.6.2
 - Fixes an issue, where stale authorization webhooks could cancel unrelated order transactions

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 10.6.4
+- Behebt ein Problem, bei dem Netto-Preise den Express Checkout mit aktivem Versand-Callback fehlschlagen lies
+
 # 10.6.3
 - Behebt ein Problem, bei dem Versandkosten Diskrepanzen den Express Checkout mit aktivem Versand-Callback fehlschlagen lies
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.6.3",
+    "version": "10.6.4",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
+++ b/src/OrdersApi/Builder/Util/ShippingOptionsProvider.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\OrdersApi\Builder\Util;
 
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -48,8 +49,10 @@ class ShippingOptionsProvider
         $option->setLabel((string) $shippingMethod->getTranslation('name'));
 
         if ($salesChannelContext->getShippingMethod()->getId() === $shippingMethod->getId()) {
+            $shippingCosts = $cart->getShippingCosts();
             $currencyCode = $salesChannelContext->getCurrency()->getIsoCode();
-            $value = $this->priceFormatter->formatPrice($cart->getShippingCosts()->getTotalPrice(), $currencyCode);
+            $taxes = $cart->getPrice()->getTaxStatus() !== CartPrice::TAX_STATE_GROSS ? $shippingCosts->getCalculatedTaxes()->getAmount() : 0.0;
+            $value = $this->priceFormatter->formatPrice($shippingCosts->getTotalPrice() + $taxes, $currencyCode);
 
             $amount = new Money();
             $amount->setValue($value);

--- a/tests/OrdersApi/Builder/Util/ShippingOptionsProviderTest.php
+++ b/tests/OrdersApi/Builder/Util/ShippingOptionsProviderTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\OrdersApi\Builder\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute;
+use Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRouteResponse;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
+use Swag\PayPal\Util\PriceFormatter;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ShippingOptionsProvider::class)]
+class ShippingOptionsProviderTest extends TestCase
+{
+    private ShippingOptionsProvider $shippingOptionsProvider;
+
+    private AbstractShippingMethodRoute $shippingMethodRoute;
+
+    protected function setUp(): void
+    {
+        $this->shippingMethodRoute = $this->createMock(AbstractShippingMethodRoute::class);
+        $this->shippingOptionsProvider = new ShippingOptionsProvider(
+            new PriceFormatter(),
+            $this->shippingMethodRoute,
+        );
+    }
+
+    public function testGetShippingOptionsCreatesAnOptionPerShippingMethod(): void
+    {
+        $this->mockRoute($this->createShippingMethod('standard-id', 'Standard'), $this->createShippingMethod('express-id', 'Express'));
+
+        $cart = $this->createCart();
+        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('unselected-id'));
+
+        static::assertCount(2, $options);
+
+        $first = $options->first();
+        static::assertNotNull($first);
+        static::assertSame('standard-id', $first->getId());
+        static::assertSame('Standard', $first->getLabel());
+    }
+
+    public function testGetShippingOptionsMarksTheSelectedMethodAndSetsItsGrossAmount(): void
+    {
+        $selected = $this->createShippingMethod('selected-id', 'Selected');
+        $unselected = $this->createShippingMethod('other-id', 'Other');
+        $this->mockRoute($selected, $unselected);
+
+        $cart = $this->createCart(shippingTotal: 4.99);
+        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
+
+        $selectedOption = $options->get('selected-id');
+        static::assertNotNull($selectedOption);
+        static::assertTrue($selectedOption->isSelected());
+        static::assertSame('4.99', $selectedOption->getAmount()->getValue());
+        static::assertSame('EUR', $selectedOption->getAmount()->getCurrencyCode());
+
+        $otherOption = $options->get('other-id');
+        static::assertNotNull($otherOption);
+        static::assertFalse($otherOption->isSelected());
+    }
+
+    public function testGetShippingOptionsAddsTaxesToTheSelectedMethodOnNetCarts(): void
+    {
+        $selected = $this->createShippingMethod('selected-id', 'Selected');
+        $this->mockRoute($selected);
+
+        $cart = $this->createCart(shippingTotal: 5.0, shippingTax: 0.95, taxState: CartPrice::TAX_STATE_NET);
+        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
+
+        $selectedOption = $options->first();
+        static::assertNotNull($selectedOption);
+        static::assertTrue($selectedOption->isSelected());
+        static::assertSame('5.95', $selectedOption->getAmount()->getValue());
+    }
+
+    public function testGetShippingOptionsReturnsEmptyCollectionWhenNoMethodsAreAvailable(): void
+    {
+        $this->mockRoute();
+
+        $options = $this->shippingOptionsProvider->getShippingOptions($this->createCart(), $this->createSalesChannelContext('selected-id'));
+
+        static::assertCount(0, $options);
+    }
+
+    private function mockRoute(ShippingMethodEntity ...$shippingMethods): void
+    {
+        $response = $this->createMock(ShippingMethodRouteResponse::class);
+        $response
+            ->method('getShippingMethods')
+            ->willReturn(new ShippingMethodCollection($shippingMethods));
+
+        $this->shippingMethodRoute
+            ->method('load')
+            ->willReturn($response);
+    }
+
+    private function createShippingMethod(string $id, string $name): ShippingMethodEntity
+    {
+        $shippingMethod = new ShippingMethodEntity();
+        $shippingMethod->setId($id);
+        $shippingMethod->setName($name);
+        $shippingMethod->addTranslated('name', $name);
+
+        return $shippingMethod;
+    }
+
+    private function createCart(
+        float $shippingTotal = 0.0,
+        float $shippingTax = 0.0,
+        string $taxState = CartPrice::TAX_STATE_GROSS,
+    ): Cart {
+        $shippingCosts = new CalculatedPrice(
+            $shippingTotal,
+            $shippingTotal,
+            new CalculatedTaxCollection([new CalculatedTax($shippingTax, 19.0, $shippingTotal)]),
+            new TaxRuleCollection(),
+        );
+
+        // getShippingCosts() is derived from the cart deliveries, so the cart is
+        // mocked to expose the shipping costs and tax state directly.
+        $cart = $this->createMock(Cart::class);
+        $cart
+            ->method('getShippingCosts')
+            ->willReturn($shippingCosts);
+        $cart
+            ->method('getPrice')
+            ->willReturn(new CartPrice(0.0, 0.0, 0.0, new CalculatedTaxCollection(), new TaxRuleCollection(), $taxState));
+
+        return $cart;
+    }
+
+    private function createSalesChannelContext(string $selectedShippingMethodId): SalesChannelContext
+    {
+        $currency = new CurrencyEntity();
+        $currency->setIsoCode('EUR');
+
+        $shippingMethod = new ShippingMethodEntity();
+        $shippingMethod->setId($selectedShippingMethodId);
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext
+            ->method('getCurrency')
+            ->willReturn($currency);
+        $salesChannelContext
+            ->method('getShippingMethod')
+            ->willReturn($shippingMethod);
+
+        return $salesChannelContext;
+    }
+}

--- a/tests/OrdersApi/Builder/Util/ShippingOptionsProviderTest.php
+++ b/tests/OrdersApi/Builder/Util/ShippingOptionsProviderTest.php
@@ -10,6 +10,11 @@ namespace Swag\PayPal\Test\OrdersApi\Builder\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\Delivery;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPositionCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
@@ -20,6 +25,8 @@ use Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRouteResponse;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
@@ -32,25 +39,11 @@ use Swag\PayPal\Util\PriceFormatter;
 #[CoversClass(ShippingOptionsProvider::class)]
 class ShippingOptionsProviderTest extends TestCase
 {
-    private ShippingOptionsProvider $shippingOptionsProvider;
-
-    private AbstractShippingMethodRoute $shippingMethodRoute;
-
-    protected function setUp(): void
-    {
-        $this->shippingMethodRoute = $this->createMock(AbstractShippingMethodRoute::class);
-        $this->shippingOptionsProvider = new ShippingOptionsProvider(
-            new PriceFormatter(),
-            $this->shippingMethodRoute,
-        );
-    }
-
     public function testGetShippingOptionsCreatesAnOptionPerShippingMethod(): void
     {
-        $this->mockRoute($this->createShippingMethod('standard-id', 'Standard'), $this->createShippingMethod('express-id', 'Express'));
+        $provider = $this->createProvider($this->createShippingMethod('standard-id', 'Standard'), $this->createShippingMethod('express-id', 'Express'));
 
-        $cart = $this->createCart();
-        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('unselected-id'));
+        $options = $provider->getShippingOptions($this->createCart(), $this->createSalesChannelContext('unselected-id'));
 
         static::assertCount(2, $options);
 
@@ -62,12 +55,13 @@ class ShippingOptionsProviderTest extends TestCase
 
     public function testGetShippingOptionsMarksTheSelectedMethodAndSetsItsGrossAmount(): void
     {
-        $selected = $this->createShippingMethod('selected-id', 'Selected');
-        $unselected = $this->createShippingMethod('other-id', 'Other');
-        $this->mockRoute($selected, $unselected);
+        $provider = $this->createProvider(
+            $this->createShippingMethod('selected-id', 'Selected'),
+            $this->createShippingMethod('other-id', 'Other'),
+        );
 
         $cart = $this->createCart(shippingTotal: 4.99);
-        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
+        $options = $provider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
 
         $selectedOption = $options->get('selected-id');
         static::assertNotNull($selectedOption);
@@ -82,11 +76,10 @@ class ShippingOptionsProviderTest extends TestCase
 
     public function testGetShippingOptionsAddsTaxesToTheSelectedMethodOnNetCarts(): void
     {
-        $selected = $this->createShippingMethod('selected-id', 'Selected');
-        $this->mockRoute($selected);
+        $provider = $this->createProvider($this->createShippingMethod('selected-id', 'Selected'));
 
         $cart = $this->createCart(shippingTotal: 5.0, shippingTax: 0.95, taxState: CartPrice::TAX_STATE_NET);
-        $options = $this->shippingOptionsProvider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
+        $options = $provider->getShippingOptions($cart, $this->createSalesChannelContext('selected-id'));
 
         $selectedOption = $options->first();
         static::assertNotNull($selectedOption);
@@ -96,23 +89,26 @@ class ShippingOptionsProviderTest extends TestCase
 
     public function testGetShippingOptionsReturnsEmptyCollectionWhenNoMethodsAreAvailable(): void
     {
-        $this->mockRoute();
+        $provider = $this->createProvider();
 
-        $options = $this->shippingOptionsProvider->getShippingOptions($this->createCart(), $this->createSalesChannelContext('selected-id'));
+        $options = $provider->getShippingOptions($this->createCart(), $this->createSalesChannelContext('selected-id'));
 
         static::assertCount(0, $options);
     }
 
-    private function mockRoute(ShippingMethodEntity ...$shippingMethods): void
+    private function createProvider(ShippingMethodEntity ...$shippingMethods): ShippingOptionsProvider
     {
         $response = $this->createMock(ShippingMethodRouteResponse::class);
         $response
             ->method('getShippingMethods')
             ->willReturn(new ShippingMethodCollection($shippingMethods));
 
-        $this->shippingMethodRoute
+        $shippingMethodRoute = $this->createMock(AbstractShippingMethodRoute::class);
+        $shippingMethodRoute
             ->method('load')
             ->willReturn($response);
+
+        return new ShippingOptionsProvider(new PriceFormatter(), $shippingMethodRoute);
     }
 
     private function createShippingMethod(string $id, string $name): ShippingMethodEntity
@@ -130,6 +126,9 @@ class ShippingOptionsProviderTest extends TestCase
         float $shippingTax = 0.0,
         string $taxState = CartPrice::TAX_STATE_GROSS,
     ): Cart {
+        $cart = new Cart(Uuid::randomHex());
+        $cart->setPrice(new CartPrice(0.0, 0.0, 0.0, new CalculatedTaxCollection(), new TaxRuleCollection(), $taxState));
+
         $shippingCosts = new CalculatedPrice(
             $shippingTotal,
             $shippingTotal,
@@ -137,15 +136,21 @@ class ShippingOptionsProviderTest extends TestCase
             new TaxRuleCollection(),
         );
 
-        // getShippingCosts() is derived from the cart deliveries, so the cart is
-        // mocked to expose the shipping costs and tax state directly.
-        $cart = $this->createMock(Cart::class);
-        $cart
-            ->method('getShippingCosts')
-            ->willReturn($shippingCosts);
-        $cart
-            ->method('getPrice')
-            ->willReturn(new CartPrice(0.0, 0.0, 0.0, new CalculatedTaxCollection(), new TaxRuleCollection(), $taxState));
+        // Cart::getShippingCosts() is derived from the deliveries, so a delivery
+        // carrying the shipping costs is added rather than set directly.
+        $country = new CountryEntity();
+        $country->setId(Uuid::randomHex());
+
+        $now = new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $cart->addDeliveries(new DeliveryCollection([
+            new Delivery(
+                new DeliveryPositionCollection(),
+                new DeliveryDate($now, $now),
+                new ShippingMethodEntity(),
+                ShippingLocation::createFromCountry($country),
+                $shippingCosts,
+            ),
+        ]));
 
         return $cart;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Shipping costs with net calculation missed the taxes

### 2. What does this change do, exactly?
Include taxes in the shipping costs

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
