### PR TITLE
ci: add Shopware CLI validate job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   check:
       if: always()
-      needs: [build-zip, test-install-zip, phpunit, acceptance]
+      needs: [build-zip, validate, test-install-zip, phpunit, acceptance]
       runs-on: ubuntu-latest
       steps:
         - uses: re-actors/alls-green@v1.2.2
@@ -32,6 +32,21 @@ jobs:
         uses: shopware/github-actions/build-zip@main
         with:
           extensionName: ${{ github.event.repository.name }}
+
+  validate:
+    needs: build-zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download zip
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ github.event.repository.name }}.zip
+
+      - name: Install shopware-cli
+        uses: shopware/shopware-cli-action@v3
+
+      - name: Validate extension
+        run: shopware-cli extension validate ${{ github.event.repository.name }}.zip --reporter github
 
   test-install-zip:
     needs: build-zip


### PR DESCRIPTION
### 1. Why is this change necessary?

The release workflow validates the packaged extension with `shopware-cli`, but that validation is only visible during the release path. Adding a dedicated CI job makes the extension validation result visible on regular integration runs and pull requests.

### 2. What does this change do, exactly?

Adds a `validate` job to the integration workflow. The job reuses the zip produced by `build-zip`, installs `shopware-cli`, and validates the packaged extension artifact. The aggregate integration `check` job now includes this validation result.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a pull request.
2. Wait for the integration workflow.
3. The workflow now runs a separate extension validation job for the built zip artifact.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/SwagPayPal/actions/runs/28950850088/job/85896895090

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
