### PR TITLE
fix(ci): keep OpenAPI DevOps code compatible with swagger-php 6.4 and 6.7.0.0

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -188,6 +188,30 @@ parameters:
           message: '#tag:v11.0.0 reason:parameter-type-change - `\$countryCode` will be renamed to `\$currencyIso`#'
           path: '**/*.php'
 
+        # swagger-php 6.4 (Shopware trunk matrix) moves the "not set" sentinel from OpenApi\Generator to
+        # OpenApi\Undefined and makes OpenApi\Context non-nullable. The v6.7.0.0 matrix still ships the older
+        # API, so we keep the version-agnostic calls (Generator::isDefault()/UNDEFINED and nullsafe _context)
+        # and suppress the 6.4-only notices here. These stay unmatched on 6.7.0.0, which is fine because CI
+        # runs with reportUnmatchedIgnoredErrors=false.
+        - # swagger-php 6.4 deprecation - Generator::isDefault() moved to OpenApi\Undefined::isDefault()
+            identifier: staticMethod.deprecated
+            message: '#Call to deprecated method isDefault\(\) of class OpenApi\\Generator#'
+            paths:
+                - src/DevOps/OpenApi
+                - tests/OpenAPISchemaTest.php
+
+        - # swagger-php 6.4 deprecation - Generator::UNDEFINED moved to OpenApi\Undefined::UNDEFINED
+            identifier: classConstant.deprecated
+            message: '#Fetching deprecated class constant UNDEFINED of class OpenApi\\Generator#'
+            path: tests/OpenAPISchemaTest.php
+
+        - # swagger-php 6.4 makes OpenApi\Context non-nullable; the nullsafe operator is still required on 6.7.0.0
+            identifier: nullsafe.neverNull
+            message: '#Using nullsafe (property access|method call) on non-nullable type OpenApi\\Context#'
+            paths:
+                - src/DevOps/OpenApi
+                - tests/OpenAPISchemaTest.php
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Internal\InternalClassRule

