### PR TITLE
fix: accept card payments when 3D Secure data is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixes an issue, where PayPal eligibility checks initialized PHP sessions during stateless Store API requests (shopware/SwagPayPal#740)
 - Fixes an issue, where PayPal Express Checkout in a stale offcanvas cart could call the PayPal API with an empty cart and fail without customer feedback (shopware/SwagPayPal#712)
 - Fixes an issue, where the Google Pay button was always displayed in English instead of the sales channel language (shopware/shopware#17804)
+- Fixes an issue, where card payments without 3D Secure data were rejected even when `ACDC_FORCE_3DS` was disabled (shopware/SwagPayPal#714)
 
 # 10.7.0
 - Added support for PayPal App Switch (currently only available in the US)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,10 +2,11 @@
 - Behebt ein Problem, bei dem Prüfungen zur Verfügbarkeit von PayPal-Zahlungsarten bei zustandslosen Store-API-Anfragen PHP-Sitzungen initialisierten (shopware/SwagPayPal#740)
 - Behebt ein Problem, bei dem PayPal Express Checkout in einem veralteten Offcanvas-Warenkorb die PayPal-API mit leerem Warenkorb aufrufen konnte und ohne Rückmeldung für den Kunden fehlschlug (shopware/SwagPayPal#712)
 - Behebt ein Problem, bei dem der Google Pay Button immer auf Englisch statt in der Verkaufskanal-Sprache angezeigt wurde (shopware/shopware#17804)
+- Behebt ein Problem, bei dem Kartenzahlungen ohne 3D-Secure-Daten abgelehnt wurden, obwohl `ACDC_FORCE_3DS` deaktiviert war (shopware/SwagPayPal#714)
 
 # 10.7.0
 - Fügt Unterstützung für PayPal App Switch hinzu (aktuell nur in den USA verfügbar)
-- Fügt vom Händler konfigurierbare Darstellungseinstellungen für das „Später bezahlen“-Ratenzahlungsbanner hinzu: Logo-Typ, Textfarbe und Textgröße
+- Fügt vom Händler konfigurierbare Darstellungseinstellungen für das „Später bezahlen”-Ratenzahlungsbanner hinzu: Logo-Typ, Textfarbe und Textgröße
 - Behebt ein Problem, bei dem die Smart Payment Buttons unter Safari/iOS ohne sichtbare Rückmeldung fehlschlugen, wenn die AGB nicht akzeptiert wurden, indem der Nutzer nun zum betreffenden Feld geführt wird, anstatt sich auf die native Formularvalidierung des Browsers zu verlassen
 
 # 10.6.4

--- a/src/Checkout/Card/AbstractCardValidator.php
+++ b/src/Checkout/Card/AbstractCardValidator.php
@@ -41,7 +41,7 @@ abstract class AbstractCardValidator implements CardValidatorInterface
         $threeDSecure = $authenticationResult->getThreeDSecure();
 
         if ($threeDSecure === null) {
-            return false;
+            return true;
         }
 
         return \in_array(

--- a/tests/Checkout/Card/AbstractCardValidatorTestCase.php
+++ b/tests/Checkout/Card/AbstractCardValidatorTestCase.php
@@ -55,6 +55,7 @@ abstract class AbstractCardValidatorTestCase extends TestCase
             [false, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, true],
             [false, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [false, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_BYPASSED, null, true],
+            [false, CardValidatorInterface::LIABILITY_SHIFT_NO, null, null, true],
             [false, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, null, null, false],
 
             [true, CardValidatorInterface::LIABILITY_SHIFT_POSSIBLE, CardValidatorInterface::ENROLLMENT_STATUS_READY, CardValidatorInterface::AUTHENTICATION_STATUS_SUCCESSFUL, true],
@@ -70,6 +71,7 @@ abstract class AbstractCardValidatorTestCase extends TestCase
             [true, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_BYPASSED, null, false],
+            [true, CardValidatorInterface::LIABILITY_SHIFT_NO, null, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, null, null, false],
         ];
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Cards that do not support 3D Secure (common for US-issued cards) return `liability_shift=NO` with no `three_d_secure` object in the authentication result. The `AbstractCardValidator` treats absent 3DS data as a validation failure and rejects the payment with `SWAG_PAYPAL__CARD_VALIDATION_FAILED`, even when `ACDC_FORCE_3DS` is disabled. This blocks legitimate card payments in regions where 3DS is not available.

### 2. What does this change do, exactly?

In `AbstractCardValidator::validateAuthenticationResult()`, when `$threeDSecure === null` and `ACDC_FORCE_3DS` is **not** enabled, the method now returns `true` (accept) instead of `false` (reject). Absent 3DS data means 3DS was not available for this card, not that authentication failed.

When `ACDC_FORCE_3DS` **is** enabled, absent 3DS data is still rejected — the merchant explicitly requires liability shift.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure ACDC payment method with `ACDC_FORCE_3DS` disabled (default)
2. Use a US-issued card that does not support 3D Secure (or a Sandbox test card that returns `liability_shift=NO` without a `three_d_secure` object)
3. Attempt to complete checkout
4. Payment is rejected with `SWAG_PAYPAL__CARD_VALIDATION_FAILED`

### 4. Please link to the relevant issues (if any).

- closes #714

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.