### PR TITLE
ci: ignore 6.8 EntitySearchResult collection-method deprecations

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -116,6 +116,17 @@ parameters:
             message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
             path: '**/*.php'
 
+        - # 6.8 deprecation - EntitySearchResult's collection shortcuts (first/get/getElements/reduce/...) move to
+          # getEntities()->...(); it is still the repository search result type on 6.7, so we keep using them.
+            identifier: method.deprecated
+            message: '#Call to deprecated method \w+\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 - Will be removed\. Use getEntities\(\)->#'
+            path: '**/*.php'
+
+        - # 6.8 deprecation - EntitySearchResult constructor signature changes in v6.8; kept for 6.7 compatibility
+            identifier: method.deprecated
+            message: '#Call to deprecated method __construct\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
+            path: '**/*.php'
+
         - # 6.8 deprecation - DAL field API will return static natively
             identifier: method.deprecated
             message: '#Call to deprecated method (addFlags|removeFlag)\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\:\s+tag\:v6\.8\.0 - reason\:return-type-change - Will return static natively#'


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Shopware 6.8/trunk deprecated the `EntitySearchResult` collection shortcuts — `first()`, `get()`, `getElements()`, `reduce()` (in favour of `getEntities()->…`) — and changed its `__construct()` signature. `EntitySearchResult` is still the repository search-result type on the supported 6.7 line, so the plugin uses these across ~30 files. The `phpstan (trunk)` matrix jobs therefore fail with ~180 `method.deprecated` errors and block the merge queue; the `v6.7.0.0` jobs pass (not deprecated there)


### 2. What does this change do, exactly?
Adds two tightly-scoped `ignoreErrors` entries to `phpstan.neon.dist`, next to the existing `EntitySearchResult` class-hierarchy-change ignores: one for the deprecated collection methods (`… Will be removed. Use getEntities()->…`) and one for the deprecated `__construct()`. They match only `EntitySearchResult` and stay unmatched on 6.7.0.0 (fine — CI runs `reportUnmatchedIgnoredErrors=false`), exactly like the existing swagger-php / class-level ignores. No production code changes; the calls remain valid on 6.7. Migrating to `getEntities()->…` is a follow-up for when the plugin drops 6.7


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
