### PR TITLE
fix(devops): key locale list by position instead of scraped priority

### DIFF
--- a/src/DevOps/Command/LocaleScraperCommand.php
+++ b/src/DevOps/Command/LocaleScraperCommand.php
@@ -52,9 +52,11 @@ class LocaleScraperCommand extends Command
 
         $localesClassContent = '';
         foreach ($locales as $countryCode => $localeOptions) {
+            \usort($localeOptions, static fn (array $a, array $b): int => (int) $a[self::PRIORITY] <=> (int) $b[self::PRIORITY]);
+
             $localeString = '';
-            foreach ($localeOptions as $locale) {
-                $localeString .= $this->getLocaleString($locale);
+            foreach ($localeOptions as $position => $locale) {
+                $localeString .= $this->getLocaleString($position, $locale[self::LOCALE_CODE_KEY]);
             }
             $localesClassContent .= \sprintf(
                 "        '%s' => [\n%s\n        ],\n",
@@ -74,10 +76,15 @@ class LocaleScraperCommand extends Command
         return 0;
     }
 
-    private function getLocaleString(array $locale): string
+    /**
+     * The key is the position within the region, not the scraped priority. PayPal changed
+     * that column from 0-based to 1-based numbering once, which broke every
+     * `SupportedLocales::LOCALES[$countryCode][0]` lookup.
+     */
+    private function getLocaleString(int $position, string $localeCode): string
     {
         return <<<EOD
-            {$locale[self::PRIORITY]} => '{$locale[self::LOCALE_CODE_KEY]}',
+            {$position} => '{$localeCode}',
 
 EOD;
     }

--- a/tests/Util/SupportedLocalesTest.php
+++ b/tests/Util/SupportedLocalesTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\Util\LocaleCodeProvider;
+use Swag\PayPal\Util\SupportedLocales;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(SupportedLocales::class)]
+class SupportedLocalesTest extends TestCase
+{
+    /**
+     * The locale codes of a region must be a list ordered by ascending language support
+     * priority, because {@see LocaleCodeProvider::getFormattedLocaleCode()} falls back to
+     * the first entry of a region. PayPal renumbered the priority column of its locale
+     * table from 0-based to 1-based once, which turned every list into a 1-based array and
+     * silently broke that fallback for all regions.
+     *
+     * @param mixed $localeCodes the generated value is deliberately untyped, as its shape
+     *                           is what this test has to verify
+     */
+    #[DataProvider('regionProvider')]
+    public function testLocaleCodesAreZeroBasedList(string $countryCode, $localeCodes): void
+    {
+        static::assertIsArray($localeCodes);
+        static::assertSame(
+            \range(0, \count($localeCodes) - 1),
+            \array_keys($localeCodes),
+            \sprintf('Locale codes of region "%s" are not a 0-based list', $countryCode)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed}>
+     */
+    public static function regionProvider(): iterable
+    {
+        foreach (SupportedLocales::LOCALES as $countryCode => $localeCodes) {
+            yield $countryCode => [$countryCode, $localeCodes];
+        }
+    }
+}


### PR DESCRIPTION
## Problem

[#757](https://github.com/shopware/SwagPayPal/pull/757) rewrote all 648 lines of `SupportedLocales.php` without changing a single locale code. All 202 regions, their order and their locale lists were byte-for-byte identical — only the array keys shifted from 0-based to 1-based:

```diff
         'AL' => [
-            0 => 'en_US',
+            1 => 'en_US',
         ],
```

The scraper copied PayPal's *"Language support priority"* column verbatim into the array keys, and PayPal renumbered that column from 0-based to 1-based.

That is not cosmetic. `LocaleCodeProvider::findMatchingSupportedLocale()` falls back to `SupportedLocales::LOCALES[$countryCode][0]`, so with 1-based keys the lookup misses for **all 202 regions**:

| Input | trunk | #757 |
| --- | --- | --- |
| `en_ZA` | `en_US` | `en_GB` (default) |
| `de_AT` | `de_DE` | `en_GB` (default) |
| `en_IN` | `en_IN` | `en_GB` (default) |
| `fr_CA` | `en_US` | `en_GB` (default) |

Every locale that PayPal does not support directly but that is mappable via its region would have silently fallen back to `en_GB` instead of the region's preferred locale.

## Fix

The scraped priority is now only used to **sort** a region's locales; the array key is the resulting position. The generated output no longer depends on how PayPal happens to number that column.

`SupportedLocalesTest` pins that invariant on the generated file, so a regression fails CI on the automated locale update PR rather than needing to be spotted by eye.

## Verification

- Ran the fixed command against the live PayPal page: the regenerated `SupportedLocales.php` is **byte-for-byte identical to trunk**, confirming #757 carried no actual locale change.
- Reverting `SupportedLocales.php` to #757's version fails the new `SupportedLocalesTest` (`Locale codes of region "PE" are not a 0-based list`) and the pre-existing `LocaleCodeProviderTest::testGetFormattedLocaleCodeWithFallbackLocale`.
- `phpunit tests/Util/SupportedLocalesTest.php tests/Util/LocaleCodeProviderTest.php` → green; `phpstan` clean on the touched files; `php-cs-fixer` reports no fixable files.

### Note on #757's CI

#757 was red, but on unrelated infrastructure flakiness (composer `HTTP/2 504` while downloading dependencies), not on this bug — so the failure that mattered was never actually reported. The pre-existing `LocaleCodeProviderTest` would have caught it had the suite run.