### PR TITLE
fix: inject clocks for native time checks

### DIFF
--- a/src/Checkout/PUI/ScheduledTask/PUIInstructionsFetchTaskHandler.php
+++ b/src/Checkout/PUI/ScheduledTask/PUIInstructionsFetchTaskHandler.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Checkout\PUI\ScheduledTask;
 
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Defaults;
@@ -37,13 +38,14 @@ class PUIInstructionsFetchTaskHandler extends ScheduledTaskHandler
         private readonly EntityRepository $orderTransactionRepository,
         private readonly PaymentMethodDataRegistry $methodDataRegistry,
         private readonly MessageBusInterface $bus,
+        private readonly ClockInterface $clock,
     ) {
         parent::__construct($scheduledTaskRepository, $logger);
     }
 
     public function run(): void
     {
-        $date = (new \DateTimeImmutable('now -1h'))->setTimezone(new \DateTimeZone('UTC'));
+        $date = $this->clock->now()->modify('-1 hour')->setTimezone(new \DateTimeZone('UTC'));
         $rangeFilter = [
             RangeFilter::GTE => $date->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ];

--- a/src/Checkout/Payment/ScheduledTask/TransactionStatusSyncTaskHandler.php
+++ b/src/Checkout/Payment/ScheduledTask/TransactionStatusSyncTaskHandler.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Checkout\Payment\ScheduledTask;
 
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
@@ -39,6 +40,7 @@ class TransactionStatusSyncTaskHandler extends ScheduledTaskHandler
         private readonly EntityRepository $orderTransactionRepository,
         private readonly PaymentMethodDataRegistry $methodDataRegistry,
         private readonly MessageBusInterface $bus,
+        private readonly ClockInterface $clock,
     ) {
         parent::__construct($scheduledTaskRepository, $logger);
     }
@@ -46,7 +48,7 @@ class TransactionStatusSyncTaskHandler extends ScheduledTaskHandler
     public function run(): void
     {
         // Check all transactions from the last 48h, but offset by an hour
-        $hourAgo = (new \DateTimeImmutable('now -1 hour'))
+        $hourAgo = $this->clock->now()->modify('-1 hour')
             ->setTimezone(new \DateTimeZone('UTC'));
 
         $twoDaysAgo = $hourAgo->modify('-48 hours');

--- a/src/Pos/Api/Authentication/Token.php
+++ b/src/Pos/Api/Authentication/Token.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Pos\Api\Authentication;
 
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\Pos\Api\Common\PosStruct;
+use Symfony\Component\Clock\Clock;
 
 #[Package('checkout')]
 final class Token extends PosStruct
@@ -41,7 +42,9 @@ final class Token extends PosStruct
         $newToken = parent::assign($arrayData);
 
         // Calculate the expiration date manually
-        $expirationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));
+        $expirationDateTime = \DateTime::createFromImmutable(
+            Clock::get()->now()->setTimezone(new \DateTimeZone('UTC'))
+        );
         $interval = \DateInterval::createFromDateString($newToken->getExpiresIn() . ' seconds');
         $expirationDateTime = $expirationDateTime->add($interval ?: new \DateInterval('PT0S'));
 

--- a/src/Pos/MessageQueue/MessageDispatcher.php
+++ b/src/Pos/MessageQueue/MessageDispatcher.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\Pos\MessageQueue;
 
 use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -21,15 +22,19 @@ class MessageDispatcher
 
     protected Connection $connection;
 
+    protected ClockInterface $clock;
+
     /**
      * @internal
      */
     public function __construct(
         MessageBusInterface $messageBus,
         Connection $connection,
+        ClockInterface $clock,
     ) {
         $this->messageBus = $messageBus;
         $this->connection = $connection;
+        $this->clock = $clock;
     }
 
     public function dispatch(AbstractSyncMessage $message, bool $tracked = false): void
@@ -61,7 +66,7 @@ class MessageDispatcher
             [
                 'runId' => Uuid::fromHexToBytes($runId),
                 'amount' => $amount,
-                'updatedAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                'updatedAt' => $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ]
         );
     }

--- a/src/Pos/Resource/TokenResource.php
+++ b/src/Pos/Resource/TokenResource.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\Pos\Resource;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\Pos\Api\Authentication\OAuthCredentials;
 use Swag\PayPal\Pos\Api\Authentication\Token;
