### PR TITLE
fix(ci): migrate OpenAPI processors to swagger-php 6.4 Undefined API

### DIFF
--- a/src/DevOps/OpenApi/PayPalApiStructSnakeCasePropertiesProcessor.php
+++ b/src/DevOps/OpenApi/PayPalApiStructSnakeCasePropertiesProcessor.php
@@ -9,7 +9,7 @@ namespace Swag\PayPal\DevOps\OpenApi;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
+use OpenApi\Undefined;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\Struct;
 use Shopware\PayPalSDK\Util\CaseConverter;
@@ -19,11 +19,11 @@ class PayPalApiStructSnakeCasePropertiesProcessor
 {
     public function __invoke(Analysis $analysis): void
     {
-        /** @var OA\Property[] $properties */
+        /** @var list<OA\Property> $properties */
         $properties = $analysis->getAnnotationsOfType(OA\Property::class);
 
         foreach ($properties as $property) {
-            if (Generator::isDefault($property->property) || !$property->_context?->namespace || !$property->_context->class || !$property->_context->property) {
+            if (Undefined::isDefault($property->property) || !$property->_context->namespace || !$property->_context->class || !$property->_context->property) {
                 continue;
             }
 

--- a/src/DevOps/OpenApi/RequireNonOptionalPropertiesProcessor.php
+++ b/src/DevOps/OpenApi/RequireNonOptionalPropertiesProcessor.php
@@ -9,7 +9,7 @@ namespace Swag\PayPal\DevOps\OpenApi;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
+use OpenApi\Undefined;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('checkout')]
@@ -17,23 +17,23 @@ class RequireNonOptionalPropertiesProcessor
 {
     public function __invoke(Analysis $analysis): void
     {
-        /** @var OA\Schema[] $schemas */
+        /** @var list<OA\Schema> $schemas */
         $schemas = $analysis->getAnnotationsOfType(OA\Schema::class, true);
 
         foreach ($schemas as $schema) {
-            if (!$schema->_context?->is('class') || !Generator::isDefault($schema->required)) {
+            if (!$schema->_context->is('class') || !Undefined::isDefault($schema->required)) {
                 continue;
             }
 
             $this->requireProps($schema);
 
-            if (!Generator::isDefault($schema->allOf)) {
+            if (!Undefined::isDefault($schema->allOf)) {
                 foreach ($schema->allOf as $item) {
                     $this->requireProps($item);
                 }
             }
 
-            if (!Generator::isDefault($schema->anyOf)) {
+            if (!Undefined::isDefault($schema->anyOf)) {
                 foreach ($schema->anyOf as $item) {
                     $this->requireProps($item);
                 }
@@ -43,13 +43,13 @@ class RequireNonOptionalPropertiesProcessor
 
     private function requireProps(OA\Schema $schema): void
     {
-        if (Generator::isDefault($schema->properties)) {
+        if (Undefined::isDefault($schema->properties)) {
             return;
         }
 
-        $required = Generator::isDefault($schema->required) ? [] : $schema->required;
+        $required = Undefined::isDefault($schema->required) ? [] : $schema->required;
         foreach ($schema->properties as $property) {
-            if (Generator::isDefault($property->property) || !Generator::isDefault($property->default)) {
+            if (Undefined::isDefault($property->property) || !Undefined::isDefault($property->default)) {
                 continue;
             }
 

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -1617,9 +1617,9 @@
                     "country_code": {
                         "description": "The 2-character ISO 3166-1 alpha-2 country code",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -2454,9 +2454,9 @@
                     "email_address": {
                         "description": "The internationalized email address.\nNote: Up to 64 characters are allowed before and 255 characters are allowed after the @ sign.\nHowever, the generally accepted maximum length for an email address is 254 characters.\nThe pattern verifies that an unquoted @ sign exists.",
                         "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$",
                         "maxLength": 254,
-                        "minLength": 3,
-                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+                        "minLength": 3
                     }
                 },
                 "type": "object"
@@ -2510,16 +2510,16 @@
                     "subdivision": {
                         "description": "Administrative subdivision code (state, province, region).\nISO 3166-2 format without country prefix (e.g., 'CA' for California, 'ON' for Ontario).",
                         "type": "string",
+                        "pattern": "^[A-Z0-9-]+$",
                         "maxLength": 10,
-                        "minLength": 1,
-                        "pattern": "^[A-Z0-9-]+$"
+                        "minLength": 1
                     },
                     "country_code": {
                         "description": "ISO 3166-1 alpha-2 country code for the coordinate location.",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -2544,9 +2544,9 @@
                     "delivery_date": {
                         "description": "Scheduled delivery date in RFC3339 format. Seconds are required while fractional seconds are optional.\n\nexample: 2024-12-25T09:00:00Z",
                         "type": "string",
+                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
                         "maxLength": 64,
-                        "minLength": 20,
-                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+                        "minLength": 20
                     },
                     "sender_name": {
                         "description": "Name of gift sender",
@@ -2612,16 +2612,16 @@
                     "currency_code": {
                         "description": "The 3-character ISO-4217 currency code that identifies the currency.",
                         "type": "string",
+                        "pattern": "^[\\S\\s]*$",
                         "maxLength": 3,
-                        "minLength": 3,
-                        "pattern": "^[\\S\\s]*$"
+                        "minLength": 3
                     },
                     "value": {
                         "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional. A decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see Currency Codes.",
                         "type": "string",
+                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$",
                         "maxLength": 0,
-                        "minLength": 32,
-                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+                        "minLength": 32
                     }
                 },
                 "type": "object"
@@ -2638,22 +2638,22 @@
                     },
                     "status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "CREATED",
                             "COMPLETE",
                             "READY",
                             "INCOMPLETE"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "VALID",
                             "INVALID",
                             "REQUIRES_ADDITIONAL_INFORMATION"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_issues": {
                         "description": "List of issues preventing checkout (empty = ready)",
@@ -2761,23 +2761,23 @@
                     "country_code": {
                         "description": "The country calling code (CC), in its canonical international E.164 numbering plan format.\nThe combined length of the CC and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN)",
                         "type": "string",
+                        "pattern": "^[0-9]{1,3}?$",
                         "maxLength": 3,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,3}?$"
+                        "minLength": 1
                     },
                     "national_number": {
                         "description": "The national number, in its canonical international E.164 numbering plan format.\nThe combined length of the country calling code (CC) and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN).",
                         "type": "string",
+                        "pattern": "^[0-9]{1,14}?$",
                         "maxLength": 14,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,14}?$"
+                        "minLength": 1
                     },
                     "extension_number": {
                         "description": "The extension number",
                         "type": "string",
+                        "pattern": "^[0-9]{1,15}?$",
                         "maxLength": 15,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,15}?$"
+                        "minLength": 1
                     }
                 },
                 "type": "object"
@@ -4010,6 +4010,7 @@
                     },
                     "dispute_state": {
                         "type": "string",
+                        "nullable": true,
                         "enum": [
                             "REQUIRED_ACTION",
                             "REQUIRED_OTHER_PARTY_ACTION",
@@ -4017,8 +4018,7 @@
                             "RESOLVED",
                             "OPEN_INQUIRIES",
                             "APPEALABLE"
-                        ],
-                        "nullable": true
+                        ]
                     },
                     "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_disputes_item_dispute_amount"
@@ -5306,8 +5306,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "tax": {
                         "type": "string"
@@ -6536,31 +6536,31 @@
                     "address_line_1": {
                         "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "address_line_2": {
                         "description": "The second line of the address. For example, suite or apartment number.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "admin_area_2": {
                         "description": "A city, town, or village. Smaller than $adminArea1",
                         "type": "string",
-                        "maxLength": 120,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 120
                     },
                     "admin_area_1": {
                         "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "postal_code": {
                         "type": "string",
-                        "maxLength": 60,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 60
                     },
                     "country_code": {
                         "type": "string",
@@ -6663,6 +6663,17 @@
                         "type": "string",
                         "maxLength": 17,
                         "minLength": 6
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_confirm_order": {
+                "required": [
+                    "payment_source"
+                ],
+                "properties": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
                     }
                 },
                 "type": "object"
@@ -8602,8 +8613,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     }
                 },
                 "type": "object"
@@ -8789,13 +8800,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_protection": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
@@ -8920,13 +8931,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_payable_breakdown": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown"
@@ -9042,18 +9053,18 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     },
                     "image_url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     }
                 },
                 "type": "object"
@@ -9336,8 +9347,6 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "array",
-                        "items": {},
                         "nullable": true,
                         "oneOf": [
                             {

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -305,9 +305,9 @@
                     "country_code": {
                         "description": "The 2-character ISO 3166-1 alpha-2 country code",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -1142,9 +1142,9 @@
                     "email_address": {
                         "description": "The internationalized email address.\nNote: Up to 64 characters are allowed before and 255 characters are allowed after the @ sign.\nHowever, the generally accepted maximum length for an email address is 254 characters.\nThe pattern verifies that an unquoted @ sign exists.",
                         "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$",
                         "maxLength": 254,
-                        "minLength": 3,
-                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+                        "minLength": 3
                     }
                 },
                 "type": "object"
@@ -1198,16 +1198,16 @@
                     "subdivision": {
                         "description": "Administrative subdivision code (state, province, region).\nISO 3166-2 format without country prefix (e.g., 'CA' for California, 'ON' for Ontario).",
                         "type": "string",
+                        "pattern": "^[A-Z0-9-]+$",
                         "maxLength": 10,
-                        "minLength": 1,
-                        "pattern": "^[A-Z0-9-]+$"
+                        "minLength": 1
                     },
                     "country_code": {
                         "description": "ISO 3166-1 alpha-2 country code for the coordinate location.",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -1232,9 +1232,9 @@
                     "delivery_date": {
                         "description": "Scheduled delivery date in RFC3339 format. Seconds are required while fractional seconds are optional.\n\nexample: 2024-12-25T09:00:00Z",
                         "type": "string",
+                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
                         "maxLength": 64,
-                        "minLength": 20,
-                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+                        "minLength": 20
                     },
                     "sender_name": {
                         "description": "Name of gift sender",
@@ -1300,16 +1300,16 @@
                     "currency_code": {
                         "description": "The 3-character ISO-4217 currency code that identifies the currency.",
                         "type": "string",
+                        "pattern": "^[\\S\\s]*$",
                         "maxLength": 3,
-                        "minLength": 3,
-                        "pattern": "^[\\S\\s]*$"
+                        "minLength": 3
                     },
                     "value": {
                         "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional. A decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see Currency Codes.",
                         "type": "string",
+                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$",
                         "maxLength": 0,
-                        "minLength": 32,
-                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+                        "minLength": 32
                     }
                 },
                 "type": "object"
@@ -1326,22 +1326,22 @@
                     },
                     "status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "CREATED",
                             "COMPLETE",
                             "READY",
                             "INCOMPLETE"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "VALID",
                             "INVALID",
                             "REQUIRES_ADDITIONAL_INFORMATION"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_issues": {
                         "description": "List of issues preventing checkout (empty = ready)",
@@ -1449,23 +1449,23 @@
                     "country_code": {
                         "description": "The country calling code (CC), in its canonical international E.164 numbering plan format.\nThe combined length of the CC and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN)",
                         "type": "string",
+                        "pattern": "^[0-9]{1,3}?$",
                         "maxLength": 3,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,3}?$"
+                        "minLength": 1
                     },
                     "national_number": {
                         "description": "The national number, in its canonical international E.164 numbering plan format.\nThe combined length of the country calling code (CC) and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN).",
                         "type": "string",
+                        "pattern": "^[0-9]{1,14}?$",
                         "maxLength": 14,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,14}?$"
+                        "minLength": 1
                     },
                     "extension_number": {
                         "description": "The extension number",
                         "type": "string",
+                        "pattern": "^[0-9]{1,15}?$",
                         "maxLength": 15,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,15}?$"
+                        "minLength": 1
                     }
                 },
                 "type": "object"
@@ -2698,6 +2698,7 @@
                     },
                     "dispute_state": {
                         "type": "string",
+                        "nullable": true,
                         "enum": [
                             "REQUIRED_ACTION",
                             "REQUIRED_OTHER_PARTY_ACTION",
@@ -2705,8 +2706,7 @@
                             "RESOLVED",
                             "OPEN_INQUIRIES",
                             "APPEALABLE"
-                        ],
-                        "nullable": true
+                        ]
                     },
                     "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_disputes_item_dispute_amount"
