### PR TITLE
refactor: extract installment banner template

### DIFF
--- a/src/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -11,10 +11,10 @@
 
             {% if installmentBanner.detailPageEnabled %}
                 <div class="row g-2 mt-0 mb-4 justify-content-end">
-                    <div class="{{ buyable ? 'col-8' : 'col-12' }}"
-                         data-swag-paypal-installment-banner="true"
-                         data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-                    </div>
+                    {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                        installmentBanner: installmentBanner,
+                        classes: buyable ? 'col-8' : 'col-12'
+                    } only %}
                 </div>
             {% endif %}
         {% endblock %}

--- a/src/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -14,9 +14,9 @@
     {% set installmentBanner = page.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
 
     {% if installmentBanner.offCanvasCartEnabled %}
-        <div class="checkout-aside-action"
-             data-swag-paypal-installment-banner="true"
-             data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-        </div>
+        {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+            installmentBanner: installmentBanner,
+            classes: 'checkout-aside-action'
+        } only %}
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Resources/views/storefront/layout/footer/footer.html.twig
@@ -6,10 +6,10 @@
         {% set installmentBanner = footer.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
 
         {% if installmentBanner.footerEnabled %}
-            <div class="col-4 mt-2 p-0 footer-logo is-payment"
-                 data-swag-paypal-installment-banner="true"
-                 data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-            </div>
+            {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                installmentBanner: installmentBanner,
+                classes: 'col-4 mt-2 p-0 footer-logo is-payment'
+            } only %}
         {% endif %}
     {% endblock %}
 

--- a/src/Resources/views/storefront/page/checkout/address/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/address/index.html.twig
@@ -23,10 +23,10 @@
 
                 {% block page_checkout_address_login_toggle_paypal_installment_banner %}
                     {% if installmentBannerEnabled %}
-                        <div class="col-12 col-sm-6"
-                             data-swag-paypal-installment-banner="true"
-                             data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-                        </div>
+                        {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                            installmentBanner: installmentBanner,
+                            classes: 'col-12 col-sm-6'
+                        } only %}
                     {% endif %}
                 {% endblock %}
             </div>

--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -9,10 +9,10 @@
 
         {% if installmentBanner.cartEnabled %}
             <div class="form-row">
-                <div class="col"
-                     data-swag-paypal-installment-banner="true"
-                     data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-                </div>
+                {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                    installmentBanner: installmentBanner,
+                    classes: 'col'
+                } only %}
             </div>
         {% endif %}
     {% endblock %}
@@ -35,10 +35,10 @@
         {% set installmentBanner = page.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
 
         {% if installmentBanner.cartEnabled %}
-            <div class="checkout-aside-action"
-                 data-swag-paypal-installment-banner="true"
-                 data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-            </div>
+            {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                installmentBanner: installmentBanner,
+                classes: 'checkout-aside-action'
+            } only %}
         {% endif %}
     {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -9,10 +9,10 @@
 
         {% if installmentBanner.detailPageEnabled %}
             <div class="row g-2 mt-0 mb-4 justify-content-end">
-                <div class="{{ buyable ? 'col-8' : 'col-12' }}"
-                     data-swag-paypal-installment-banner="true"
-                     data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
-                </div>
+                {% sw_include '@SwagPayPal/storefront/paypal/installment-banner.html.twig' with {
+                    installmentBanner: installmentBanner,
+                    classes: buyable ? 'col-8' : 'col-12'
+                } only %}
             </div>
         {% endif %}
     {% endblock %}

--- a/src/Resources/views/storefront/paypal/installment-banner.html.twig
+++ b/src/Resources/views/storefront/paypal/installment-banner.html.twig
@@ -1,0 +1,9 @@
+{% set installmentBanner = installmentBanner ?? page.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
+{% set installmentBanner = installmentBanner ?? footer.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
+
+{% block swag_paypal_message %}
+    <div class="{{ classes ?? '' }}"
+         data-swag-paypal-installment-banner="true"
+         data-swag-pay-pal-installment-banner-options="{{ installmentBanner|json_encode }}">
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extracts the existing Pay Later installment banner markup into `@SwagPayPal/storefront/paypal/installment-banner.html.twig`
- refactors the existing storefront placements to include that template while preserving the current SDK data-attribute renderer
- keeps all enablement guards, CSS classes, extension IDs, and the special cart-table banner data unchanged

## Context
This keeps the changeset intentionally small while #468 and the JS SDK v6 work remain delayed. The template path matches the direction from #468, but this PR does not introduce SDK v6 custom elements, PHP data-model changes, storefront JavaScript changes, admin controls, or new style options.

## Validation
Whitespace check passed. No PHP or JavaScript behavior was changed.


## Development

Closes #704
