### PR TITLE
fix: remove SVG doctype from PayPal logo [6.5.x]

### DIFF
--- a/src/Resources/app/administration/static/img/paypal-logo.svg
+++ b/src/Resources/app/administration/static/img/paypal-logo.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="122px" height="30px" viewBox="0 0 122 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <title>PayPal</title>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
## What changed

Backports `8fa92cf6b38900a5743e4509caf2aa72a55594fa` to `6.5.x`.

The PayPal administration logo SVG no longer contains the XML declaration and SVG doctype header.

## Why

The original fix removes the obsolete SVG doctype from the logo asset so the release branch matches the current trunk fix.

## Validation

- Verified the PR branch contains one cherry-picked commit on top of `origin/6.5.x`.
- Verified the diff only removes two header lines from `src/Resources/app/administration/static/img/paypal-logo.svg`.
- No automated tests run; this is a static SVG asset change.