--- a/src/DevOps/OpenApi/PayPalApiStructSnakeCasePropertiesProcessor.php
+++ b/src/DevOps/OpenApi/PayPalApiStructSnakeCasePropertiesProcessor.php
@@ -19,7 +19,7 @@ class PayPalApiStructSnakeCasePropertiesProcessor
 {
     public function __invoke(Analysis $analysis): void
     {
-        /** @var OA\Property[] $properties */
+        /** @var list<OA\Property> $properties */
         $properties = $analysis->getAnnotationsOfType(OA\Property::class);
 
         foreach ($properties as $property) {

--- a/src/DevOps/OpenApi/RequireNonOptionalPropertiesProcessor.php
+++ b/src/DevOps/OpenApi/RequireNonOptionalPropertiesProcessor.php
@@ -17,7 +17,7 @@ class RequireNonOptionalPropertiesProcessor
 {
     public function __invoke(Analysis $analysis): void
     {
-        /** @var OA\Schema[] $schemas */
+        /** @var list<OA\Schema> $schemas */
         $schemas = $analysis->getAnnotationsOfType(OA\Schema::class, true);
 
         foreach ($schemas as $schema) {

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -1617,9 +1617,9 @@
                     "country_code": {
                         "description": "The 2-character ISO 3166-1 alpha-2 country code",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -2454,9 +2454,9 @@
                     "email_address": {
                         "description": "The internationalized email address.\nNote: Up to 64 characters are allowed before and 255 characters are allowed after the @ sign.\nHowever, the generally accepted maximum length for an email address is 254 characters.\nThe pattern verifies that an unquoted @ sign exists.",
                         "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$",
                         "maxLength": 254,
-                        "minLength": 3,
-                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+                        "minLength": 3
                     }
                 },
                 "type": "object"
@@ -2510,16 +2510,16 @@
                     "subdivision": {
                         "description": "Administrative subdivision code (state, province, region).\nISO 3166-2 format without country prefix (e.g., 'CA' for California, 'ON' for Ontario).",
                         "type": "string",
+                        "pattern": "^[A-Z0-9-]+$",
                         "maxLength": 10,
-                        "minLength": 1,
-                        "pattern": "^[A-Z0-9-]+$"
+                        "minLength": 1
                     },
                     "country_code": {
                         "description": "ISO 3166-1 alpha-2 country code for the coordinate location.",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -2544,9 +2544,9 @@
                     "delivery_date": {
                         "description": "Scheduled delivery date in RFC3339 format. Seconds are required while fractional seconds are optional.\n\nexample: 2024-12-25T09:00:00Z",
                         "type": "string",
+                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
                         "maxLength": 64,
-                        "minLength": 20,
-                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+                        "minLength": 20
                     },
                     "sender_name": {
                         "description": "Name of gift sender",
@@ -2612,16 +2612,16 @@
                     "currency_code": {
                         "description": "The 3-character ISO-4217 currency code that identifies the currency.",
                         "type": "string",
+                        "pattern": "^[\\S\\s]*$",
                         "maxLength": 3,
-                        "minLength": 3,
-                        "pattern": "^[\\S\\s]*$"
+                        "minLength": 3
                     },
                     "value": {
                         "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional. A decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see Currency Codes.",
                         "type": "string",
+                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$",
                         "maxLength": 0,
-                        "minLength": 32,
-                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+                        "minLength": 32
                     }
                 },
                 "type": "object"
@@ -2638,22 +2638,22 @@
                     },
                     "status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "CREATED",
                             "COMPLETE",
                             "READY",
                             "INCOMPLETE"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "VALID",
                             "INVALID",
                             "REQUIRES_ADDITIONAL_INFORMATION"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_issues": {
                         "description": "List of issues preventing checkout (empty = ready)",
@@ -2761,23 +2761,23 @@
                     "country_code": {
                         "description": "The country calling code (CC), in its canonical international E.164 numbering plan format.\nThe combined length of the CC and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN)",
                         "type": "string",
+                        "pattern": "^[0-9]{1,3}?$",
                         "maxLength": 3,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,3}?$"
+                        "minLength": 1
                     },
                     "national_number": {
                         "description": "The national number, in its canonical international E.164 numbering plan format.\nThe combined length of the country calling code (CC) and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN).",
                         "type": "string",
+                        "pattern": "^[0-9]{1,14}?$",
                         "maxLength": 14,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,14}?$"
+                        "minLength": 1
                     },
                     "extension_number": {
                         "description": "The extension number",
                         "type": "string",
+                        "pattern": "^[0-9]{1,15}?$",
                         "maxLength": 15,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,15}?$"
+                        "minLength": 1
                     }
                 },
                 "type": "object"
@@ -4010,6 +4010,7 @@
                     },
                     "dispute_state": {
                         "type": "string",
+                        "nullable": true,
                         "enum": [
                             "REQUIRED_ACTION",
                             "REQUIRED_OTHER_PARTY_ACTION",
@@ -4017,8 +4018,7 @@
                             "RESOLVED",
                             "OPEN_INQUIRIES",
                             "APPEALABLE"
-                        ],
-                        "nullable": true
+                        ]
                     },
                     "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_disputes_item_dispute_amount"
@@ -5306,8 +5306,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "tax": {
                         "type": "string"
@@ -6536,31 +6536,31 @@
                     "address_line_1": {
                         "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "address_line_2": {
                         "description": "The second line of the address. For example, suite or apartment number.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "admin_area_2": {
                         "description": "A city, town, or village. Smaller than $adminArea1",
                         "type": "string",
-                        "maxLength": 120,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 120
                     },
                     "admin_area_1": {
                         "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "postal_code": {
                         "type": "string",
-                        "maxLength": 60,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 60
                     },
                     "country_code": {
                         "type": "string",
@@ -8602,8 +8602,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     }
                 },
                 "type": "object"
@@ -8789,13 +8789,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_protection": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
@@ -8920,13 +8920,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_payable_breakdown": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown"
@@ -9042,18 +9042,18 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     },
                     "image_url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     }
                 },
                 "type": "object"
