### PR TITLE
fix(checkout): charge tax-provider-adjusted total instead of stale transaction amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
+
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)
 - Fixes an issue, where PayPal eligibility checks initialized PHP sessions during stateless Store API requests (shopware/SwagPayPal#740)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
+
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)
 - Behebt ein Problem, bei dem Prüfungen zur Verfügbarkeit von PayPal-Zahlungsarten bei zustandslosen Store-API-Anfragen PHP-Sitzungen initialisierten (shopware/SwagPayPal#740)

--- a/src/OrdersApi/Builder/AbstractOrderBuilder.php
+++ b/src/OrdersApi/Builder/AbstractOrderBuilder.php
@@ -113,8 +113,8 @@ abstract class AbstractOrderBuilder
         $items = $this->submitCart($order->getSalesChannelId()) ? $this->itemListProvider->getItemList($currency, $order) : null;
         $taxStatus = $order->getTaxStatus() ?? $order->getPrice()->getTaxStatus();
 
-        return $this->purchaseUnitProvider->createPurchaseUnit(
-            $orderTransaction->getAmount(),
+        return $this->purchaseUnitProvider->createPurchaseUnitFromPrice(
+            $order->getPrice(),
             $order->getShippingCosts(),
             null,
             $items,
@@ -130,8 +130,7 @@ abstract class AbstractOrderBuilder
         SalesChannelContext $salesChannelContext,
         Cart $cart,
     ): PurchaseUnit {
-        $cartTransaction = $cart->getTransactions()->first();
-        if ($cartTransaction === null) {
+        if ($cart->getTransactions()->first() === null) {
             throw PaymentException::invalidTransaction('');
         }
 
@@ -139,8 +138,8 @@ abstract class AbstractOrderBuilder
             ? $this->itemListProvider->getItemListFromCart($salesChannelContext->getCurrency(), $cart)
             : null;
 
-        return $this->purchaseUnitProvider->createPurchaseUnit(
-            $cartTransaction->getAmount(),
+        return $this->purchaseUnitProvider->createPurchaseUnitFromPrice(
+            $cart->getPrice(),
             $cart->getShippingCosts(),
             $salesChannelContext->getCustomer(),
             $items,

--- a/src/OrdersApi/Builder/Util/AmountProvider.php
+++ b/src/OrdersApi/Builder/Util/AmountProvider.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\OrdersApi\Builder\Util;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\PayPalSDK\Struct\V2\Common\Money;
@@ -30,8 +31,31 @@ class AmountProvider
         $this->priceFormatter = $priceFormatter;
     }
 
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed. Use {@see AmountProvider::createAmountFromPrice()} instead.
+     */
     public function createAmount(
         CalculatedPrice $totalAmount,
+        CalculatedPrice $shippingCosts,
+        CurrencyEntity $currency,
+        PurchaseUnit $purchaseUnit,
+        bool $isNet,
+    ): Amount {
+        return $this->buildAmount($totalAmount->getTotalPrice(), $shippingCosts, $currency, $purchaseUnit, $isNet);
+    }
+
+    public function createAmountFromPrice(
+        CartPrice $price,
+        CalculatedPrice $shippingCosts,
+        CurrencyEntity $currency,
+        PurchaseUnit $purchaseUnit,
+        bool $isNet,
+    ): Amount {
+        return $this->buildAmount($price->getTotalPrice(), $shippingCosts, $currency, $purchaseUnit, $isNet);
+    }
+
+    private function buildAmount(
+        float $totalPrice,
         CalculatedPrice $shippingCosts,
         CurrencyEntity $currency,
         PurchaseUnit $purchaseUnit,
@@ -41,7 +65,7 @@ class AmountProvider
 
         $amount = new Amount();
         $amount->setCurrencyCode($currencyCode);
-        $amount->setValue($this->priceFormatter->formatPrice($totalAmount->getTotalPrice(), $currencyCode));
+        $amount->setValue($this->priceFormatter->formatPrice($totalPrice, $currencyCode));
 
         $items = $purchaseUnit->getItems();
         if ($items !== null) {

--- a/src/OrdersApi/Builder/Util/PurchaseUnitProvider.php
+++ b/src/OrdersApi/Builder/Util/PurchaseUnitProvider.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal\OrdersApi\Builder\Util;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
@@ -50,8 +51,8 @@ class PurchaseUnitProvider
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function createPurchaseUnit(
-        CalculatedPrice $totalAmount,
+    public function createPurchaseUnitFromPrice(
+        CartPrice $price,
         CalculatedPrice $shippingCosts,
         ?CustomerEntity $customer,
         ?ItemCollection $itemList,
@@ -67,8 +68,8 @@ class PurchaseUnitProvider
             $purchaseUnit->setItems($itemList);
         }
 
-        $amount = $this->amountProvider->createAmount(
-            $totalAmount,
+        $amount = $this->amountProvider->createAmountFromPrice(
+            $price,
             $shippingCosts,
             $currency,
             $purchaseUnit,
@@ -98,6 +99,42 @@ class PurchaseUnitProvider
         }
 
         return $purchaseUnit;
+    }
+
+    /**
+     * @deprecated tag:v11.0.0 - Will be removed. Use {@see PurchaseUnitProvider::createPurchaseUnitFromPrice()} instead.
+     */
+    public function createPurchaseUnit(
+        CalculatedPrice $totalAmount,
+        CalculatedPrice $shippingCosts,
+        ?CustomerEntity $customer,
+        ?ItemCollection $itemList,
+        CurrencyEntity $currency,
+        Context $context,
+        bool $isNet,
+        ?OrderEntity $order = null,
+        ?OrderTransactionEntity $orderTransaction = null,
+    ): PurchaseUnit {
+        $price = new CartPrice(
+            $totalAmount->getTotalPrice(),
+            $totalAmount->getTotalPrice(),
+            $totalAmount->getTotalPrice(),
+            $totalAmount->getCalculatedTaxes(),
+            $totalAmount->getTaxRules(),
+            CartPrice::TAX_STATE_GROSS,
+        );
+
+        return $this->createPurchaseUnitFromPrice(
+            $price,
+            $shippingCosts,
+            $customer,
+            $itemList,
+            $currency,
+            $context,
+            $isNet,
+            $order,
+            $orderTransaction,
+        );
     }
 
     private function createShipping(?CustomerEntity $customer, ?OrderEntity $order): ?Shipping

--- a/src/OrdersApi/Patch/PurchaseUnitPatchBuilder.php
+++ b/src/OrdersApi/Patch/PurchaseUnitPatchBuilder.php
@@ -50,8 +50,8 @@ class PurchaseUnitPatchBuilder
 
         $taxStatus = $order->getTaxStatus() ?? $order->getPrice()->getTaxStatus();
 
-        $purchaseUnit = $this->purchaseUnitProvider->createPurchaseUnit(
-            $orderTransaction->getAmount(),
+        $purchaseUnit = $this->purchaseUnitProvider->createPurchaseUnitFromPrice(
+            $order->getPrice(),
             $order->getShippingCosts(),
             $customer,
             $itemList,

--- a/tests/Helper/OrderTransactionTrait.php
+++ b/tests/Helper/OrderTransactionTrait.php
@@ -194,7 +194,7 @@ trait OrderTransactionTrait
             [
                 'id' => $orderId,
                 'orderNumber' => $orderNumber,
-                'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
+                'price' => new CartPrice(20028, 20028, 20028, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
                 'stateId' => $this->getContainer()->get(InitialStateIdLoader::class)->get(OrderStates::STATE_MACHINE),
                 'versionId' => Defaults::LIVE_VERSION,

--- a/tests/OrdersApi/Builder/AbstractOrderBuilderTestCase.php
+++ b/tests/OrdersApi/Builder/AbstractOrderBuilderTestCase.php
@@ -250,6 +250,93 @@ abstract class AbstractOrderBuilderTestCase extends TestCase
         static::assertNull($purchaseUnit->getItems());
     }
 
+    public function testGetOrderFromCartUsesTaxAdjustedCartTotalNotStaleTransactionAmount(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+        $this->systemConfig->set(Settings::SUBMIT_CART, false);
+
+        // The cart transaction is calculated with the original product taxes, before a tax provider runs.
+        $cart = $this->createCart('', true, 10.0, 10.0);
+        // A tax provider (e.g. an app with net customer group) then adjusts the cart total. The transaction
+        // amount is not refreshed and stays stale - PayPal must be charged the adjusted total nonetheless.
+        $cart->setPrice($this->createCartPrice(15.0, 15.0, 15.0));
+
+        $order = $this->getBuilder()->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());
+
+        $purchaseUnit = $order->getPurchaseUnits()->first();
+        static::assertNotNull($purchaseUnit);
+        static::assertSame('15.00', $purchaseUnit->getAmount()->getValue());
+    }
+
+    public function testGetOrderFromCartWithSubmittedItemsChargesTaxAdjustedTotalAndReconcilesBreakdown(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+        // SUBMIT_CART is enabled by default in production, so the amount breakdown (items) is built as well.
+        $this->systemConfig->set(Settings::SUBMIT_CART, true);
+
+        // Transaction and line item carry the pre-tax-provider amounts.
+        $cart = $this->createCart('', true, 10.0, 10.0);
+        $cart->add($this->createLineItem(new CalculatedPrice(10.0, 10.0, new CalculatedTaxCollection(), new TaxRuleCollection())));
+        // A tax provider raises the cart total afterwards without refreshing the transaction or line items.
+        $cart->setPrice($this->createCartPrice(15.0, 15.0, 15.0));
+
+        $order = $this->getBuilder()->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag());
+
+        $purchaseUnit = $order->getPurchaseUnits()->first();
+        static::assertNotNull($purchaseUnit);
+
+        $amount = $purchaseUnit->getAmount();
+        static::assertSame('15.00', $amount->getValue());
+
+        // The breakdown must still reconcile to the adjusted top-line total (PayPal rejects mismatches).
+        $breakdown = $amount->getBreakdown();
+        static::assertNotNull($breakdown);
+        $itemTotal = $breakdown->getItemTotal();
+        $taxTotal = $breakdown->getTaxTotal();
+        $shipping = $breakdown->getShipping();
+        $handling = $breakdown->getHandling();
+        $discount = $breakdown->getDiscount();
+        static::assertNotNull($itemTotal);
+        static::assertNotNull($taxTotal);
+        static::assertNotNull($shipping);
+        static::assertNotNull($handling);
+        static::assertNotNull($discount);
+        $reconciled = (float) $itemTotal->getValue()
+            + (float) $taxTotal->getValue()
+            + (float) $shipping->getValue()
+            + (float) $handling->getValue()
+            - (float) $discount->getValue();
+        static::assertEqualsWithDelta(15.0, $reconciled, 0.001);
+    }
+
+    public function testGetOrderUsesTaxAdjustedOrderTotalNotStaleTransactionAmount(): void
+    {
+        $this->systemConfig->set(Settings::SUBMIT_CART, false);
+
+        // The order total (860.00) reflects the tax provider adjustment, but the order transaction was
+        // persisted with the pre-adjustment amount. PayPal must be charged the order total, not the transaction.
+        $order = $this->createOrder();
+        $orderTransaction = $this->createOrderTransaction();
+        $orderTransaction->setAmount(new CalculatedPrice(
+            700.0,
+            800.0,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection()
+        ));
+
+        $payPalOrder = $this->getBuilder()->getOrder(
+            new PaymentTransactionStruct($orderTransaction->getId()),
+            $orderTransaction,
+            $order,
+            Context::createDefaultContext(),
+            new Request(),
+        );
+
+        $purchaseUnit = $payPalOrder->getPurchaseUnits()->first();
+        static::assertNotNull($purchaseUnit);
+        static::assertSame('860.00', $purchaseUnit->getAmount()->getValue());
+    }
+
     public function testGetOrderWithProductWithZeroPrice(): void
     {
         $cart = $this->createCartWithLineItem(new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()));

--- a/tests/OrdersApi/Builder/Util/AmountProviderTest.php
+++ b/tests/OrdersApi/Builder/Util/AmountProviderTest.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Test\OrdersApi\Builder\Util;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
@@ -128,8 +129,8 @@ class AmountProviderTest extends TestCase
 
     private function createAmount(PurchaseUnit $purchaseUnit, float $total, float $shipping, bool $isNet = false): Amount
     {
-        return $this->amountProvider->createAmount(
-            new CalculatedPrice($total, $total, new CalculatedTaxCollection([new CalculatedTax($total - ($total / 1.19), 19.0, $total)]), new TaxRuleCollection()),
+        return $this->amountProvider->createAmountFromPrice(
+            new CartPrice($total, $total, $total, new CalculatedTaxCollection([new CalculatedTax($total - ($total / 1.19), 19.0, $total)]), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS),
             new CalculatedPrice($shipping, $shipping, new CalculatedTaxCollection([new CalculatedTax($shipping * 0.19, 19.0, $shipping)]), new TaxRuleCollection()),
             $this->getCurrency(),
             $purchaseUnit,


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The PayPal amount was built from the `cart/order transaction`, which is calculated before tax providers run and never refreshed. With a custom tax provider (e.g. net-price customer groups) it stayed stale, so PayPal charged the pre-adjustment total

### 2. What does this change do, exactly?
Derive the total from the cart/order price instead

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
- closes #722
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