@@ -22,15 +23,19 @@ class TokenResource
 
     private TokenClientFactory $tokenClientFactory;
 
+    private ClockInterface $clock;
+
     /**
      * @internal
      */
     public function __construct(
         CacheItemPoolInterface $cache,
         TokenClientFactory $tokenClientFactory,
+        ClockInterface $clock,
     ) {
         $this->cache = $cache;
         $this->tokenClientFactory = $tokenClientFactory;
+        $this->clock = $clock;
     }
 
     public function getToken(OAuthCredentials $credentials): Token
@@ -99,7 +104,7 @@ class TokenResource
 
     private function isTokenValid(Token $token): bool
     {
-        $dateTimeNow = new \DateTime('now', new \DateTimeZone('UTC'));
+        $dateTimeNow = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
         $dateTimeExpire = $token->getExpireDateTime();
         // Decrease expire date by one hour just to make sure, it doesn't run into an unauthorized exception.
         $dateTimeExpire = $dateTimeExpire->sub(new \DateInterval('PT1H'));

--- a/src/Pos/Run/Administration/LogCleaner.php
+++ b/src/Pos/Run/Administration/LogCleaner.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Pos\Run\Administration;
 
+use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -23,12 +24,17 @@ class LogCleaner
 
     private EntityRepository $runRepository;
 
+    private ClockInterface $clock;
+
     /**
      * @internal
      */
-    public function __construct(EntityRepository $runRepository)
-    {
+    public function __construct(
+        EntityRepository $runRepository,
+        ClockInterface $clock,
+    ) {
         $this->runRepository = $runRepository;
+        $this->clock = $clock;
     }
 
     public function cleanUpLog(string $salesChannelId, Context $context): void
@@ -43,7 +49,7 @@ class LogCleaner
         /** @var PosSalesChannelRunCollection $runs */
         $runs = $this->runRepository->search($criteria, $context)->getEntities();
 
-        $now = new \DateTime();
+        $now = $this->clock->now();
         $logsPerProduct = [];
 
         foreach ($runs as $run) {

--- a/src/Pos/Run/RunService.php
+++ b/src/Pos/Run/RunService.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Pos\Run;
 
 use Doctrine\DBAL\Connection;
 use Monolog\Logger;
+use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -32,6 +33,8 @@ class RunService
 
     private Logger $logger;
 
+    private ClockInterface $clock;
+
     /**
      * @internal
      */
@@ -40,11 +43,13 @@ class RunService
         EntityRepository $logRepository,
         Connection $connection,
         Logger $logger,
+        ClockInterface $clock,
     ) {
         $this->runRepository = $runRepository;
         $this->logRepository = $logRepository;
         $this->connection = $connection;
         $this->logger = $logger;
+        $this->clock = $clock;
     }
 
     public function startRun(string $salesChannelId, string $taskName, array $steps, Context $context): string
@@ -89,7 +94,7 @@ class RunService
     {
         $data = [
             'id' => $runId,
-            'finishedAt' => new \DateTime(),
+            'finishedAt' => $this->clock->now(),
             'status' => $status,
             'messageCount' => 0,
         ];
@@ -149,7 +154,10 @@ class RunService
                         `message_count` = GREATEST(0, `message_count` - 1),
                         `updated_at` = :updatedAt
                     WHERE `id` = :runId',
-            ['runId' => Uuid::fromHexToBytes($runId), 'updatedAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)],
+            [
+                'runId' => Uuid::fromHexToBytes($runId),
+                'updatedAt' => $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ],
         );
     }
 

--- a/src/Reporting/ScheduledTask/TurnoverReportingTaskHandler.php
+++ b/src/Reporting/ScheduledTask/TurnoverReportingTaskHandler.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\RequestOptions;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Framework\Context;
@@ -41,6 +42,7 @@ class TurnoverReportingTaskHandler extends ScheduledTaskHandler
         private readonly EntityRepository $transactionReportRepository,
         private readonly string $shopwareVersion,
         private readonly ?string $instanceId,
+        private readonly ClockInterface $clock,
     ) {
         $this->client = new Client(['base_uri' => 'https://api.shopware.com']);
         parent::__construct($scheduledTaskRepository, $logger);
@@ -77,7 +79,7 @@ class TurnoverReportingTaskHandler extends ScheduledTaskHandler
         foreach ($reports as $currency => $turnover) {
             $body = [
                 'identifier' => self::API_IDENTIFIER,
-                'reportDate' => (new \DateTime())->format(\DateTimeInterface::ATOM),
+                'reportDate' => $this->clock->now()->format(\DateTimeInterface::ATOM),
                 'instanceId' => $this->instanceId,
                 'shopwareVersion' => $this->shopwareVersion,
                 'reportDataKeys' => ['turnover' => \round((float) $turnover, 2)],

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -168,6 +168,7 @@
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
             <argument type="service" id="messenger.default_bus"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/src/Resources/config/services/pos/api.xml
+++ b/src/Resources/config/services/pos/api.xml
@@ -63,6 +63,7 @@
         <service id="Swag\PayPal\Pos\Resource\TokenResource">
             <argument type="service" id="cache.object"/>
             <argument type="service" id="Swag\PayPal\Pos\Client\TokenClientFactory"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
         </service>
 
         <service id="Swag\PayPal\Pos\Resource\UserResource">

--- a/src/Resources/config/services/pos/message_queue.xml
+++ b/src/Resources/config/services/pos/message_queue.xml
@@ -105,6 +105,7 @@
         <service id="Swag\PayPal\Pos\MessageQueue\MessageDispatcher">
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
         </service>
 
         <service id="Swag\PayPal\Pos\MessageQueue\MessageHydrator">

--- a/src/Resources/config/services/pos/run.xml
+++ b/src/Resources/config/services/pos/run.xml
@@ -26,10 +26,12 @@
             <argument type="service" id="swag_paypal_pos_sales_channel_run_log.repository"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Swag\PayPal\Pos\Run\Logger"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
         </service>
 
         <service id="Swag\PayPal\Pos\Run\Administration\LogCleaner">
             <argument type="service" id="swag_paypal_pos_sales_channel_run.repository"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
         </service>
 
         <service id="Swag\PayPal\Pos\Run\Administration\SyncResetter">

--- a/src/Resources/config/services/pui.xml
+++ b/src/Resources/config/services/pui.xml
@@ -58,6 +58,7 @@
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry"/>
             <argument type="service" id="messenger.default_bus"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/src/Resources/config/services/reporting.xml
+++ b/src/Resources/config/services/reporting.xml
@@ -20,6 +20,7 @@
             <argument type="service" id="swag_paypal_transaction_report.repository"/>
             <argument>%kernel.shopware_version%</argument>
             <argument>%instance_id%</argument>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/tests/Checkout/PUI/ScheduledTask/PUIInstructionsFetchTaskHandlerTest.php
+++ b/tests/Checkout/PUI/ScheduledTask/PUIInstructionsFetchTaskHandlerTest.php
@@ -24,6 +24,7 @@ use Swag\PayPal\Checkout\PUI\MessageQueue\PUIInstructionsFetchMessage;
 use Swag\PayPal\Checkout\PUI\ScheduledTask\PUIInstructionsFetchTaskHandler;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Swag\PayPal\Util\Lifecycle\Method\PUIMethodData;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -54,6 +55,7 @@ class PUIInstructionsFetchTaskHandlerTest extends TestCase
             $this->orderTransactionRepository,
             $this->paymentMethodDataRegistry,
             $this->bus,
+            new NativeClock(),
         );
     }
 

--- a/tests/Checkout/Payment/ScheduledTask/TransactionStatusSyncTaskHandlerTest.php
+++ b/tests/Checkout/Payment/ScheduledTask/TransactionStatusSyncTaskHandlerTest.php
@@ -28,6 +28,7 @@ use Swag\PayPal\Checkout\Payment\MessageQueue\TransactionStatusSyncMessage;
 use Swag\PayPal\Checkout\Payment\ScheduledTask\TransactionStatusSyncTaskHandler;
 use Swag\PayPal\SwagPayPal;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -58,6 +59,7 @@ class TransactionStatusSyncTaskHandlerTest extends TestCase
             $this->orderTransactionRepository,
             $this->paymentMethodDataRegistry,
             $this->bus,
+            new NativeClock(),
         );
     }
 