@@ -3994,8 +3994,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "tax": {
                         "type": "string"
@@ -5224,31 +5224,31 @@
                     "address_line_1": {
                         "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "address_line_2": {
                         "description": "The second line of the address. For example, suite or apartment number.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "admin_area_2": {
                         "description": "A city, town, or village. Smaller than $adminArea1",
                         "type": "string",
-                        "maxLength": 120,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 120
                     },
                     "admin_area_1": {
                         "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "postal_code": {
                         "type": "string",
-                        "maxLength": 60,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 60
                     },
                     "country_code": {
                         "type": "string",
@@ -5351,6 +5351,17 @@
                         "type": "string",
                         "maxLength": 17,
                         "minLength": 6
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_confirm_order": {
+                "required": [
+                    "payment_source"
+                ],
+                "properties": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
                     }
                 },
                 "type": "object"
@@ -7290,8 +7301,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     }
                 },
                 "type": "object"
@@ -7477,13 +7488,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_protection": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
@@ -7608,13 +7619,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_payable_breakdown": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown"
@@ -7730,18 +7741,18 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     },
                     "image_url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     }
                 },
                 "type": "object"
@@ -8024,8 +8035,6 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "array",
-                        "items": {},
                         "nullable": true,
                         "oneOf": [
                             {

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -2067,6 +2067,9 @@ export interface components {
             type: string;
             code: string;
         };
+        paypal_v2_confirm_order: {
+            payment_source: components["schemas"]["paypal_v2_order_payment_source"];
+        };
         paypal_v2_eligible_methods_data: {
             eligible_methods: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods"];
             supplementary_data: components["schemas"]["paypal_v2_eligible_methods_data_supplementary_data"];
@@ -2668,7 +2671,7 @@ export interface components {
         paypal_v2_patch: {
             op: string;
             path: string;
-            value: (unknown[] & (number | Record<string, unknown> | string | boolean | Record<string, unknown>[])) | null;
+            value: (number | Record<string, unknown> | string | boolean | Record<string, unknown>[]) | null;
             from: string;
         };
         paypal_v2_referral: {

--- a/tests/OpenAPISchemaTest.php
+++ b/tests/OpenAPISchemaTest.php
@@ -14,6 +14,7 @@ use Monolog\LogRecord;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Operation;
 use OpenApi\Generator;
+use OpenApi\Undefined;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCategoryRoute;
@@ -93,7 +94,7 @@ class OpenAPISchemaTest extends TestCase
         $failures = [];
 
         foreach ($this->oa->_analysis->annotations as $annotation) {
-            if (!$annotation instanceof Operation || !$annotation->_context?->class || !$annotation->_context->namespace || !$annotation->_context->method) {
+            if (!$annotation instanceof Operation || !$annotation->_context->class || !$annotation->_context->namespace || !$annotation->_context->method) {
                 continue;
             }
 
@@ -123,7 +124,7 @@ class OpenAPISchemaTest extends TestCase
             if (!\in_array($annotation->method, $routeMethods, true)) {
                 $failures[] = $fqdn . ' was expected to have a method of "' . \implode('" or "', $routeMethods) . '", but found "' . $annotation->method . '" in OpenAPI Schema';
             } else {
-                if ($annotation->method === 'GET' && $annotation->requestBody !== Generator::UNDEFINED) {
+                if ($annotation->method === 'GET' && $annotation->requestBody !== Undefined::UNDEFINED) {
                     $failures[] = $fqdn . ' is a GET-Request and was not expected to have a request body';
                 }
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution)

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

CI runs against swagger-php 6.4, but the DevOps OpenAPI processors, the schema test, and the committed schema files still target the old API — so PHPStan (deprecated `Generator::isDefault()`/`UNDEFINED`, nullsafe on the now non-nullable `Context`) and the OpenAPI schema check both fail

### 2. What does this change do, exactly?

Migrates the DevOps OpenAPI code off the swagger-php APIs that 6.4 deprecated:

- Uses `OpenApi\Undefined::isDefault()` / `Undefined::UNDEFINED` instead of the deprecated `Generator::isDefault()` / `Generator::UNDEFINED`. These check swagger-php's "property was never set" sentinel; 6.4 moved them from `Generator` to the dedicated `Undefined` class
- Drops the `_context?->` nullsafe access, since `Context` is non-nullable in 6.4
- Tightens the `@var array<...>` PHPDoc to `@var list<...>` to match `Analysis::getAnnotationsOfType()`
- Regenerates `openapi.json` (Store + Admin) and the admin `openapi.d.ts` with swagger-php 6.4


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
