### PR TITLE
fix: keep PayPal Smart Payment Buttons disabled until terms are accepted [6.5.x]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 8.11.5
+- Fixes an issue, where the Smart Payment Buttons failed silently when the terms and conditions were not accepted, by guiding the user to the invalid field
+
 # 8.11.4
 - Fixes an issue, where net prices could cause the express checkout with shipping callback enabled to fail
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 8.11.5
+- Behebt ein Problem, bei dem die Smart Payment Buttons ohne sichtbare Rückmeldung fehlschlugen, wenn die AGB nicht akzeptiert wurden, indem der Nutzer nun zum betreffenden Feld geführt wird
+
 # 8.11.4
 - Behebt ein Problem, bei dem Netto-Preise den Express Checkout mit aktivem Versand-Callback fehlschlagen lies
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "8.11.4",
+    "version": "8.11.5",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
@@ -215,16 +215,36 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
     }
 
     /**
-     * Triggers the form validation
+     * Triggers the form validation and, when invalid, guides the user to the offending field.
      * @param _
      * @param {{reject: Function, resolve: Function}} actions
      * @returns {*}
      */
     onClick(_, actions) {
-        if (!this.confirmOrderForm.checkValidity()) {
-            return actions.reject();
+        if (this.confirmOrderForm.checkValidity()) {
+            return actions.resolve();
         }
 
-        return actions.resolve();
+        this.focusFirstInvalidField();
+
+        return actions.reject();
+    }
+
+    /**
+     * Scrolls to and focuses the first invalid field of the confirm form to guide the user to it.
+     *
+     * The required checkboxes (terms, revocation) are associated with the form via the `form`
+     * attribute but live outside of it in the DOM, so they are read from `form.elements`.
+     */
+    focusFirstInvalidField() {
+        const field = Array.from(this.confirmOrderForm.elements)
+            .find((element) => !element.validity.valid);
+
+        if (!field) {
+            return;
+        }
+
+        field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        field.focus();
     }
 }


### PR DESCRIPTION
Backport of the trunk fix to 6.5.x. The Smart Payment Buttons rejected the click when the confirm form was invalid (e.g. terms not accepted) without any feedback. Scroll to and focus the first invalid field so the user is guided to their mistake.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
backport of #710 
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
