### PR TITLE
Backport 10.8.0 fixes to 6.6.x (9.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-# 9.12.5
+# 9.13.0
 - Fixes an issue, where the Smart Payment Buttons failed silently when the terms and conditions were not accepted, by guiding the user to the invalid field
+- Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)
+- Fixes an issue, where PayPal eligibility checks initialized PHP sessions during stateless Store API requests (shopware/SwagPayPal#740)
+- Fixes an issue, where PayPal Express Checkout in a stale offcanvas cart could call the PayPal API with an empty cart and fail without customer feedback (shopware/SwagPayPal#712)
+- Fixes an issue, where the Google Pay button was always displayed in English instead of the sales channel language (shopware/shopware#17804)
+- Fixes an issue, where card payments without 3D Secure data were rejected even when `ACDC_FORCE_3DS` was disabled (shopware/SwagPayPal#714)
+- Changes disabled "Enforce 3D Secure" to allow no 3DS challenge if not required
 
 # 9.12.4
 - Fixes an issue, where net prices could cause the express checkout with shipping callback enabled to fail

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,11 @@
-# 9.12.5
+# 9.13.0
 - Behebt ein Problem, bei dem die Smart Payment Buttons ohne sichtbare Rückmeldung fehlschlugen, wenn die AGB nicht akzeptiert wurden, indem der Nutzer nun zum betreffenden Feld geführt wird
+- Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)
+- Behebt ein Problem, bei dem Prüfungen zur Verfügbarkeit von PayPal-Zahlungsarten bei zustandslosen Store-API-Anfragen PHP-Sitzungen initialisierten (shopware/SwagPayPal#740)
+- Behebt ein Problem, bei dem PayPal Express Checkout in einem veralteten Offcanvas-Warenkorb die PayPal-API mit leerem Warenkorb aufrufen konnte und ohne Rückmeldung für den Kunden fehlschlug (shopware/SwagPayPal#712)
+- Behebt ein Problem, bei dem der Google Pay Button immer auf Englisch statt in der Verkaufskanal-Sprache angezeigt wurde (shopware/shopware#17804)
+- Behebt ein Problem, bei dem Kartenzahlungen ohne 3D-Secure-Daten abgelehnt wurden, obwohl `ACDC_FORCE_3DS` deaktiviert war (shopware/SwagPayPal#714)
+- Deaktiviertes „3D Secure erzwingen” erlaubt nun, dass keine 3DS-Abfrage erfolgt, wenn sie nicht erforderlich ist
 
 # 9.12.4
 - Behebt ein Problem, bei dem Netto-Preise den Express Checkout mit aktivem Versand-Callback fehlschlagen lies

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "9.12.5",
+    "version": "9.13.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,8 +27,12 @@ parameters:
         constantHassers: false
 
     ignoreErrors:
+        - # WebhookSystemConfigController decorates the core SystemConfigController to (de)register webhooks on settings save and must keep its class-level route scope for the inherited route methods. Deprecated (tag:v10.0.0) and removed on the 6.7 line.
+            message: '#is a decorator but overrides @Route attributes#'
+            path: src/Webhook/Registration/WebhookSystemConfigController.php
+
         - # in tests, we can use internal methods
-            message: '#(internal.*from outside its root namespace Shopware\.)|(internal class Shopware\\Core)#'
+            message: '#(internal.*from outside its root namespace)|(internal class Shopware\\Core)#'
             path: tests/*.php
 
         - # ignore package annotation, as it is required

--- a/src/Checkout/Card/AbstractCardValidator.php
+++ b/src/Checkout/Card/AbstractCardValidator.php
@@ -42,7 +42,7 @@ abstract class AbstractCardValidator implements CardValidatorInterface
         $threeDSecure = $authenticationResult->getThreeDSecure();
 
         if ($threeDSecure === null) {
-            return false;
+            return true;
         }
 
         return \in_array(

--- a/src/Checkout/Cart/Service/CartPriceService.php
+++ b/src/Checkout/Cart/Service/CartPriceService.php
@@ -10,6 +10,8 @@ namespace Swag\PayPal\Checkout\Cart\Service;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\Exception\EmptyCartException;
+use Swag\PayPal\Checkout\Exception\OrderZeroValueException;
 use Swag\PayPal\Util\PriceFormatter;
 
 #[Package('checkout')]
@@ -21,6 +23,22 @@ class CartPriceService
     public function __construct(
         private readonly PriceFormatter $priceFormatter,
     ) {
+    }
+
+    public function isProcessable(Cart $cart, SalesChannelContext $context): bool
+    {
+        return $cart->getLineItems()->count() > 0 && !$this->hasZeroPrice($cart, $context);
+    }
+
+    public function validateProcessable(Cart $cart, SalesChannelContext $context): void
+    {
+        if ($cart->getLineItems()->count() === 0) {
+            throw new EmptyCartException();
+        }
+
+        if ($this->hasZeroPrice($cart, $context)) {
+            throw new OrderZeroValueException();
+        }
     }
 
     public function hasZeroPrice(Cart $cart, SalesChannelContext $context): bool

--- a/src/Checkout/Cart/Validation/CartValidator.php
+++ b/src/Checkout/Cart/Validation/CartValidator.php
@@ -15,12 +15,11 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\Cart\Service\ExcludedProductValidator;
-use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Util\Availability\AvailabilityService;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
-use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 #[Package('checkout')]
@@ -38,6 +37,8 @@ class CartValidator implements CartValidatorInterface
 
     private AvailabilityService $availabilityService;
 
+    private MethodEligibilityStateService $methodEligibilityStateService;
+
     /**
      * @internal
      */
@@ -48,6 +49,7 @@ class CartValidator implements CartValidatorInterface
         RequestStack $requestStack,
         ExcludedProductValidator $excludedProductValidator,
         AvailabilityService $availabilityService,
+        MethodEligibilityStateService $methodEligibilityStateService,
     ) {
         $this->cartPriceService = $cartPriceService;
         $this->methodDataRegistry = $methodDataRegistry;
@@ -55,6 +57,7 @@ class CartValidator implements CartValidatorInterface
         $this->requestStack = $requestStack;
         $this->excludedProductValidator = $excludedProductValidator;
         $this->availabilityService = $availabilityService;
+        $this->methodEligibilityStateService = $methodEligibilityStateService;
     }
 
     public function validate(Cart $cart, ErrorCollection $errors, SalesChannelContext $context): void
@@ -77,14 +80,13 @@ class CartValidator implements CartValidatorInterface
             return;
         }
 
-        try {
-            $ineligiblePaymentMethods = $this->requestStack->getSession()->get(MethodEligibilityRoute::SESSION_KEY);
-            if (\is_array($ineligiblePaymentMethods) && \in_array($context->getPaymentMethod()->getHandlerIdentifier(), $ineligiblePaymentMethods, true)) {
-                $errors->add(new PaymentMethodBlockedError((string) $context->getPaymentMethod()->getTranslation('name')));
+        $ineligiblePaymentMethods = $this->methodEligibilityStateService->getIneligiblePaymentMethods(
+            $this->requestStack->getCurrentRequest(),
+            $context,
+        );
+        if (\in_array($context->getPaymentMethod()->getHandlerIdentifier(), $ineligiblePaymentMethods, true)) {
+            $errors->add(new PaymentMethodBlockedError((string) $context->getPaymentMethod()->getTranslation('name')));
 
-                return;
-            }
-        } catch (SessionNotFoundException $e) {
             return;
         }
 

--- a/src/Checkout/Exception/EmptyCartException.php
+++ b/src/Checkout/Exception/EmptyCartException.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Checkout\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('checkout')]
+class EmptyCartException extends ShopwareHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('PayPal Express Checkout is unable to process an empty shopping cart');
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__EXPRESS_EMPTY_CART';
+    }
+}

--- a/src/Checkout/Exception/MissingCountryIdException.php
+++ b/src/Checkout/Exception/MissingCountryIdException.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Checkout\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('checkout')]
+class MissingCountryIdException extends ShopwareHttpException
+{
+    public function __construct(
+        string $orderId,
+        string $code,
+    ) {
+        parent::__construct(
+            'Shipping to the selected country is not available because "{{code}}" is not assigned to the sales channel.',
+            [
+                'code' => $code,
+                'orderId' => $orderId,
+            ]
+        );
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__MISSING_COUNTRY_ID';
+    }
+}

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCategoryRoute.php
@@ -20,10 +20,8 @@ use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\Lifecycle\Method\PayPalMethodData;
 use Swag\PayPal\Util\PaymentMethodUtil;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Attribute\Route;
 
 #[Package('checkout')]
-#[Route(defaults: ['_routeScope' => ['store-api']])]
 class ExpressCategoryRoute extends AbstractCategoryRoute
 {
     /**
@@ -43,7 +41,6 @@ class ExpressCategoryRoute extends AbstractCategoryRoute
         return $this->inner;
     }
 
-    #[Route(path: '/store-api/category/{navigationId}', name: 'store-api.category.detail', methods: ['GET', 'POST'])]
     public function load(string $navigationId, Request $request, SalesChannelContext $context): CategoryRouteResponse
     {
         $response = $this->inner->load($navigationId, $request, $context);

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRoute.php
@@ -17,7 +17,6 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
-use Swag\PayPal\Checkout\Exception\OrderZeroValueException;
 use Swag\PayPal\Checkout\TokenResponse;
 use Swag\PayPal\OrdersApi\Builder\PayPalOrderBuilder;
 use Swag\PayPal\RestApi\PartnerAttributionId;
@@ -71,9 +70,7 @@ class ExpressCreateOrderRoute extends AbstractExpressCreateOrderRoute
             $this->logger->debug('Started');
             $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext, taxed: true);
 
-            if ($this->cartPriceService->hasZeroPrice($cart, $salesChannelContext)) {
-                throw new OrderZeroValueException();
-            }
+            $this->cartPriceService->validateProcessable($cart, $salesChannelContext);
 
             $this->logger->debug('Building order');
             $order = $this->paypalOrderBuilder->getOrderFromCart($cart, $salesChannelContext, new RequestDataBag($request->request->all()));

--- a/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
+++ b/src/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRoute.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutData;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
 use Swag\PayPal\Checkout\Payment\PayPalPaymentHandler;
@@ -39,6 +40,7 @@ class ExpressPrepareCheckoutRoute extends AbstractExpressPrepareCheckoutRoute
         private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
         private readonly OrderResource $orderResource,
         private readonly CartService $cartService,
+        private readonly CartPriceService $cartPriceService,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -91,6 +93,8 @@ class ExpressPrepareCheckoutRoute extends AbstractExpressPrepareCheckoutRoute
             );
 
             $cart = $this->cartService->getCart($newSalesChannelContext->getToken(), $salesChannelContext, taxed: true);
+
+            $this->cartPriceService->validateProcessable($cart, $newSalesChannelContext);
 
             $expressCheckoutData = new ExpressCheckoutData($paypalOrderId);
             $cart->addExtension(self::PAYPAL_EXPRESS_CHECKOUT_CART_EXTENSION_ID, $expressCheckoutData);

--- a/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
+++ b/src/Checkout/ExpressCheckout/Service/ExpressCustomerService.php
@@ -27,6 +27,7 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swag\PayPal\Checkout\Exception\MissingCountryIdException;
 use Swag\PayPal\Checkout\Exception\MissingPayloadException;
 use Swag\PayPal\RestApi\V2\Api\Order;
 
@@ -172,6 +173,11 @@ class ExpressCustomerService
 
         $countryCode = $address->getCountryCode();
         $countryId = $this->getCountryId($countryCode, $context);
+
+        if (!$countryId) {
+            throw new MissingCountryIdException($order->getId(), $countryCode);
+        }
+
         $countryStateId = $this->getCountryStateId($countryId, $countryCode, $address->getAdminArea1(), $context->getContext());
         $phone = $paypal->getPhoneNumber();
 

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -58,11 +58,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService impleme
     ): ?ExpressCheckoutButtonData {
         $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
 
-        if (!$addProductToCart && $cart->getLineItems()->count() === 0) {
-            return null;
-        }
-
-        if (!$addProductToCart && $this->cartPriceService->hasZeroPrice($cart, $salesChannelContext)) {
+        if (!$addProductToCart && !$this->cartPriceService->isProcessable($cart, $salesChannelContext)) {
             return null;
         }
 

--- a/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
+++ b/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
@@ -23,7 +23,6 @@ use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Service\SettingsValidationServiceInterface;
 use Swag\PayPal\Util\Availability\AvailabilityService;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
-use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Attribute\Route;
@@ -50,6 +49,8 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
 
     private EntityRepository $orderRepository;
 
+    private MethodEligibilityStateService $methodEligibilityStateService;
+
     /**
      * @internal
      */
@@ -63,6 +64,7 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
         RequestStack $requestStack,
         AvailabilityService $availabilityService,
         EntityRepository $orderRepository,
+        MethodEligibilityStateService $methodEligibilityStateService,
     ) {
         $this->decorated = $decorated;
         $this->methodDataRegistry = $methodDataRegistry;
@@ -73,6 +75,7 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
         $this->requestStack = $requestStack;
         $this->availabilityService = $availabilityService;
         $this->orderRepository = $orderRepository;
+        $this->methodEligibilityStateService = $methodEligibilityStateService;
     }
 
     public function getDecorated(): AbstractPaymentMethodRoute
@@ -109,12 +112,12 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
             return $response;
         }
 
-        try {
-            $ineligiblePaymentMethods = $this->requestStack->getSession()->get(MethodEligibilityRoute::SESSION_KEY);
-            if (\is_array($ineligiblePaymentMethods)) {
-                $this->removePaymentMethods($response->getPaymentMethods(), $ineligiblePaymentMethods);
-            }
-        } catch (SessionNotFoundException $e) {
+        $ineligiblePaymentMethods = $this->methodEligibilityStateService->getIneligiblePaymentMethods(
+            $this->requestStack->getCurrentRequest(),
+            $context,
+        );
+        if ($ineligiblePaymentMethods !== []) {
+            $this->removePaymentMethods($response->getPaymentMethods(), $ineligiblePaymentMethods);
         }
 
         $order = $this->checkOrder($request, $context->getContext());

--- a/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
+++ b/src/Checkout/SalesChannel/FilteredPaymentMethodRoute.php
@@ -25,10 +25,8 @@ use Swag\PayPal\Util\Availability\AvailabilityService;
 use Swag\PayPal\Util\Lifecycle\Method\PaymentMethodDataRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Attribute\Route;
 
 #[Package('checkout')]
-#[Route(defaults: ['_routeScope' => ['store-api']])]
 class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
 {
     private AbstractPaymentMethodRoute $decorated;
@@ -83,7 +81,6 @@ class FilteredPaymentMethodRoute extends AbstractPaymentMethodRoute
         return $this->decorated;
     }
 
-    #[Route(path: '/store-api/payment-method', name: 'store-api.payment.method', defaults: ['_entity' => 'payment_method'], methods: ['GET', 'POST'])]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): PaymentMethodRouteResponse
     {
         $response = $this->getDecorated()->load($request, $context, $criteria);

--- a/src/Checkout/SalesChannel/MethodEligibilityRoute.php
+++ b/src/Checkout/SalesChannel/MethodEligibilityRoute.php
@@ -13,7 +13,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\NoContentResponse;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Swag\PayPal\Checkout\Payment\Method\ACDCHandler;
 use Swag\PayPal\Checkout\Payment\Method\PayLaterHandler;
 use Swag\PayPal\Checkout\Payment\Method\SEPAHandler;
@@ -37,12 +39,17 @@ class MethodEligibilityRoute extends AbstractMethodEligibilityRoute
 
     private LoggerInterface $logger;
 
+    private MethodEligibilityStateService $methodEligibilityStateService;
+
     /**
      * @internal
      */
-    public function __construct(LoggerInterface $logger)
-    {
+    public function __construct(
+        LoggerInterface $logger,
+        MethodEligibilityStateService $methodEligibilityStateService,
+    ) {
         $this->logger = $logger;
+        $this->methodEligibilityStateService = $methodEligibilityStateService;
     }
 
     public function getDecorated(): AbstractMethodEligibilityRoute
@@ -56,7 +63,7 @@ class MethodEligibilityRoute extends AbstractMethodEligibilityRoute
     #[OA\Post(
         path: '/paypal/payment-method-eligibility',
         operationId: 'setPaymentMethodEligibility',
-        description: 'Sets ineligible payment methods to be removed from the session',
+        description: 'Sets ineligible payment methods to be removed from the current sales channel context',
         requestBody: new OA\RequestBody(content: new OA\JsonContent(properties: [
             new OA\Property(
                 property: 'paymentMethods',
@@ -84,8 +91,13 @@ class MethodEligibilityRoute extends AbstractMethodEligibilityRoute
             }
         }
 
-        $request->getSession()->set(self::SESSION_KEY, $handlers);
-        $this->logger->info('Removed ineligible PayPal payment methods from session', ['handlers' => $handlers]);
+        $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+        $this->methodEligibilityStateService->setIneligiblePaymentMethods(
+            $request,
+            $salesChannelContext instanceof SalesChannelContext ? $salesChannelContext : null,
+            $handlers,
+        );
+        $this->logger->info('Removed ineligible PayPal payment methods from sales channel context', ['handlers' => $handlers]);
 
         return new NoContentResponse();
     }

--- a/src/Checkout/SalesChannel/MethodEligibilityStateService.php
+++ b/src/Checkout/SalesChannel/MethodEligibilityStateService.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Checkout\SalesChannel;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class MethodEligibilityStateService
+{
+    public function __construct(private readonly SalesChannelContextPersister $contextPersister)
+    {
+    }
+
+    /**
+     * @param list<class-string> $handlers
+     */
+    public function setIneligiblePaymentMethods(Request $request, ?SalesChannelContext $context, array $handlers): void
+    {
+        $session = $this->getStartedSession($request);
+        if ($session !== null) {
+            $session->set(MethodEligibilityRoute::SESSION_KEY, $handlers);
+
+            return;
+        }
+
+        if ($context === null) {
+            return;
+        }
+
+        // The persister recursively merges arrays, so a scalar is required to reliably clear an empty handler list.
+        $this->contextPersister->save(
+            $context->getToken(),
+            [MethodEligibilityRoute::SESSION_KEY => \json_encode($handlers, \JSON_THROW_ON_ERROR)],
+            $context->getSalesChannelId(),
+            $context->getCustomerId(),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getIneligiblePaymentMethods(?Request $request, SalesChannelContext $context): array
+    {
+        if ($request === null) {
+            return [];
+        }
+
+        // A started session (storefront) is the authoritative storage, even if it holds no handlers yet.
+        // Falling through to the persister would add a database query to every cart validation.
+        $session = $this->getStartedSession($request);
+        if ($session !== null) {
+            return $this->normalizeHandlers($session->get(MethodEligibilityRoute::SESSION_KEY));
+        }
+
+        $parameters = $this->contextPersister->load($context->getToken(), $context->getSalesChannelId());
+
+        return $this->normalizeHandlers($parameters[MethodEligibilityRoute::SESSION_KEY] ?? null);
+    }
+
+    private function getStartedSession(Request $request): ?SessionInterface
+    {
+        if (!$request->hasSession(true)) {
+            return null;
+        }
+
+        $session = $request->getSession();
+
+        return $session->isStarted() ? $session : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeHandlers(mixed $handlers): array
+    {
+        if (\is_string($handlers)) {
+            $handlers = \json_decode($handlers, true);
+        }
+
+        if (!\is_array($handlers)) {
+            return [];
+        }
+
+        return \array_values(\array_filter($handlers, \is_string(...)));
+    }
+}

--- a/src/OrdersApi/Builder/ACDCOrderBuilder.php
+++ b/src/OrdersApi/Builder/ACDCOrderBuilder.php
@@ -22,6 +22,7 @@ use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Card;
 use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Card\StoredCredential;
 use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Common\Attributes;
 use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Common\Attributes\Verification;
+use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Util\LocaleCodeProvider;
 
 #[Package('checkout')]
@@ -51,7 +52,11 @@ class ACDCOrderBuilder extends AbstractOrderBuilder
         $card->setExperienceContext($this->createExperienceContext($salesChannelContext, $paymentTransaction));
 
         $attributes = new Attributes();
-        $attributes->setVerification(new Verification());
+        $verification = new Verification();
+        if (!$this->systemConfigService->getBool(Settings::ACDC_FORCE_3DS, $salesChannelContext->getSalesChannelId())) {
+            $verification->setMethod(Verification::METHOD_SCA_WHEN_REQUIRED);
+        }
+        $attributes->setVerification($verification);
         $card->setAttributes($attributes);
 
         $paymentSource->setCard($card);
@@ -90,7 +95,11 @@ class ACDCOrderBuilder extends AbstractOrderBuilder
         $card->setExperienceContext($this->createExperienceContext($salesChannelContext, $cart));
 
         $attributes = new Attributes();
-        $attributes->setVerification(new Verification());
+        $verification = new Verification();
+        if (!$this->systemConfigService->getBool(Settings::ACDC_FORCE_3DS, $salesChannelContext->getSalesChannelId())) {
+            $verification->setMethod(Verification::METHOD_SCA_WHEN_REQUIRED);
+        }
+        $attributes->setVerification($verification);
         $card->setAttributes($attributes);
 
         $paymentSource->setCard($card);

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -230,7 +230,7 @@
                     "Store API",
                     "PayPal"
                 ],
-                "description": "Sets ineligible payment methods to be removed from the session",
+                "description": "Sets ineligible payment methods to be removed from the current sales channel context",
                 "operationId": "setPaymentMethodEligibility",
                 "requestBody": {
                     "content": {

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.google-pay.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.google-pay.js
@@ -1,6 +1,19 @@
 import SwagPaypalAbstractStandalone from './swag-paypal.abstract-standalone';
 import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
 
+const GOOGLE_PAY_BUTTON_LOCALES = new Set([
+    'en', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'es', 'et', 'fi', 'fr', 'hr', 'id', 'it',
+    'ja', 'ko', 'ms', 'nl', 'no', 'pl', 'pt', 'ru', 'sk', 'sl', 'sr', 'sv', 'th', 'tr', 'uk', 'zh',
+]);
+
+// Google Pay uses the macrolanguage code `no` for Norwegian, but locales use the
+// individual Bokmål (`nb`) / Nynorsk (`nn`) subtags. Map those so Norwegian stores
+// still get a localized button instead of falling back to the browser locale.
+const GOOGLE_PAY_LOCALE_ALIASES = {
+    nb: 'no',
+    nn: 'no',
+};
+
 export default class SwagPaypalGooglePay extends SwagPaypalAbstractStandalone {
     static options = {
         ...super.options,
@@ -80,8 +93,10 @@ export default class SwagPaypalGooglePay extends SwagPaypalAbstractStandalone {
 
         gpClient.prefetchPaymentData(paymentDataRequest);
 
+        const buttonLocale = this.getButtonLocale();
         const button = gpClient.createButton({
             allowedPaymentMethods,
+            ...(buttonLocale ? { buttonLocale } : {}),
             onClick: () => {
                 if (this.confirmOrderForm.checkValidity())
                     gpClient.loadPaymentData(paymentDataRequest).catch();
@@ -127,5 +142,27 @@ export default class SwagPaypalGooglePay extends SwagPaypalAbstractStandalone {
             environment: this.options.sandbox ? 'TEST' : 'PRODUCTION',
             paymentDataCallbacks: { onPaymentAuthorized },
         });
+    }
+
+    getButtonLocale() {
+        const languageIso = this.options.languageIso;
+        if (!languageIso) {
+            return undefined;
+        }
+
+        let language;
+        try {
+            language = new Intl.Locale(languageIso.replace(/_/g, '-')).language;
+        } catch {
+            return undefined;
+        }
+
+        if (!language) {
+            return undefined;
+        }
+
+        const buttonLocale = GOOGLE_PAY_LOCALE_ALIASES[language] ?? language;
+
+        return GOOGLE_PAY_BUTTON_LOCALES.has(buttonLocale) ? buttonLocale : undefined;
     }
 }

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -263,6 +263,7 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
                 (responseText, request) => {
                     if (request.status >= 400) {
                         reject(responseText);
+                        return;
                     }
 
                     return Promise.resolve().then(() => {
@@ -281,6 +282,9 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
                         });
                 },
             );
+        }).catch((error) => {
+            this.handleError(this.GENERIC_ERROR, false, error);
+            throw error;
         });
     }
 
@@ -339,10 +343,13 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
         );
     }
 
-    onErrorHandled(code) {
+    onErrorHandled(code, fatal, error, isCheckout = false) {
         if (code === this.USER_CANCELLED) {
             window.scrollTo(0, 0);
             window.location = this.options.cancelRedirectUrl;
+            return;
         }
+
+        super.onErrorHandled(code, fatal, error, isCheckout);
     }
 }

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -336,6 +336,15 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
             (response, request) => {
                 if (request.status < 400) {
                     return actions.redirect(this.options.checkoutConfirmUrl);
+                } else if (request.status === 400) {
+                    try {
+                        this.onError(JSON.parse(request.response));
+                    } catch (error) {
+                        console.warn('SwagPayPalExpressCheckout: Could not parse error response', error);
+                        this.onError();
+                    }
+
+                    return window.location.reload();
                 }
 
                 return this.onError();

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="Swag\PayPal\Checkout\Cart\Service\ExcludedProductValidator"/>
             <argument type="service" id="Swag\PayPal\Util\Availability\AvailabilityService"/>
+            <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService"/>
             <tag name="shopware.cart.validator"/>
         </service>
 
@@ -30,8 +31,13 @@
             <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
         </service>
 
+        <service id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
+        </service>
+
         <service id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute" public="true">
             <argument type="service" id="monolog.logger.paypal"/>
+            <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\SalesChannel\CreateOrderRoute" public="true">
@@ -66,6 +72,7 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="Swag\PayPal\Util\Availability\AvailabilityService"/>
             <argument type="service" id="order.repository"/>
+            <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\Card\AbstractCardValidator">

--- a/src/Resources/config/services/express_checkout.xml
+++ b/src/Resources/config/services/express_checkout.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
             <argument type="service" id="Swag\PayPal\RestApi\V2\Resource\OrderResource"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Swag\PayPal\Checkout\Cart\Service\CartPriceService"/>
             <argument type="service" id="monolog.logger.paypal"/>
         </service>
 

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -62,6 +62,7 @@
             <argument type="service" id="Swag\PayPal\Util\LocaleCodeProvider"/>
             <argument type="service" id="router"/>
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService"/>
         </service>
 
         <service id="Swag\PayPal\Storefront\Data\Service\VaultDataService">

--- a/src/Resources/config/services/storefront.xml
+++ b/src/Resources/config/services/storefront.xml
@@ -14,6 +14,8 @@
             <argument type="service" id="Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressShippingCallbackRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartDeleteRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Swag\PayPal\Checkout\Cart\Service\CartPriceService"/>
             <argument type="service" id="Swag\PayPal\Checkout\SalesChannel\ClearVaultRoute"/>
             <argument type="service" id="monolog.logger.paypal"/>
 

--- a/src/Resources/snippet/storefront/paypal.de-DE.json
+++ b/src/Resources/snippet/storefront/paypal.de-DE.json
@@ -7,6 +7,7 @@
         },
         "error": {
             "SWAG_PAYPAL__EXPRESS_GENERIC_ERROR": "Während des Bestellvorgangs mit PayPal ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal oder verwenden Sie den normalen Bestellprozess.",
+            "SWAG_PAYPAL__EXPRESS_EMPTY_CART": "Ihr Warenkorb ist leer. Bitte laden Sie die Seite neu oder fügen Sie Produkte zu Ihrem Warenkorb hinzu.",
             "SWAG_PAYPAL__EXPRESS_USER_CANCELLED": "Der Bestellvorgang mit PayPal wurde abgebrochen. Bitte versuchen Sie es noch einmal oder verwenden Sie den normalen Bestellprozess.",
             "SWAG_PAYPAL__GENERIC_ERROR": "Während des Zahlungsvorgangs ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal oder wählen Sie eine andere Zahlungsart.",
             "SWAG_PAYPAL__USER_CANCELLED": "Der Zahlungsvorgang wurde abgebrochen. Bitte versuchen Sie es noch einmal oder wählen Sie eine andere Zahlungsart.",

--- a/src/Resources/snippet/storefront/paypal.de-DE.json
+++ b/src/Resources/snippet/storefront/paypal.de-DE.json
@@ -13,6 +13,7 @@
             "SWAG_PAYPAL__USER_CANCELLED": "Der Zahlungsvorgang wurde abgebrochen. Bitte versuchen Sie es noch einmal oder wählen Sie eine andere Zahlungsart.",
             "SWAG_PAYPAL__BROWSER_UNSUPPORTED": "Die gewählte Zahlungsart wird von Ihrem aktuellen Browser nicht unterstützt. Bitte versuchen Sie es mit einem anderen Browser oder wählen Sie eine andere Zahlungsart.",
             "SWAG_PAYPAL__CARD_VALIDATION_FAILED": "Die eingegebenen Kreditkartendaten sind ungültig. Bitte kontrollieren Sie Ihre Eingaben und versuchen Sie es erneut.",
+            "SWAG_PAYPAL__MISSING_COUNTRY_ID": "Lieferungen in das Land der gewählten Lieferadresse sind nicht möglich.",
             "SWAG_PAYPAL__API_POSTAL_CODE_REQUIRED": "Die eingegebene Adresse enthält keine Postleitzahl. Bitte ergänzen Sie Ihre Eingaben.",
             "SWAG_PAYPAL__API_CANNOT_BE_ZERO_OR_NEGATIVE": "Der Betrag kann nicht null oder negativ sein. Bitte versuchen Sie es mit einem Betrag größer als null oder wählen Sie eine andere Zahlungsart aus.",
             "SWAG_PAYPAL__API_SHIPPING_ADDRESS_INVALID": "Die angegebene Lieferadresse wurde vom Zahlungsanbieter nicht akzeptiert. Bitte überprüfen Sie Ihre Adresse oder wählen Sie eine andere Zahlungsart.",

--- a/src/Resources/snippet/storefront/paypal.en-GB.json
+++ b/src/Resources/snippet/storefront/paypal.en-GB.json
@@ -13,6 +13,7 @@
             "SWAG_PAYPAL__USER_CANCELLED": "The payment process has been cancelled. Please try again or choose another payment method.",
             "SWAG_PAYPAL__BROWSER_UNSUPPORTED": "The selected payment method does not support your current browser. Please try again with another browser or choose another payment method.",
             "SWAG_PAYPAL__CARD_VALIDATION_FAILED": "The entered credit card details could not be validated. Please check your entries and try again.",
+            "SWAG_PAYPAL__MISSING_COUNTRY_ID": "Shipping to the selected shipping address is currently not possible.",
             "SWAG_PAYPAL__API_POSTAL_CODE_REQUIRED": "The provided address does not contain a postal code. Please add your postal code.",
             "SWAG_PAYPAL__API_CANNOT_BE_ZERO_OR_NEGATIVE": "The total amount must not be zero or negative. Please try again with an amount greater than zero or choose another payment method.",
             "SWAG_PAYPAL__API_SHIPPING_ADDRESS_INVALID": "The entered shipping address was not accepted by the payment provider. Please check your address or choose another payment method.",

--- a/src/Resources/snippet/storefront/paypal.en-GB.json
+++ b/src/Resources/snippet/storefront/paypal.en-GB.json
@@ -8,6 +8,7 @@
         "error": {
             "SWAG_PAYPAL__EXPRESS_USER_CANCELLED": "The PayPal order process has been cancelled. Please try again or use the regular checkout.",
             "SWAG_PAYPAL__EXPRESS_GENERIC_ERROR": "An error occurred during the PayPal order process. Please try again later or use the regular checkout.",
+            "SWAG_PAYPAL__EXPRESS_EMPTY_CART": "Your shopping cart is empty. Please refresh the page or add products to your cart.",
             "SWAG_PAYPAL__GENERIC_ERROR": "An error occurred during the payment process. Please try again later or choose another payment method.",
             "SWAG_PAYPAL__USER_CANCELLED": "The payment process has been cancelled. Please try again or choose another payment method.",
             "SWAG_PAYPAL__BROWSER_UNSUPPORTED": "The selected payment method does not support your current browser. Please try again with another browser or choose another payment method.",

--- a/src/Storefront/Controller/PayPalController.php
+++ b/src/Storefront/Controller/PayPalController.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Framework\AffiliateTracking\AffiliateTrackingListener;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
+use Swag\PayPal\Checkout\Exception\MissingCountryIdException;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressShippingCallbackRoute;
@@ -91,7 +92,7 @@ class PayPalController extends StorefrontController
     }
 
     #[Route(path: '/paypal/express/prepare-checkout', name: 'frontend.paypal.express.prepare_checkout', methods: ['POST'], defaults: ['XmlHttpRequest' => true, 'csrf_protected' => false])]
-    public function expressPrepareCheckout(Request $request, SalesChannelContext $context): ContextTokenResponse
+    public function expressPrepareCheckout(Request $request, SalesChannelContext $context): ContextTokenResponse|Response
     {
         $affiliateCode = $request->getSession()->get(AffiliateTrackingListener::AFFILIATE_CODE_KEY);
         $campaignCode = $request->getSession()->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY);
@@ -104,7 +105,11 @@ class PayPalController extends StorefrontController
             $request->request->set(AffiliateTrackingListener::CAMPAIGN_CODE_KEY, $campaignCode);
         }
 
-        return $this->expressPrepareCheckoutRoute->prepareCheckout($context, $request);
+        try {
+            return $this->expressPrepareCheckoutRoute->prepareCheckout($context, $request);
+        } catch (PayPalApiException|MissingCountryIdException $e) {
+            return (new ErrorResponseFactory())->getResponseFromException($e);
+        }
     }
 
     #[Route(path: '/paypal/express/create-order', name: 'frontend.paypal.express.create_order', methods: ['POST'], defaults: ['XmlHttpRequest' => true, 'csrf_protected' => false])]

--- a/src/Storefront/Controller/PayPalController.php
+++ b/src/Storefront/Controller/PayPalController.php
@@ -11,6 +11,7 @@ use Monolog\Level;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Framework\Api\EventListener\ErrorResponseFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -22,6 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Framework\AffiliateTracking\AffiliateTrackingListener;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressShippingCallbackRoute;
@@ -58,6 +60,8 @@ class PayPalController extends StorefrontController
         private readonly AbstractExpressShippingCallbackRoute $expressShippingCallbackRoute,
         private readonly AbstractContextSwitchRoute $contextSwitchRoute,
         private readonly AbstractCartDeleteRoute $cartDeleteRoute,
+        private readonly CartService $cartService,
+        private readonly CartPriceService $cartPriceService,
         private readonly AbstractClearVaultRoute $clearVaultRoute,
         private readonly LoggerInterface $logger,
     ) {
@@ -112,6 +116,11 @@ class PayPalController extends StorefrontController
     #[Route(path: '/paypal/express/prepare-cart', name: 'frontend.paypal.express.prepare_cart', methods: ['POST'], defaults: ['XmlHttpRequest' => true, 'csrf_protected' => false])]
     public function expressPrepareCart(Request $request, SalesChannelContext $context): Response
     {
+        if (!$request->request->getBoolean('deleteCart')) {
+            $cart = $this->cartService->getCart($context->getToken(), $context);
+            $this->cartPriceService->validateProcessable($cart, $context);
+        }
+
         $this->contextSwitchRoute->switchContext(new RequestDataBag([
             SalesChannelContextService::PAYMENT_METHOD_ID => $request->get('paymentMethodId'),
         ]), $context);

--- a/src/Storefront/Data/Service/FundingEligibilityDataService.php
+++ b/src/Storefront/Data/Service/FundingEligibilityDataService.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService;
 use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Storefront\Data\Struct\FundingEligibilityData;
 use Swag\PayPal\Util\LocaleCodeProvider;
@@ -29,6 +30,7 @@ class FundingEligibilityDataService extends AbstractScriptDataService
         LocaleCodeProvider $localeCodeProvider,
         private readonly RouterInterface $router,
         private readonly RequestStack $requestStack,
+        private readonly MethodEligibilityStateService $methodEligibilityStateService,
     ) {
         parent::__construct($localeCodeProvider, $systemConfigService, $credentialsUtil);
     }
@@ -38,22 +40,20 @@ class FundingEligibilityDataService extends AbstractScriptDataService
         return (new FundingEligibilityData())->assign([
             ...parent::getBaseData($context),
             'methodEligibilityUrl' => $this->router->generate('frontend.paypal.payment-method-eligibility'),
-            'filteredPaymentMethods' => $this->getFilteredPaymentMethods(),
+            'filteredPaymentMethods' => $this->getFilteredPaymentMethods($context),
         ]);
     }
 
-    private function getFilteredPaymentMethods(): array
+    private function getFilteredPaymentMethods(SalesChannelContext $context): array
     {
-        $handlers = $this->requestStack->getSession()->get(MethodEligibilityRoute::SESSION_KEY, []);
-        if (!$handlers) {
-            return [];
-        }
+        $handlers = $this->methodEligibilityStateService->getIneligiblePaymentMethods(
+            $this->requestStack->getCurrentRequest(),
+            $context,
+        );
 
-        $methods = [];
-        foreach ($handlers as $handler) {
-            $methods[] = \array_search($handler, MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS, true);
-        }
-
-        return \array_filter($methods);
+        return \array_keys(\array_filter(\array_intersect(
+            MethodEligibilityRoute::REMOVABLE_PAYMENT_HANDLERS,
+            $handlers,
+        )));
     }
 }

--- a/tests/Checkout/Card/AbstractCardValidatorTestCase.php
+++ b/tests/Checkout/Card/AbstractCardValidatorTestCase.php
@@ -57,6 +57,7 @@ abstract class AbstractCardValidatorTestCase extends TestCase
             [false, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, true],
             [false, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [false, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_BYPASSED, null, true],
+            [false, CardValidatorInterface::LIABILITY_SHIFT_NO, null, null, true],
             [false, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, null, null, false],
 
             [true, CardValidatorInterface::LIABILITY_SHIFT_POSSIBLE, CardValidatorInterface::ENROLLMENT_STATUS_READY, CardValidatorInterface::AUTHENTICATION_STATUS_SUCCESSFUL, true],
@@ -72,6 +73,7 @@ abstract class AbstractCardValidatorTestCase extends TestCase
             [true, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, CardValidatorInterface::ENROLLMENT_STATUS_UNAVAILABLE, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_NO, CardValidatorInterface::ENROLLMENT_STATUS_BYPASSED, null, false],
+            [true, CardValidatorInterface::LIABILITY_SHIFT_NO, null, null, false],
             [true, CardValidatorInterface::LIABILITY_SHIFT_UNKNOWN, null, null, false],
         ];
     }

--- a/tests/Checkout/Cart/Service/CartPriceServiceTest.php
+++ b/tests/Checkout/Cart/Service/CartPriceServiceTest.php
@@ -18,6 +18,8 @@ use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
+use Swag\PayPal\Checkout\Exception\EmptyCartException;
+use Swag\PayPal\Checkout\Exception\OrderZeroValueException;
 use Swag\PayPal\Util\PriceFormatter;
 
 /**
@@ -33,6 +35,75 @@ class CartPriceServiceTest extends TestCase
     {
         $this->priceFormatter = new PriceFormatter();
         $this->cartPriceService = new CartPriceService($this->priceFormatter);
+    }
+
+    #[DataProvider('isProcessableProvider')]
+    public function testIsProcessable(bool $expected, float $totalPrice, string $currencyIso, bool $withLineItem): void
+    {
+        $cart = $this->createCart($totalPrice, $withLineItem);
+
+        static::assertSame($expected, $this->cartPriceService->isProcessable($cart, $this->createSalesChannelContext($currencyIso)));
+    }
+
+    /**
+     * @return iterable<string, array{expected: bool, totalPrice: float, currencyIso: string, withLineItem: bool}>
+     */
+    public static function isProcessableProvider(): iterable
+    {
+        yield 'empty carts are not processable' => [
+            'expected' => false,
+            'totalPrice' => 0.0,
+            'currencyIso' => 'EUR',
+            'withLineItem' => false,
+        ];
+
+        yield 'positive totals are processable' => [
+            'expected' => true,
+            'totalPrice' => 10.99,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+
+        yield 'rounded zero totals are not processable' => [
+            'expected' => false,
+            'totalPrice' => 0.004,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+
+        yield 'negative totals are not processable' => [
+            'expected' => false,
+            'totalPrice' => -5.0,
+            'currencyIso' => 'EUR',
+            'withLineItem' => true,
+        ];
+    }
+
+    public function testValidateProcessableThrowsForEmptyCart(): void
+    {
+        $cart = $this->createCart(0.0, false);
+
+        static::expectException(EmptyCartException::class);
+
+        $this->cartPriceService->validateProcessable($cart, $this->createSalesChannelContext('EUR'));
+    }
+
+    public function testValidateProcessableThrowsForZeroValueCart(): void
+    {
+        $cart = $this->createCart(0.0, true);
+
+        static::expectException(OrderZeroValueException::class);
+
+        $this->cartPriceService->validateProcessable($cart, $this->createSalesChannelContext('EUR'));
+    }
+
+    public function testValidateProcessableDoesNotThrowForValidCart(): void
+    {
+        $cart = $this->createCart(10.99, true);
+
+        static::expectNotToPerformAssertions();
+
+        $this->cartPriceService->validateProcessable($cart, $this->createSalesChannelContext('EUR'));
     }
 
     #[DataProvider('hasZeroPriceProvider')]

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
@@ -49,6 +50,7 @@ class ExpressCreateOrderRouteTaxedCartTest extends TestCase
             ->willReturn('express-token');
 
         $cart = new Cart('express-token');
+        $cart->add(new LineItem('test', LineItem::PRODUCT_LINE_ITEM_TYPE, 'test'));
 
         $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
         $taxProviderProcessor
@@ -59,9 +61,9 @@ class ExpressCreateOrderRouteTaxedCartTest extends TestCase
         $cartPriceService = $this->createMock(CartPriceService::class);
         $cartPriceService
             ->expects(static::once())
-            ->method('hasZeroPrice')
-            ->with($cart)
-            ->willReturn(true);
+            ->method('validateProcessable')
+            ->with($cart, $salesChannelContext)
+            ->willThrowException(new OrderZeroValueException());
 
         $route = new ExpressCreateOrderRoute(
             $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
+use Swag\PayPal\Checkout\Exception\EmptyCartException;
 use Swag\PayPal\Checkout\Exception\OrderZeroValueException;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\Payment\Service\VaultTokenService;
@@ -85,9 +86,33 @@ class ExpressCreateOrderRouteTest extends TestCase
         $route->createPayPalOrder(new Request(), $salesChannelContext);
     }
 
-    public function testCreatePayment(): void
+    public function testCreatePaymentWithEmptyCart(): void
     {
         $salesChannelContext = $this->getSalesChannelContext();
+
+        $cart = new Cart('token');
+
+        $cartService = $this->createMock(CartService::class);
+        $cartService->method('getCart')->willReturn($cart);
+
+        $route = new ExpressCreateOrderRoute(
+            $cartService,
+            $this->createMock(PayPalOrderBuilder::class),
+            new OrderResource(new PayPalClientFactoryMock(new NullLogger())),
+            $this->getContainer()->get(CartPriceService::class),
+            $this->getContainer()->get(SystemConfigService::class),
+            $this->createMock(RouterInterface::class),
+            new NullLogger(),
+        );
+
+        static::expectException(EmptyCartException::class);
+
+        $route->createPayPalOrder(new Request(), $salesChannelContext);
+    }
+
+    public function testCreatePayment(): void
+    {
+        $salesChannelContext = $this->getSalesChannelContextWithCart();
 
         $response = $this->createRoute()->createPayPalOrder(new Request(), $salesChannelContext);
 
@@ -99,7 +124,7 @@ class ExpressCreateOrderRouteTest extends TestCase
 
     public function testCreateWithLocalEnvironmentActive(): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getSalesChannelContextWithCart();
 
         $response = $this->createRoute([Settings::IS_LOCAL_ENVIRONMENT => true])->createPayPalOrder(new Request(), $salesChannelContext);
 
@@ -111,7 +136,7 @@ class ExpressCreateOrderRouteTest extends TestCase
 
     public function testCreateWithShippingCallbackDisabled(): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getSalesChannelContextWithCart();
 
         $response = $this->createRoute([Settings::ECS_SHIPPING_CALLBACK_ENABLED => false])->createPayPalOrder(new Request(), $salesChannelContext);
 
@@ -123,7 +148,7 @@ class ExpressCreateOrderRouteTest extends TestCase
 
     public function testCreateShippingCallbackStoreApi(): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getSalesChannelContextWithCart();
 
         $router = $this->createMock(RouterInterface::class);
         $router
@@ -147,7 +172,7 @@ class ExpressCreateOrderRouteTest extends TestCase
 
     public function testCreateShippingCallbackStorefront(): void
     {
-        $salesChannelContext = $this->getSalesChannelContext();
+        $salesChannelContext = $this->getSalesChannelContextWithCart();
 
         $router = $this->createMock(RouterInterface::class);
         $router

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartFactory;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
@@ -26,6 +27,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutData;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
@@ -54,6 +56,7 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
 
         $newToken = 'new-context-token';
         $cart = new Cart($newToken);
+        $cart->add(new LineItem('test', LineItem::PRODUCT_LINE_ITEM_TYPE, 'test'));
 
         $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
         $taxProviderProcessor
@@ -86,11 +89,18 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
             ->with('paypal-order-id', $salesChannel->getId())
             ->willReturn(new Order());
 
+        $cartPriceService = $this->createMock(CartPriceService::class);
+        $cartPriceService
+            ->expects(static::once())
+            ->method('validateProcessable')
+            ->with($cart, $newSalesChannelContext);
+
         $route = new ExpressPrepareCheckoutRoute(
             $expressCustomerService,
             $salesChannelContextFactory,
             $orderResource,
             $this->createTaxedCartService($cart, $salesChannelContext, $newSalesChannelContext, $taxProviderProcessor),
+            $cartPriceService,
             new NullLogger(),
         );
 

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTest.php
@@ -21,12 +21,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\ExpressCheckoutData;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\ExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
@@ -66,9 +64,7 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
 
     public function testPrepare(): void
     {
-        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
-            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
-        );
+        $salesChannelContext = $this->createSalesChannelContextWithCart();
 
         $this->getContainer()->get(SystemConfigService::class)->set(
             'core.loginRegistration.requireDataProtectionCheckbox',
@@ -159,6 +155,7 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
             $this->getContainer()->get(SalesChannelContextFactory::class),
             new OrderResource(new PayPalClientFactoryMock(new NullLogger())),
             $cartService,
+            $this->getContainer()->get(CartPriceService::class),
             new NullLogger()
         );
     }
@@ -182,9 +179,7 @@ class ExpressPrepareCheckoutRouteTest extends TestCase
 
     private function assertNoState(string $testPaypalOrderId): void
     {
-        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
-            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
-        );
+        $salesChannelContext = $this->createSalesChannelContextWithCart();
 
         $request = new Request([], [
             PayPalPaymentHandler::PAYPAL_REQUEST_PARAMETER_TOKEN => $testPaypalOrderId,

--- a/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressCustomerServiceTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
+use Swag\PayPal\Checkout\Exception\MissingCountryIdException;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressCustomerService;
 use Swag\PayPal\RestApi\V2\Api\Order;
 use Swag\PayPal\Setting\Settings;
@@ -144,6 +145,17 @@ class ExpressCustomerServiceTest extends TestCase
 
         static::assertFalse($customer->getDoubleOptInRegistration());
         static::assertNull($customer->getDoubleOptInEmailSentDate());
+    }
+
+    public function testLoginWithCountryNotAssignedToSalesChannel(): void
+    {
+        $order = new Order();
+        $order->assign(GetOrderCapture::get());
+        $order->getPurchaseUnits()->first()?->getShipping()?->getAddress()->setCountryCode('XX');
+
+        $this->expectException(MissingCountryIdException::class);
+
+        $this->doLogin($order);
     }
 
     private function doLogin(Order $order): CustomerEntity

--- a/tests/Checkout/SalesChannel/MethodEligibilityStateServiceTest.php
+++ b/tests/Checkout/SalesChannel/MethodEligibilityStateServiceTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Checkout\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(MethodEligibilityStateService::class)]
+class MethodEligibilityStateServiceTest extends TestCase
+{
+    private SalesChannelContextPersister&MockObject $contextPersister;
+
+    private MethodEligibilityStateService $stateService;
+
+    protected function setUp(): void
+    {
+        $this->contextPersister = $this->createMock(SalesChannelContextPersister::class);
+        $this->stateService = new MethodEligibilityStateService($this->contextPersister);
+    }
+
+    #[DataProvider('unstartedSessionProvider')]
+    public function testReadingContextStateDoesNotInitializeSession(bool $sessionAlreadyInstantiated): void
+    {
+        $request = new Request();
+        $storage = new MockArraySessionStorage();
+        $factoryCalls = 0;
+        $request->setSessionFactory(static function () use ($storage, &$factoryCalls): Session {
+            ++$factoryCalls;
+
+            return new Session($storage);
+        });
+
+        if ($sessionAlreadyInstantiated) {
+            $request->getSession();
+        }
+        $factoryCallsBeforeRead = $factoryCalls;
+
+        $this->contextPersister
+            ->expects(static::once())
+            ->method('load')
+            ->with('context-token', 'sales-channel-id')
+            ->willReturn([MethodEligibilityRoute::SESSION_KEY => '["handler-from-context"]']);
+
+        $handlers = $this->stateService->getIneligiblePaymentMethods($request, $this->createSalesChannelContext());
+
+        static::assertSame(['handler-from-context'], $handlers);
+        static::assertFalse($storage->isStarted());
+        static::assertSame($factoryCallsBeforeRead, $factoryCalls);
+    }
+
+    public static function unstartedSessionProvider(): \Generator
+    {
+        yield 'request has only the lazy session factory' => [false];
+        yield 'session was instantiated but not started' => [true];
+    }
+
+    #[DataProvider('unstartedSessionProvider')]
+    public function testWritingContextStateDoesNotInitializeSession(bool $sessionAlreadyInstantiated): void
+    {
+        $request = new Request();
+        $storage = new MockArraySessionStorage();
+        $factoryCalls = 0;
+        $request->setSessionFactory(static function () use ($storage, &$factoryCalls): Session {
+            ++$factoryCalls;
+
+            return new Session($storage);
+        });
+
+        if ($sessionAlreadyInstantiated) {
+            $request->getSession();
+        }
+        $factoryCallsBeforeWrite = $factoryCalls;
+
+        $this->contextPersister
+            ->expects(static::once())
+            ->method('save')
+            ->with(
+                'context-token',
+                [MethodEligibilityRoute::SESSION_KEY => '[]'],
+                'sales-channel-id',
+                'customer-id',
+            );
+
+        $this->stateService->setIneligiblePaymentMethods($request, $this->createSalesChannelContext(), []);
+
+        static::assertFalse($storage->isStarted());
+        static::assertSame($factoryCallsBeforeWrite, $factoryCalls);
+    }
+
+    public function testReadingWithoutRequestNeverQueriesTheContextPersister(): void
+    {
+        $this->contextPersister->expects(static::never())->method('load');
+
+        static::assertSame([], $this->stateService->getIneligiblePaymentMethods(null, $this->createSalesChannelContext()));
+    }
+
+    public function testStartedSessionWithoutHandlersNeverQueriesTheContextPersister(): void
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+        $request->setSession($session);
+
+        $this->contextPersister->expects(static::never())->method('load');
+
+        static::assertSame([], $this->stateService->getIneligiblePaymentMethods($request, $this->createSalesChannelContext()));
+    }
+
+    public function testStartedSessionRemainsTheStorefrontStateStorage(): void
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(MethodEligibilityRoute::SESSION_KEY, ['handler-from-session']);
+        $request->setSession($session);
+
+        $this->contextPersister->expects(static::never())->method('load');
+        $this->contextPersister->expects(static::never())->method('save');
+
+        $context = $this->createSalesChannelContext();
+        static::assertSame(
+            ['handler-from-session'],
+            $this->stateService->getIneligiblePaymentMethods($request, $context),
+        );
+
+        $this->stateService->setIneligiblePaymentMethods($request, $context, [\stdClass::class]);
+
+        static::assertSame([\stdClass::class], $session->get(MethodEligibilityRoute::SESSION_KEY));
+    }
+
+    private function createSalesChannelContext(): SalesChannelContext
+    {
+        $context = static::createStub(SalesChannelContext::class);
+        $context->method('getToken')->willReturn('context-token');
+        $context->method('getSalesChannelId')->willReturn('sales-channel-id');
+        $context->method('getCustomerId')->willReturn('customer-id');
+
+        return $context;
+    }
+}

--- a/tests/Helper/CheckoutRouteTrait.php
+++ b/tests/Helper/CheckoutRouteTrait.php
@@ -7,6 +7,8 @@
 
 namespace Swag\PayPal\Test\Helper;
 
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Exception\PaymentMethodNotAvailableException;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
@@ -17,10 +19,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Exception\SalesChannelNotFoundException;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\System\Tax\TaxEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Swag\PayPal\Util\PaymentMethodUtil;
@@ -61,6 +67,84 @@ trait CheckoutRouteTrait
         $salesChannelContext->assign(['customer' => null]);
 
         return $salesChannelContext;
+    }
+
+    private function getSalesChannelContextWithCart(): SalesChannelContext
+    {
+        $paymentMethod = $this->getAvailablePaymentMethod();
+        $this->getSalesChannel($paymentMethod);
+
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
+        );
+        $salesChannelContext->assign(['customer' => null]);
+
+        $this->addProductToSalesChannelContext($salesChannelContext);
+
+        return $salesChannelContext;
+    }
+
+    private function createSalesChannelContextWithCart(): SalesChannelContext
+    {
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, Uuid::randomHex())
+        );
+        $this->addProductToSalesChannelContext($salesChannelContext);
+
+        return $salesChannelContext;
+    }
+
+    private function addProductToSalesChannelContext(SalesChannelContext $salesChannelContext): void
+    {
+        $productId = $this->createTestProduct($this->getTaxIdForSalesChannelContext($salesChannelContext));
+        $lineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE, $productId);
+
+        $cartService = $this->getContainer()->get(CartService::class);
+        $cart = $cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
+        $cartService->add($cart, $lineItem, $salesChannelContext);
+    }
+
+    private function getTaxIdForSalesChannelContext(SalesChannelContext $salesChannelContext): string
+    {
+        /** @var TaxEntity|null $tax */
+        $tax = $salesChannelContext->getTaxRules()->first();
+
+        if ($tax !== null) {
+            return $tax->getId();
+        }
+
+        return $this->getValidTaxId();
+    }
+
+    private function createTestProduct(string $taxId): string
+    {
+        $productId = Uuid::randomHex();
+
+        /** @var EntityRepository $productRepository */
+        $productRepository = $this->getContainer()->get('product.repository');
+        $productRepository->upsert([[
+            'id' => $productId,
+            'name' => 'PayPal test product',
+            'taxId' => $taxId,
+            'price' => [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => '100',
+                    'linked' => true,
+                    'net' => '90',
+                ],
+            ],
+            'visibilities' => [
+                [
+                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'visibility' => 30,
+                ],
+            ],
+            'productNumber' => $productId,
+            'stock' => 100,
+        ]], Context::createDefaultContext());
+
+        return $productId;
     }
 
     private function getSalesChannel(PaymentMethodEntity $otherPaymentMethod): SalesChannelEntity