--- a/tests/Pos/Mock/Client/PosClientFactoryMock.php
+++ b/tests/Pos/Mock/Client/PosClientFactoryMock.php
@@ -15,6 +15,7 @@ use Swag\PayPal\Pos\Client\PosClient;
 use Swag\PayPal\Pos\Client\PosClientFactory;
 use Swag\PayPal\Pos\Resource\TokenResource;
 use Swag\PayPal\Test\Mock\CacheMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -33,7 +34,8 @@ class PosClientFactoryMock extends PosClientFactory
         $this->logger = new NullLogger();
         $this->tokenResource = new TokenResource(
             new CacheMock(),
-            new TokenClientFactoryMock()
+            new TokenClientFactoryMock(),
+            new NativeClock()
         );
         parent::__construct($this->tokenResource, new NullLogger());
     }

--- a/tests/Pos/Resource/TokenResourceTest.php
+++ b/tests/Pos/Resource/TokenResourceTest.php
@@ -15,6 +15,7 @@ use Swag\PayPal\Test\Pos\ConstantsForTesting;
 use Swag\PayPal\Test\Pos\Mock\Client\_fixtures\CreateTokenResponseFixture;
 use Swag\PayPal\Test\Pos\Mock\Client\TokenClientFactoryMock;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -27,7 +28,7 @@ class TokenResourceTest extends TestCase
     public function testExpireDateTimeIsSerializedAsString(): void
     {
         $cache = new ArrayAdapter();
-        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+        $resource = new TokenResource($cache, new TokenClientFactoryMock(), new NativeClock());
         $credentials = $this->createCredentials();
 
         $resource->getToken($credentials);
@@ -50,7 +51,7 @@ class TokenResourceTest extends TestCase
     public function testValidCachedTokenIsReturnedWithoutReauth(): void
     {
         $cache = new ArrayAdapter();
-        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+        $resource = new TokenResource($cache, new TokenClientFactoryMock(), new NativeClock());
 
         $credentials = $this->createCredentials();
 
@@ -67,7 +68,7 @@ class TokenResourceTest extends TestCase
     public function testExpiredCachedTokenTriggersReauth(): void
     {
         $cache = new ArrayAdapter();
-        $resource = new TokenResource($cache, new TokenClientFactoryMock());
+        $resource = new TokenResource($cache, new TokenClientFactoryMock(), new NativeClock());
 
         $credentials = $this->createCredentials();
 

--- a/tests/Pos/Run/PosCommandTest.php
+++ b/tests/Pos/Run/PosCommandTest.php
@@ -31,6 +31,7 @@ use Swag\PayPal\Pos\Run\Task\InventoryTask;
 use Swag\PayPal\Pos\Run\Task\ProductTask;
 use Swag\PayPal\Test\Pos\Mock\MessageBusMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -68,7 +69,7 @@ class PosCommandTest extends TestCase
         $this->logCleaner = $this->createMock(LogCleaner::class);
         $this->syncResetter = $this->createMock(SyncResetter::class);
 
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class), new NativeClock());
         $productTask = new ProductTask($messageDispatcher, $this->runService);
         $imageTask = new ImageTask($messageDispatcher, $this->runService);
         $inventoryTask = new InventoryTask($messageDispatcher, $this->runService);

--- a/tests/Pos/Run/PosSyncControllerTest.php
+++ b/tests/Pos/Run/PosSyncControllerTest.php
@@ -30,6 +30,7 @@ use Swag\PayPal\Pos\Run\Task\ProductTask;
 use Swag\PayPal\Pos\Sync\ProductSelection;
 use Swag\PayPal\Test\Pos\Mock\MessageBusMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -63,7 +64,7 @@ class PosSyncControllerTest extends TestCase
         $this->runService = $this->createMock(RunService::class);
         $this->syncResetter = $this->createMock(SyncResetter::class);
 
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class), new NativeClock());
         $productTask = new ProductTask($messageDispatcher, $this->runService);
         $imageTask = new ImageTask($messageDispatcher, $this->runService);
         $inventoryTask = new InventoryTask($messageDispatcher, $this->runService);

