### PR TITLE
fix: align phpstan assertion checks

### DIFF
--- a/tests/Pos/Sync/CompleteProductTest.php
+++ b/tests/Pos/Sync/CompleteProductTest.php
@@ -277,9 +277,10 @@ class CompleteProductTest extends TestCase
         static::assertNotSame((new Product())->generateChecksum(), $productStateD->getChecksum());
         static::assertNotSame((new Product())->generateChecksum(), $productStateE->getChecksum());
 
+        static::assertNotNull(DeleteProductsFixture::$deletedUuids);
         static::assertEqualsCanonicalizing(
             [ConstantsForTesting::PRODUCT_F_ID_CONVERTED, ConstantsForTesting::PRODUCT_G_ID_CONVERTED],
-            DeleteProductsFixture::$deletedUuids
+            \array_values(DeleteProductsFixture::$deletedUuids)
         );
 
         static::assertEquals($this->createConvertedProduct($productB, $variantA, $variantB), CreateProductFixture::$lastCreatedProducts[1]);

--- a/tests/Pos/Sync/Inventory/StockSubscriberTest.php
+++ b/tests/Pos/Sync/Inventory/StockSubscriberTest.php
@@ -118,7 +118,7 @@ class StockSubscriberTest extends TestCase
                         ConstantsForTesting::PRODUCT_B_ID,
                         ConstantsForTesting::PRODUCT_C_ID,
                     ],
-                    $message->getIds()
+                    \array_values($message->getIds())
                 );
             }
         }

--- a/tests/Webhook/Registration/WebhookSubscriberTest.php
+++ b/tests/Webhook/Registration/WebhookSubscriberTest.php
@@ -235,7 +235,7 @@ class WebhookSubscriberTest extends TestCase
 
     public function testSubscribedEvents(): void
     {
-        static::assertEqualsCanonicalizing([
+        static::assertSame([
             SalesChannelEvents::SALES_CHANNEL_DELETED => 'removeSalesChannelWebhookConfiguration',
             BeforeSystemConfigMultipleChangedEvent::class => 'checkWebhookBefore',
             SystemConfigMultipleChangedEvent::class => 'checkWebhookAfter',

--- a/tests/Webhook/WebhookControllerTest.php
+++ b/tests/Webhook/WebhookControllerTest.php
@@ -70,7 +70,7 @@ class WebhookControllerTest extends TestCase
 
         $result = \json_decode($content, true);
 
-        static::assertEqualsCanonicalizing(['result' => WebhookService::STATUS_WEBHOOK_VALID], $result);
+        static::assertSame(['result' => WebhookService::STATUS_WEBHOOK_VALID], $result);
     }
 
     public function testRegisterWebhook(): void
@@ -81,7 +81,7 @@ class WebhookControllerTest extends TestCase
 
         $result = \json_decode($content, true);
 
-        static::assertEqualsCanonicalizing(['result' => WebhookService::WEBHOOK_CREATED], $result);
+        static::assertSame(['result' => WebhookService::WEBHOOK_CREATED], $result);
     }
 
     public function testDeregisterWebhook(): void
@@ -93,7 +93,7 @@ class WebhookControllerTest extends TestCase
         $result = \json_decode($content, true);
 
         // no action because no Webhook ID is defined by default
-        static::assertEqualsCanonicalizing(['result' => WebhookService::NO_WEBHOOK_ACTION_REQUIRED], $result);
+        static::assertSame(['result' => WebhookService::NO_WEBHOOK_ACTION_REQUIRED], $result);
     }
 
     public function testExecuteWebhook(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware trunk PHPStan now reports `shopware.assertEqualsCanonicalizingListArgument` when `assertEqualsCanonicalizing()` is used with associative arrays or runtime arrays that are not known lists. These failures show up on #709 but are unrelated to that feature branch.

The previous product-stream compatibility change on this branch is no longer needed because the related change in `shopware/shopware` trunk was reverted, so this PR has been rewritten to contain only the assertion fixes.

### 2. What does this change do, exactly?

- Converts associative-array webhook assertions from `assertEqualsCanonicalizing()` to `assertSame()`.
- Normalizes POS runtime arrays with `array_values()` before canonicalizing list comparisons.
- Drops the old product-stream compatibility diff from this PR branch.

### 3. Describe each step to reproduce the issue or behaviour.

Run PHPStan for the plugin against the trunk dependency set, as in the PR #709 `phpstan (8.2, trunk)` or `phpstan (8.4, trunk)` checks.

### 4. Please link to the relevant issues (if any).

- fixes unrelated PHPStan failures observed in #709

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.