### PR TITLE
fix: ignore ProductStreamBuilderInterface deprecation on trunk

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -112,6 +112,26 @@ parameters:
                 - tests/Pos/Mock/Repositories/ProductRepoMock.php
                 - tests/Pos/Sync/Inventory
 
+        - # 6.8 deprecation - kept for 6.7.0.0 compatibility
+            identifier: property.deprecatedInterface
+            message: '#Property \$productStreamBuilder references deprecated interface Shopware\\Core\\Content\\ProductStream\\Service\\ProductStreamBuilderInterface in its type:#'
+            path: src/Pos/Sync/ProductSelection.php
+
+        - # 6.8 deprecation - kept for 6.7.0.0 compatibility
+            identifier: parameter.deprecatedInterface
+            message: '#Parameter \$productStreamBuilder of method Swag\\PayPal\\Pos\\Sync\\ProductSelection::__construct\(\) has typehint with deprecated interface Shopware\\Core\\Content\\ProductStream\\Service\\ProductStreamBuilderInterface:#'
+            path: src/Pos/Sync/ProductSelection.php
+
+        - # 6.8 deprecation - kept for 6.7.0.0 compatibility
+            identifier: method.deprecatedInterface
+            message: '#Call to method buildFilters\(\) of deprecated interface Shopware\\Core\\Content\\ProductStream\\Service\\ProductStreamBuilderInterface:#'
+            path: src/Pos/Sync/ProductSelection.php
+
+        - # 6.8 deprecation - kept for 6.7.0.0 compatibility
+            identifier: classConstant.deprecatedInterface
+            message: '#Access to constant on deprecated interface Shopware\\Core\\Content\\ProductStream\\Service\\ProductStreamBuilderInterface:#'
+            path: tests/Pos/Sync/Product/ProductSelectionTestProductSync.php
+
         - # Shopware trunk classifies these plugin tests as non-Unit by namespace
             identifier: shopware.unexpectedTestCovers
 


### PR DESCRIPTION
### What changed

Adds shared PHPStan ignores for the `ProductStreamBuilderInterface` deprecation diagnostics in `ProductSelection` and its product sync test.

### Why

The trunk phpstan matrix reports the interface as deprecated for 6.8, but switching to the suggested replacement would risk breaking the plugin's required compatibility with Shopware 6.7.0.0.

The ignores live in `phpstan.neon.dist`. CI sets `reportUnmatchedIgnoredErrors` to `false`, so the 6.7.0.0 matrix can keep using the same config without failing on unmatched trunk-only deprecation ignores.

### Root cause

PR #707 surfaced an unrelated pipeline failure: trunk phpstan reports `property.deprecatedInterface`, `parameter.deprecatedInterface`, `method.deprecatedInterface`, and `classConstant.deprecatedInterface` for `Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface`.

### Validation

- `php -l bin/phpstan-config-generator.php`
- `CI=1 php -d memory_limit=-1 bin/phpstan-config-generator.php`
- `CI=1 php -d memory_limit=-1 ../../../vendor/bin/phpstan analyze src/Pos/Sync/ProductSelection.php tests/Pos/Sync/Product/ProductSelectionTestProductSync.php`