--- a/tests/Pos/Run/RunServiceTest.php
+++ b/tests/Pos/Run/RunServiceTest.php
@@ -27,6 +27,7 @@ use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelRunEntity;
 use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelRunLogEntity;
 use Swag\PayPal\Pos\Run\LoggerFactory;
 use Swag\PayPal\Pos\Run\RunService;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -59,7 +60,7 @@ class RunServiceTest extends TestCase
         $this->context = Context::createDefaultContext();
 
         $this->logger = (new LoggerFactory())->createLogger();
-        $this->runService = new RunService($this->runRepository, $this->logRepository, $this->getContainer()->get(Connection::class), $this->logger);
+        $this->runService = new RunService($this->runRepository, $this->logRepository, $this->getContainer()->get(Connection::class), $this->logger, new NativeClock());
     }
 
     public function testLogProcessAddLogWithoutProduct(): void

--- a/tests/Pos/Run/RunTaskTest.php
+++ b/tests/Pos/Run/RunTaskTest.php
@@ -25,6 +25,7 @@ use Swag\PayPal\Pos\Run\Task\InventoryTask;
 use Swag\PayPal\Pos\Run\Task\ProductTask;
 use Swag\PayPal\Test\Pos\Helper\SalesChannelTrait;
 use Swag\PayPal\Test\Pos\Mock\MessageBusMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -49,7 +50,7 @@ class RunTaskTest extends TestCase
         $this->messageBus = new MessageBusMock();
         $this->runService = $this->createMock(RunService::class);
 
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class), new NativeClock());
         $this->tasks = [
             CompleteTask::class => new CompleteTask($messageDispatcher, $this->runService),
             ProductTask::class => new ProductTask($messageDispatcher, $this->runService),

--- a/tests/Pos/Run/ScheduledTaskTest.php
+++ b/tests/Pos/Run/ScheduledTaskTest.php
@@ -31,6 +31,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\RunLogRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -47,8 +48,8 @@ class ScheduledTaskTest extends TestCase
 
         $messageBus = new MessageBusMock();
         $runRepository = new RunRepoMock();
-        $runService = new RunServiceMock($runRepository, new RunLogRepoMock(), $this->createMock(Connection::class), new Logger('test'));
-        $completeTask = new CompleteTask(new MessageDispatcher($messageBus, $this->createMock(Connection::class)), $runService);
+        $runService = new RunServiceMock($runRepository, new RunLogRepoMock(), $this->createMock(Connection::class), new Logger('test'), new NativeClock());
+        $completeTask = new CompleteTask(new MessageDispatcher($messageBus, $this->createMock(Connection::class), new NativeClock()), $runService);
 
         $taskHandler = new CompleteSyncTaskHandler($scheduledTaskRepository, new NullLogger(), $salesChannelRepoMock, $completeTask);
 
@@ -72,8 +73,8 @@ class ScheduledTaskTest extends TestCase
 
         $messageBus = new MessageBusMock();
         $runRepository = new RunRepoMock();
-        $runService = new RunServiceMock($runRepository, new RunLogRepoMock(), $this->createMock(Connection::class), new Logger('test'));
-        $inventoryTask = new InventoryTask(new MessageDispatcher($messageBus, $this->createMock(Connection::class)), $runService);
+        $runService = new RunServiceMock($runRepository, new RunLogRepoMock(), $this->createMock(Connection::class), new Logger('test'), new NativeClock());
+        $inventoryTask = new InventoryTask(new MessageDispatcher($messageBus, $this->createMock(Connection::class), new NativeClock()), $runService);
 
         $taskHandler = new InventorySyncTaskHandler($scheduledTaskRepository, new NullLogger(), $salesChannelRepoMock, $inventoryTask);
 
@@ -106,7 +107,7 @@ class ScheduledTaskTest extends TestCase
         $runB->setLogs(new PosSalesChannelRunLogCollection());
         $runRepository->addMockEntity($runA);
         $runRepository->addMockEntity($runB);
-        $logCleaner = new LogCleaner($runRepository);
+        $logCleaner = new LogCleaner($runRepository, new NativeClock());
 
         $taskHandler = new CleanUpLogTaskHandler($scheduledTaskRepository, new NullLogger(), $salesChannelRepoMock, $logCleaner);
 

--- a/tests/Pos/Run/SyncManagerTest.php
+++ b/tests/Pos/Run/SyncManagerTest.php
@@ -31,6 +31,7 @@ use Swag\PayPal\Pos\Run\Task\CompleteTask;
 use Swag\PayPal\Test\Pos\Helper\SalesChannelTrait;
 use Swag\PayPal\Test\Pos\Mock\MessageBusMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -59,7 +60,7 @@ class SyncManagerTest extends TestCase
         $this->context = Context::createDefaultContext();
         $this->runService = $this->getContainer()->get(RunService::class);
 
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->getContainer()->get(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->getContainer()->get(Connection::class), new NativeClock());
         $this->task = new CompleteTask($messageDispatcher, $this->runService);
 
         $this->context = Context::createDefaultContext();

--- a/tests/Pos/Sync/CompleteInventoryTest.php
+++ b/tests/Pos/Sync/CompleteInventoryTest.php
@@ -47,6 +47,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\RunLogRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelProductRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -71,7 +72,7 @@ class CompleteInventoryTest extends TestCase
         );
 
         $messageBus = new MessageBusMock();