@@ -9336,8 +9336,6 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "array",
-                        "items": {},
                         "nullable": true,
                         "oneOf": [
                             {

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -305,9 +305,9 @@
                     "country_code": {
                         "description": "The 2-character ISO 3166-1 alpha-2 country code",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -1142,9 +1142,9 @@
                     "email_address": {
                         "description": "The internationalized email address.\nNote: Up to 64 characters are allowed before and 255 characters are allowed after the @ sign.\nHowever, the generally accepted maximum length for an email address is 254 characters.\nThe pattern verifies that an unquoted @ sign exists.",
                         "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$",
                         "maxLength": 254,
-                        "minLength": 3,
-                        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+                        "minLength": 3
                     }
                 },
                 "type": "object"
@@ -1198,16 +1198,16 @@
                     "subdivision": {
                         "description": "Administrative subdivision code (state, province, region).\nISO 3166-2 format without country prefix (e.g., 'CA' for California, 'ON' for Ontario).",
                         "type": "string",
+                        "pattern": "^[A-Z0-9-]+$",
                         "maxLength": 10,
-                        "minLength": 1,
-                        "pattern": "^[A-Z0-9-]+$"
+                        "minLength": 1
                     },
                     "country_code": {
                         "description": "ISO 3166-1 alpha-2 country code for the coordinate location.",
                         "type": "string",
+                        "pattern": "^[A-Z]{2}$",
                         "maxLength": 2,
-                        "minLength": 2,
-                        "pattern": "^[A-Z]{2}$"
+                        "minLength": 2
                     }
                 },
                 "type": "object"
@@ -1232,9 +1232,9 @@
                     "delivery_date": {
                         "description": "Scheduled delivery date in RFC3339 format. Seconds are required while fractional seconds are optional.\n\nexample: 2024-12-25T09:00:00Z",
                         "type": "string",
+                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
                         "maxLength": 64,
-                        "minLength": 20,
-                        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+                        "minLength": 20
                     },
                     "sender_name": {
                         "description": "Name of gift sender",
@@ -1300,16 +1300,16 @@
                     "currency_code": {
                         "description": "The 3-character ISO-4217 currency code that identifies the currency.",
                         "type": "string",
+                        "pattern": "^[\\S\\s]*$",
                         "maxLength": 3,
-                        "minLength": 3,
-                        "pattern": "^[\\S\\s]*$"
+                        "minLength": 3
                     },
                     "value": {
                         "description": "The value, which might be: An integer for currencies like JPY that are not typically fractional. A decimal fraction for currencies like TND that are subdivided into thousandths. For the required number of decimal places for a currency code, see Currency Codes.",
                         "type": "string",
+                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$",
                         "maxLength": 0,
-                        "minLength": 32,
-                        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+                        "minLength": 32
                     }
                 },
                 "type": "object"
@@ -1326,22 +1326,22 @@
                     },
                     "status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "CREATED",
                             "COMPLETE",
                             "READY",
                             "INCOMPLETE"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_status": {
                         "type": "string",
+                        "readOnly": true,
                         "enum": [
                             "VALID",
                             "INVALID",
                             "REQUIRES_ADDITIONAL_INFORMATION"
-                        ],
-                        "readOnly": true
+                        ]
                     },
                     "validation_issues": {
                         "description": "List of issues preventing checkout (empty = ready)",
@@ -1449,23 +1449,23 @@
                     "country_code": {
                         "description": "The country calling code (CC), in its canonical international E.164 numbering plan format.\nThe combined length of the CC and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN)",
                         "type": "string",
+                        "pattern": "^[0-9]{1,3}?$",
                         "maxLength": 3,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,3}?$"
+                        "minLength": 1
                     },
                     "national_number": {
                         "description": "The national number, in its canonical international E.164 numbering plan format.\nThe combined length of the country calling code (CC) and the national number must not be greater than 15 digits.\nThe national number consists of a national destination code (NDC) and subscriber number (SN).",
                         "type": "string",
+                        "pattern": "^[0-9]{1,14}?$",
                         "maxLength": 14,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,14}?$"
+                        "minLength": 1
                     },
                     "extension_number": {
                         "description": "The extension number",
                         "type": "string",
+                        "pattern": "^[0-9]{1,15}?$",
                         "maxLength": 15,
-                        "minLength": 1,
-                        "pattern": "^[0-9]{1,15}?$"
+                        "minLength": 1
                     }
                 },
                 "type": "object"
@@ -2698,6 +2698,7 @@
                     },
                     "dispute_state": {
                         "type": "string",
+                        "nullable": true,
                         "enum": [
                             "REQUIRED_ACTION",
                             "REQUIRED_OTHER_PARTY_ACTION",
@@ -2705,8 +2706,7 @@
                             "RESOLVED",
                             "OPEN_INQUIRIES",
                             "APPEALABLE"
-                        ],
-                        "nullable": true
+                        ]
                     },
                     "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_disputes_item_dispute_amount"
