### PR TITLE
fix: handle PHPStan EntitySearchResult deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,12 +157,6 @@ parameters:
 			path: tests/OrdersApi/Builder/APMOrderBuilderTest.php
 
 		-
-			message: '#^Parameter \#1 \$entity of method Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection\<Shopware\\Core\\Content\\Product\\ProductEntity\>\:\:add\(\) expects Shopware\\Core\\Content\\Product\\ProductEntity, Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity given\.$#'
-			identifier: argument.type
-			count: 2
-			path: tests/Pos/Mock/Repositories/SalesChannelProductRepoMock.php
-
-		-
 			message: '#^Return type \(Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\<Shopware\\Core\\Content\\Product\\SalesChannel\\SalesChannelProductCollection\>\) of method Swag\\PayPal\\Test\\Pos\\Mock\\Repositories\\SalesChannelProductRepoMock\:\:search\(\) should be compatible with return type \(Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\<Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection\>\) of method Shopware\\Core\\System\\SalesChannel\\Entity\\SalesChannelRepository\<Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection\>\:\:search\(\)$#'
 			identifier: method.childReturnType
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,7 +11,6 @@ parameters:
 
     excludePaths:
         - src/Resources
-        - tests/acceptance/node_modules
         - tests/Checkout/ExpressCheckout/ExpressCheckoutSubscriberTest.php
         - tests/DeprecatedTagTest.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,7 @@ parameters:
 
     excludePaths:
         - src/Resources
+        - tests/acceptance/node_modules
         - tests/Checkout/ExpressCheckout/ExpressCheckoutSubscriberTest.php
         - tests/DeprecatedTagTest.php
 
@@ -96,6 +97,26 @@ parameters:
             identifier: method.deprecated
             message: '#(setActiveBillingAddress|setActiveShippingAddress).*Shopware\\Core\\Checkout\\Customer\\CustomerEntity.*#'
 
+        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
+            identifier: method.deprecatedClass
+            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
+            path: '**/*.php'
+
+        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
+            identifier: return.deprecatedClass
+            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
+            path: '**/*.php'
+
+        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
+            identifier: new.deprecatedClass
+            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
+            path: '**/*.php'
+
+        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
+            identifier: classConstant.deprecatedClass
+            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
+            path: '**/*.php'
+
         - # 6.8 deprecation - DAL field API will return static natively
             identifier: method.deprecated
             message: '#Call to deprecated method (addFlags|removeFlag)\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\:\s+tag\:v6\.8\.0 - reason\:return-type-change - Will return static natively#'
@@ -103,14 +124,6 @@ parameters:
                 - src/DataAbstractionLayer
                 - src/Pos/DataAbstractionLayer
                 - src/Reporting/DataAbstractionLayer
-
-        - # 6.8 deprecation - POS inventory sync still relies on available stock semantics
-            identifier: method.deprecated
-            message: '#Call to deprecated method (getAvailableStock|setAvailableStock)\(\) of class .*ProductEntity#'
-            paths:
-                - src/Pos/Sync/Inventory
-                - tests/Pos/Mock/Repositories/ProductRepoMock.php
-                - tests/Pos/Sync/Inventory
 
         - # 6.8 deprecation - kept for 6.7.0.0 compatibility
             identifier: property.deprecatedInterface

--- a/tests/Pos/Mock/Repositories/SalesChannelProductRepoMock.php
+++ b/tests/Pos/Mock/Repositories/SalesChannelProductRepoMock.php
@@ -123,7 +123,7 @@ class SalesChannelProductRepoMock extends SalesChannelRepository
             && $firstFilter->getField() === 'parentId'
             && $firstFilter->getValue() === null) {
             $collection = new SalesChannelProductCollection();
-            foreach ($this->getCollection()->getElements() as $product) {
+            foreach ($this->getCollection() as $product) {
                 if ($product->getParentId() === null && !$product->getChildCount()) {
                     $collection->add($product);
                 }
@@ -140,7 +140,7 @@ class SalesChannelProductRepoMock extends SalesChannelRepository
                 && $subFilter->getField() === 'parentId'
                 && $subFilter->getValue() === null) {
                 $collection = new SalesChannelProductCollection();
-                foreach ($this->getCollection()->getElements() as $product) {
+                foreach ($this->getCollection() as $product) {
                     if ($product->getParentId() !== null) {
                         $collection->add($product);
                     }
@@ -152,7 +152,7 @@ class SalesChannelProductRepoMock extends SalesChannelRepository
             if ($subFilter instanceof EqualsAnyFilter
                 && ($subFilter->getField() === 'id' || $subFilter->getField() === 'parentId')) {
                 $collection = new SalesChannelProductCollection();
-                foreach ($this->getCollection()->getElements() as $product) {
+                foreach ($this->getCollection() as $product) {
                     if (\in_array($product->getParentId(), $subFilter->getValue(), true)
                         || \in_array($product->getId(), $subFilter->getValue(), true)) {
                         $collection->add($product);
@@ -166,7 +166,7 @@ class SalesChannelProductRepoMock extends SalesChannelRepository
         if ($firstFilter instanceof EqualsAnyFilter
             && $firstFilter->getField() === 'parentId') {
             $collection = new SalesChannelProductCollection();
-            foreach ($this->getCollection()->getElements() as $product) {
+            foreach ($this->getCollection() as $product) {
                 if (\in_array($product->getParentId(), $firstFilter->getValue(), true)) {
                     $collection->add($product);
                 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware trunk reports PHPStan deprecation errors for the `EntitySearchResult` v6.8 class-hierarchy change. The type is still part of the 6.7 repository search contract, so current plugin code, tests, and mocks cannot avoid referencing it while staying compatible.

### 2. What does this change do, exactly?

Adds targeted PHPStan ignores for the `EntitySearchResult` class-hierarchy deprecation identifiers that appear on trunk.

Excludes the ignored acceptance `node_modules` directory from PHPStan path scanning.

Removes stale PHPStan ignores that are no longer matched on current trunk.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the lint PHPStan job on trunk or a PR based on trunk.
2. Observe the `EntitySearchResult` class-hierarchy deprecation errors.
3. Run PHPStan with this branch and observe that the analyzer completes without errors.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/SwagPayPal/actions/runs/28877220774/job/85655470338?pr=707

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.