-        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class), new NativeClock());
         $messageHydrator = new MessageHydrator($this->createMock(SalesChannelContextService::class), $this->createMock(EntityRepository::class));
 
         $inventorySyncManager = new InventorySyncManager(
@@ -90,7 +91,8 @@ class CompleteInventoryTest extends TestCase
             new RunRepoMock(),
             new RunLogRepoMock(),
             $this->createMock(Connection::class),
-            new Logger('test')
+            new Logger('test'),
+            new NativeClock()
         );
 
         $inventorySyncHandler = new InventorySyncHandler(
@@ -216,7 +218,7 @@ class CompleteInventoryTest extends TestCase
 
     public function testDisabledInventoryStockManagement(): void
     {
-        $messageDispatcher = new MessageDispatcher(new MessageBusMock(), $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher(new MessageBusMock(), $this->createMock(Connection::class), new NativeClock());
 
         $productSelection = $this->createMock(ProductSelection::class);
         $productSelection->expects($this->never())->method('getSalesChannelContext');

--- a/tests/Pos/Sync/CompleteProductTest.php
+++ b/tests/Pos/Sync/CompleteProductTest.php
@@ -75,6 +75,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelProductRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -116,14 +117,15 @@ class CompleteProductTest extends TestCase
         );
 
         $messageBus = new MessageBusMock();
-        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class), new NativeClock());
         $messageHydrator = new MessageHydrator($this->createMock(SalesChannelContextService::class), $this->createMock(EntityRepository::class));
 
         $runService = new RunServiceMock(
             new RunRepoMock(),
             new RunLogRepoMock(),
             $this->createMock(Connection::class),
-            new Logger('test')
+            new Logger('test'),
+            new NativeClock()
         );
 
         $productSyncer = new ProductSyncer(

--- a/tests/Pos/Sync/ImageSyncerTest.php
+++ b/tests/Pos/Sync/ImageSyncerTest.php
@@ -46,6 +46,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\PosMediaRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\RunLogRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -101,13 +102,14 @@ class ImageSyncerTest extends TestCase
         );
 
         $messageBus = new MessageBusMock();