@@ -3994,8 +3994,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "tax": {
                         "type": "string"
@@ -5224,31 +5224,31 @@
                     "address_line_1": {
                         "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "address_line_2": {
                         "description": "The second line of the address. For example, suite or apartment number.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "admin_area_2": {
                         "description": "A city, town, or village. Smaller than $adminArea1",
                         "type": "string",
-                        "maxLength": 120,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 120
                     },
                     "admin_area_1": {
                         "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
                         "type": "string",
-                        "maxLength": 300,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 300
                     },
                     "postal_code": {
                         "type": "string",
-                        "maxLength": 60,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 60
                     },
                     "country_code": {
                         "type": "string",
@@ -7290,8 +7290,8 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     }
                 },
                 "type": "object"
@@ -7477,13 +7477,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_protection": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
@@ -7608,13 +7608,13 @@
                     },
                     "invoice_id": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "note_to_payer": {
                         "type": "string",
-                        "maxLength": 255,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 255
                     },
                     "seller_payable_breakdown": {
                         "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown"
@@ -7730,18 +7730,18 @@
                     },
                     "sku": {
                         "type": "string",
-                        "maxLength": 127,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 127
                     },
                     "url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     },
                     "image_url": {
                         "type": "string",
-                        "maxLength": 2048,
-                        "nullable": true
+                        "nullable": true,
+                        "maxLength": 2048
                     }
                 },
                 "type": "object"
@@ -8024,8 +8024,6 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "array",
-                        "items": {},
                         "nullable": true,
                         "oneOf": [
                             {

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -2668,7 +2668,7 @@ export interface components {
         paypal_v2_patch: {
             op: string;
             path: string;
-            value: (unknown[] & (number | Record<string, unknown> | string | boolean | Record<string, unknown>[])) | null;
+            value: (number | Record<string, unknown> | string | boolean | Record<string, unknown>[]) | null;
             from: string;
         };
         paypal_v2_referral: {


### PR DESCRIPTION
### 1. Why is this change necessary?

The CI `trunk` matrix installs **swagger-php 6.4**, which:

- deprecates `OpenApi\Generator::isDefault()` / `Generator::UNDEFINED` (the "property was never set" sentinel moved to the dedicated `OpenApi\Undefined` class), and
- makes `OpenApi\Context` non-nullable.

As a result PHPStan fails on the DevOps OpenAPI processors and the schema test on every PR (e.g. #699), and `trunk` itself will re-break on its next run. `#743` already adapted the generator to the removed `Util::finder` / `Generator::scan` APIs, but not these deprecations.

The catch is that the `v6.7.0.0` matrix still ships the **older** swagger-php, where `OpenApi\Undefined` does not exist and `Context` is nullable. So simply migrating to the new symbols (as attempted in the now-closed #749) just moves the failure to the `v6.7.0.0` matrix:

```
Call to static method isDefault() on an unknown class OpenApi\Undefined.
Access to constant UNDEFINED on an unknown class OpenApi\Undefined.
Cannot access property $class on OpenApi\Context|null.
```

The code has to satisfy **both** swagger-php versions at once.

### 2. What does this change do, exactly?

- Keeps the version-agnostic runtime calls: `Generator::isDefault()` / `Generator::UNDEFINED` still exist on 6.4 (only deprecated), and the nullsafe `_context?->` access is still required on 6.7.0.0.
- Suppresses only the **6.4-specific** PHPStan notices via scoped `ignoreErrors` (`staticMethod.deprecated`, `classConstant.deprecated`, `nullsafe.neverNull`), limited to `src/DevOps/OpenApi` and `tests/OpenAPISchemaTest.php`. These stay unmatched on the `v6.7.0.0` matrix, which is harmless because CI runs with `reportUnmatchedIgnoredErrors=false`.
- Tightens `@var array<...>` PHPDoc to `@var list<...>` to match `Analysis::getAnnotationsOfType()` on both versions (a real fix, not a suppression).
- Does **not** regenerate the schema files. `openapi.json` is left as `trunk`'s (`#743`) version, which already matches CI generation — this avoids the schema mismatch that also broke #749's `validate-openapi-typescript`.

### 3. Describe each step to reproduce the issue or behaviour.

Run the `phpstan (trunk)` matrix job (swagger-php 6.4) against `trunk` without this change.

### 4. Please link to the relevant issues (if any).

- relates #743
- supersedes #749

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (n/a — CI-only fix; verified by the existing `phpstan` + `validate-openapi-typescript` matrix jobs)
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