--- a/tests/OrdersApi/Builder/ACDCOrderBuilderTest.php
+++ b/tests/OrdersApi/Builder/ACDCOrderBuilderTest.php
@@ -7,11 +7,15 @@
 
 namespace Swag\PayPal\Test\OrdersApi\Builder;
 
+use Shopware\Core\Checkout\Payment\Cart\SyncPaymentTransactionStruct;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\ACDCOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\Util\AddressProvider;
 use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Card;
+use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Common\Attributes\Verification;
+use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\Test\OrdersApi\Builder\Trait\VaultableOrderBuildTrait;
 
 /**
@@ -21,6 +25,38 @@ use Swag\PayPal\Test\OrdersApi\Builder\Trait\VaultableOrderBuildTrait;
 class ACDCOrderBuilderTest extends AbstractOrderBuilderTestCase
 {
     use VaultableOrderBuildTrait;
+
+    public function testGetOrderUsesScaWhenRequiredByDefault(): void
+    {
+        $paymentTransaction = new SyncPaymentTransactionStruct($this->createOrderTransaction(), $this->createOrder());
+
+        $order = $this->getBuilder()->getOrder(
+            $paymentTransaction,
+            $this->createSalesChannelContext(),
+            new RequestDataBag(),
+        );
+
+        $card = $order->getPaymentSource()?->first(Card::class);
+        static::assertInstanceOf(Card::class, $card);
+        static::assertSame(Verification::METHOD_SCA_WHEN_REQUIRED, $card->getAttributes()?->getVerification()?->getMethod());
+    }
+
+    public function testGetOrderUsesScaAlwaysIfForce3dsEnabled(): void
+    {
+        $this->systemConfig->set(Settings::ACDC_FORCE_3DS, true);
+
+        $paymentTransaction = new SyncPaymentTransactionStruct($this->createOrderTransaction(), $this->createOrder());
+
+        $order = $this->getBuilder()->getOrder(
+            $paymentTransaction,
+            $this->createSalesChannelContext(),
+            new RequestDataBag(),
+        );
+
+        $card = $order->getPaymentSource()?->first(Card::class);
+        static::assertInstanceOf(Card::class, $card);
+        static::assertSame(Verification::METHOD_SCA_ALWAYS, $card->getAttributes()?->getVerification()?->getMethod());
+    }
 
     protected function getBuilder(): AbstractOrderBuilder
     {

--- a/tests/Storefront/Controller/PayPalControllerTest.php
+++ b/tests/Storefront/Controller/PayPalControllerTest.php
@@ -15,11 +15,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
+use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressCreateOrderRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressPrepareCheckoutRoute;
 use Swag\PayPal\Checkout\ExpressCheckout\SalesChannel\AbstractExpressShippingCallbackRoute;
@@ -29,6 +31,7 @@ use Swag\PayPal\Checkout\SalesChannel\AbstractCreateOrderRoute;
 use Swag\PayPal\Checkout\SalesChannel\AbstractMethodEligibilityRoute;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\Storefront\Controller\PayPalController;
+use Swag\PayPal\Util\PriceFormatter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -62,6 +65,8 @@ class PayPalControllerTest extends TestCase
                 $this->createMock(AbstractExpressShippingCallbackRoute::class),
                 $this->createMock(AbstractContextSwitchRoute::class),
                 $this->createMock(AbstractCartDeleteRoute::class),
+                $this->createMock(CartService::class),
+                new CartPriceService(new PriceFormatter()),
                 $this->createMock(AbstractClearVaultRoute::class),
                 new Logger('test', [$this->logHandler]),
             ])

--- a/tests/Storefront/Data/FundingSubscriberTest.php
+++ b/tests/Storefront/Data/FundingSubscriberTest.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Test\Storefront\Data;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
@@ -17,6 +18,7 @@ use Shopware\Storefront\Pagelet\Footer\FooterPagelet;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedEvent;
 use Swag\PayPal\Checkout\Payment\Method\SEPAHandler;
 use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityRoute;
+use Swag\PayPal\Checkout\SalesChannel\MethodEligibilityStateService;
 use Swag\PayPal\RestApi\V2\PaymentIntentV2;
 use Swag\PayPal\Setting\Service\CredentialsUtil;
 use Swag\PayPal\Setting\Service\SettingsValidationService;
@@ -123,7 +125,8 @@ class FundingSubscriberTest extends TestCase
                 $systemConfig,
                 $localeCodeProvider,
                 $router,
-                $requestStack
+                $requestStack,
+                new MethodEligibilityStateService($this->createMock(SalesChannelContextPersister::class)),
             ),
             $paymentMethodUtil,
         );


### PR DESCRIPTION
Bulk backport of the fixes prepared for the **10.8.0** trunk release to the **6.6.x** line, shipped as a new minor release **9.13.0**.

## Backported changes
Each change is its own commit so the individual upstream fixes stay visible in the history (merge or rebase — please do not squash).

| Change | Upstream PR / issue |
|---|---|
| Display Google Pay button in the sales channel language | #726 / shopware/shopware#17804 |
| Block Express Checkout on an empty cart | #736 / #712 |
| Use `SCA_WHEN_REQUIRED` for ACDC when 3DS is not enforced | #717 |
| Accept card payments when 3D Secure data is absent | #715 / #714 |
| Fail Express Checkout gracefully for a country not assigned to the sales channel | #699 / shopware/shopware#15067 |
| Eligibility checks no longer initialize PHP sessions on stateless Store API requests | #746 / #740 |
| Remove `@Route` attributes from core-route decorators | #684 |

## Notes on #746 and #684 (added beyond the original five)
Current Shopware 6.6 core has drifted since this line was last released, which surfaced two failures unrelated to the five feature fixes:
- **`MethodEligibilityRouteTest`** failed because the core now enforces "no session on stateless Store API requests"; **#746** is the fix, so it was backported here as well (it was only meant to be skipped where not required — 6.5.x does not need it).
- **PHPStan `routeDecorator`** flagged decorators redefining `@Route`; **#684** removes those from `ExpressCategoryRoute` / `FilteredPaymentMethodRoute`. `WebhookSystemConfigController` must keep its route scope for the inherited core-controller methods, so its single finding is ignored via `phpstan.neon.dist` (the class is `@deprecated` and removed on the 6.7 line).

## Release / changelog
- Bumps `composer.json` to **9.13.0**.
- Folds the prepared-but-unreleased **9.12.5** changelog entry (SPB terms-not-accepted fix; last tag was 9.12.4) into 9.13.0.
- `CHANGELOG.md` / `CHANGELOG_de-DE.md` updated (EN + DE), including the #740 entry.

## CI
All checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