-        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($messageBus, $this->createMock(Connection::class), new NativeClock());
         $messageHydrator = new MessageHydrator($this->createMock(SalesChannelContextService::class), $this->createMock(EntityRepository::class));
         $runService = new RunServiceMock(
             new RunRepoMock(),
             new RunLogRepoMock(),
             $this->createMock(Connection::class),
-            new Logger('test')
+            new Logger('test'),
+            new NativeClock()
         );
 
         $imageSyncHandler = new ImageSyncHandler(
@@ -161,12 +163,13 @@ class ImageSyncerTest extends TestCase
             new NullLogger()
         );
 
-        $messageDispatcher = new MessageDispatcher(new MessageBusMock(), $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher(new MessageBusMock(), $this->createMock(Connection::class), new NativeClock());
         $runService = new RunServiceMock(
             new RunRepoMock(),
             new RunLogRepoMock(),
             $this->createMock(Connection::class),
-            new Logger('test')
+            new Logger('test'),
+            new NativeClock()
         );
 
         $imageSyncManager = new ImageSyncManager($messageDispatcher, new PosMediaRepoMock(), $imageSyncer);

--- a/tests/Pos/Util/LogCleanerTest.php
+++ b/tests/Pos/Util/LogCleanerTest.php
@@ -18,6 +18,7 @@ use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelRunLogCollection;
 use Swag\PayPal\Pos\DataAbstractionLayer\Entity\PosSalesChannelRunLogEntity;
 use Swag\PayPal\Pos\Run\Administration\LogCleaner;
 use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
@@ -29,7 +30,7 @@ class LogCleanerTest extends TestCase
     {
         $context = Context::createDefaultContext();
         $runRepository = $this->createLogHistory();
-        $logCleaner = new LogCleaner($runRepository);
+        $logCleaner = new LogCleaner($runRepository, new NativeClock());
 
         static::assertCount(7, $runRepository->getCollection());
 
@@ -43,7 +44,7 @@ class LogCleanerTest extends TestCase
     {
         $context = Context::createDefaultContext();
         $runRepository = $this->createLogHistory();
-        $logCleaner = new LogCleaner($runRepository);
+        $logCleaner = new LogCleaner($runRepository, new NativeClock());
 
         static::assertCount(7, $runRepository->getCollection());
 

--- a/tests/Pos/Util/SettingsControllerTest.php
+++ b/tests/Pos/Util/SettingsControllerTest.php
@@ -62,6 +62,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelProductRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -155,7 +156,7 @@ class SettingsControllerTest extends TestCase
             'toSalesChannelId' => self::TO_SALES_CHANNEL,
         ]), $context);
 
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class), new NativeClock());
         $messageHydrator = new MessageHydrator($this->createMock(SalesChannelContextService::class), $this->salesChannelRepository);
 
         $this->messageBus->execute([
@@ -264,12 +265,13 @@ class SettingsControllerTest extends TestCase
             $this->runRepository,
             new RunLogRepoMock(),
             $this->createMock(Connection::class),
-            new Logger('test')
+            new Logger('test'),
+            new NativeClock()
         );
 
         $this->salesChannelProductRepository = new SalesChannelProductRepoMock();
         $this->salesChannelRepository = new SalesChannelRepoMock();
-        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class));
+        $messageDispatcher = new MessageDispatcher($this->messageBus, $this->createMock(Connection::class), new NativeClock());
 
         if (!$withSalesChannels) {
             $this->salesChannelRepository->getCollection()->clear();
@@ -279,7 +281,8 @@ class SettingsControllerTest extends TestCase
             new ApiCredentialService(
                 new TokenResource(
                     new CacheMock(),
-                    new TokenClientFactoryMock()
+                    new TokenClientFactoryMock(),
+                    new NativeClock()
                 ),
                 $this->salesChannelRepository,
                 new ApiKeyDecoder()

--- a/tests/Pos/Webhook/InventoryChangedTest.php
+++ b/tests/Pos/Webhook/InventoryChangedTest.php
@@ -40,6 +40,7 @@ use Swag\PayPal\Test\Pos\Mock\Repositories\RunRepoMock;
 use Swag\PayPal\Test\Pos\Mock\Repositories\SalesChannelRepoMock;
 use Swag\PayPal\Test\Pos\Mock\RunServiceMock;
 use Swag\PayPal\Test\Pos\Webhook\_fixtures\InventoryChangeFixture;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -87,7 +88,8 @@ class InventoryChangedTest extends TestCase
                 new RunRepoMock(),
                 new RunLogRepoMock(),
                 $this->createMock(Connection::class),
-                new Logger('test')
+                new Logger('test'),
+                new NativeClock()
             ),
             $localCalculator,
             $localUpdater,


### PR DESCRIPTION
## What?
- Injects `Psr\Clock\ClockInterface` into services that read the current time.
- Replaces native `DateTime`/`DateTimeImmutable` now reads in scheduled tasks, POS token/run helpers, and turnover reporting.
- Keeps direct test/helper constructions compatible with `NativeClock` defaults.

## Why?
This resolves the trunk PHPStan `shopware.noNativeTimeRead` failures separately from the App Switch feature branch.