### PR TITLE
feat: use SCA_WHEN_REQUIRED for ACDC when 3DS is not enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where the Google Pay button was always displayed in English instead of the sales channel language (shopware/shopware#17804)
+- Use `SCA_WHEN_REQUIRED` for ACDC payments when "Enforce 3D Secure" is disabled
 
 # 10.7.0
 - Added support for PayPal App Switch (currently only available in the US)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where the Google Pay button was always displayed in English instead of the sales channel language (shopware/shopware#17804)
-- Use `SCA_WHEN_REQUIRED` for ACDC payments when "Enforce 3D Secure" is disabled
+- Changes disabled "Enforce 3D Secure" to allow no 3DS challenge if not required
 
 # 10.7.0
 - Added support for PayPal App Switch (currently only available in the US)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem der Google Pay Button immer auf Englisch statt in der Verkaufskanal-Sprache angezeigt wurde (shopware/shopware#17804)
-- `SCA_WHEN_REQUIRED` für ACDC-Zahlungen verwenden, wenn „3D Secure erzwingen” deaktiviert ist
+- Deaktiviertes „3D Secure erzwingen” erlaubt nun, dass keine 3DS-Abfrage erfolgt, wenn sie nicht erforderlich ist
 
 # 10.7.0
 - Fügt Unterstützung für PayPal App Switch hinzu (aktuell nur in den USA verfügbar)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,9 +1,10 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem der Google Pay Button immer auf Englisch statt in der Verkaufskanal-Sprache angezeigt wurde (shopware/shopware#17804)
+- `SCA_WHEN_REQUIRED` für ACDC-Zahlungen verwenden, wenn „3D Secure erzwingen” deaktiviert ist
 
 # 10.7.0
 - Fügt Unterstützung für PayPal App Switch hinzu (aktuell nur in den USA verfügbar)
-- Fügt vom Händler konfigurierbare Darstellungseinstellungen für das „Später bezahlen“-Ratenzahlungsbanner hinzu: Logo-Typ, Textfarbe und Textgröße
+- Fügt vom Händler konfigurierbare Darstellungseinstellungen für das „Später bezahlen”-Ratenzahlungsbanner hinzu: Logo-Typ, Textfarbe und Textgröße
 - Behebt ein Problem, bei dem die Smart Payment Buttons unter Safari/iOS ohne sichtbare Rückmeldung fehlschlugen, wenn die AGB nicht akzeptiert wurden, indem der Nutzer nun zum betreffenden Feld geführt wird, anstatt sich auf die native Formularvalidierung des Browsers zu verlassen
 
 # 10.6.4

--- a/src/OrdersApi/Builder/ACDCOrderBuilder.php
+++ b/src/OrdersApi/Builder/ACDCOrderBuilder.php
@@ -25,6 +25,7 @@ use Swag\PayPal\Checkout\Payment\Service\VaultTokenService;
 use Swag\PayPal\OrdersApi\Builder\Util\AddressProvider;
 use Swag\PayPal\OrdersApi\Builder\Util\ItemListProvider;
 use Swag\PayPal\OrdersApi\Builder\Util\PurchaseUnitProvider;
+use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\LocaleCodeProvider;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -60,7 +61,11 @@ class ACDCOrderBuilder extends AbstractOrderBuilder
         $card->setExperienceContext($this->createExperienceContext($order, $salesChannel, $context, $paymentTransaction, new RequestDataBag($request->request->all())));
 
         $attributes = new Attributes();
-        $attributes->setVerification(new Verification());
+        $verification = new Verification();
+        if (!$this->systemConfigService->getBool(Settings::ACDC_FORCE_3DS, $order->getSalesChannelId())) {
+            $verification->setMethod(Verification::METHOD_SCA_WHEN_REQUIRED);
+        }
+        $attributes->setVerification($verification);
         $card->setAttributes($attributes);
 
         $paymentSource->setCard($card);
@@ -96,7 +101,11 @@ class ACDCOrderBuilder extends AbstractOrderBuilder
         $card->setExperienceContext($this->createExperienceContext($cart, $salesChannelContext->getSalesChannel(), $salesChannelContext->getContext(), null, $requestDataBag));
 
         $attributes = new Attributes();
-        $attributes->setVerification(new Verification());
+        $verification = new Verification();
+        if (!$this->systemConfigService->getBool(Settings::ACDC_FORCE_3DS, $salesChannelContext->getSalesChannelId())) {
+            $verification->setMethod(Verification::METHOD_SCA_WHEN_REQUIRED);
+        }
+        $attributes->setVerification($verification);
         $card->setAttributes($attributes);
 
         $paymentSource->setCard($card);

--- a/tests/OrdersApi/Builder/ACDCOrderBuilderTest.php
+++ b/tests/OrdersApi/Builder/ACDCOrderBuilderTest.php
@@ -7,12 +7,17 @@
 
 namespace Swag\PayPal\Test\OrdersApi\Builder;
 
+use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStruct;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes\Verification;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\ACDCOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\Util\AddressProvider;
+use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Test\OrdersApi\Builder\Trait\VaultableOrderBuildTrait;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -21,6 +26,43 @@ use Swag\PayPal\Test\OrdersApi\Builder\Trait\VaultableOrderBuildTrait;
 class ACDCOrderBuilderTest extends AbstractOrderBuilderTestCase
 {
     use VaultableOrderBuildTrait;
+
+    public function testGetOrderUsesScaWhenRequiredByDefault(): void
+    {
+        $orderTransaction = $this->createOrderTransaction();
+        $order = $this->createOrder();
+        $paymentTransaction = new PaymentTransactionStruct($orderTransaction->getId());
+
+        $paypalOrder = $this->getBuilder()->getOrder(
+            $paymentTransaction,
+            $orderTransaction,
+            $order,
+            Context::createDefaultContext(),
+            new Request(),
+        );
+
+        $card = $paypalOrder->getPaymentSource()?->first(Card::class);
+        static::assertSame(Verification::METHOD_SCA_WHEN_REQUIRED, $card?->getAttributes()?->getVerification()?->getMethod());
+    }
+
+    public function testGetOrderUsesScaAlwaysIfForce3dsEnabled(): void
+    {
+        $this->systemConfig->set(Settings::ACDC_FORCE_3DS, true);
+        $orderTransaction = $this->createOrderTransaction();
+        $order = $this->createOrder();
+        $paymentTransaction = new PaymentTransactionStruct($orderTransaction->getId());
+
+        $paypalOrder = $this->getBuilder()->getOrder(
+            $paymentTransaction,
+            $orderTransaction,
+            $order,
+            Context::createDefaultContext(),
+            new Request(),
+        );
+
+        $card = $paypalOrder->getPaymentSource()?->first(Card::class);
+        static::assertSame(Verification::METHOD_SCA_ALWAYS, $card?->getAttributes()?->getVerification()?->getMethod());
+    }
 
     protected function getBuilder(): AbstractOrderBuilder
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

The plugin hardcodes `SCA_ALWAYS` for all ACDC (credit/debit card) transactions, triggering 3D Secure on every payment regardless of regional requirements. This causes unnecessary friction and payment declines for cardholders in regions where 3DS is not mandated (e.g. the US). Google Pay already uses `SCA_WHEN_REQUIRED`, but there is no way to configure this for credit/debit card payments.

### 2. What does this change do, exactly?

Ties the SCA mode to the existing `ACDC_FORCE_3DS` setting:
- **Force 3DS enabled** → `SCA_ALWAYS`
- **Force 3DS disabled** (default) → `SCA_WHEN_REQUIRED` (recommended by PayPal)

When 3D Secure enforcement is disabled, the `ACDCOrderBuilder` sets `verification.method` to `SCA_WHEN_REQUIRED`, letting PayPal determine whether 3DS is needed based on regional mandates (e.g. PSD2 in the EU).

**Changes:**
- `ACDCOrderBuilder.php` — reads `ACDC_FORCE_3DS` in both `buildPaymentSource` and `buildPaymentSourceFromCart`
- `ACDCOrderBuilderTest.php` — two new tests verifying both SCA modes

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable ACDC payment method
2. Inspect the PayPal order creation request — `verification.method` is always `SCA_ALWAYS`
3. US customers experience 3D Secure prompts on every transaction even though their banks/cards do not require it

### 4. Please link to the relevant issues (if any).

- closes #716

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.