### PR TITLE
fix: forward-port agentic commerce fixes from 6.6.x backport

### DIFF
--- a/src/AgenticCommerce/Subscriber/ProductFilterSubscriber.php
+++ b/src/AgenticCommerce/Subscriber/ProductFilterSubscriber.php
@@ -7,11 +7,14 @@
 
 namespace Swag\PayPal\AgenticCommerce\Subscriber;
 
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Content\Product\Events\ProductGatewayCriteriaEvent;
+use Shopware\Core\Content\ProductExport\Event\ProductExportProductCriteriaEvent;
 use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\AgenticCommerce\Routing\AgentSource;
+use Swag\PayPal\SwagPayPal;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -24,6 +27,7 @@ class ProductFilterSubscriber implements EventSubscriberInterface
     {
         return [
             ProductGatewayCriteriaEvent::class => 'onProductGatewayCriteria',
+            ProductExportProductCriteriaEvent::class => 'onProductExportProductCriteria',
         ];
     }
 
@@ -37,5 +41,15 @@ class ProductFilterSubscriber implements EventSubscriberInterface
 
         $event->getCriteria()
             ->addFilter(new EqualsFilter('streams.id', $source->getStreamId()));
+    }
+
+    public function onProductExportProductCriteria(ProductExportProductCriteriaEvent $event): void
+    {
+        if ($event->getProductExport()->getSalesChannel()?->getTypeId() !== SwagPayPal::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE) {
+            return;
+        }
+
+        // Product Export for agentic commerce should have net prices
+        $event->getSalesChannelContext()->setTaxState(CartPrice::TAX_STATE_NET);
     }
 }

--- a/src/AgenticCommerce/Tax/AgenticTaxDetector.php
+++ b/src/AgenticCommerce/Tax/AgenticTaxDetector.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\AgenticCommerce\Tax;
+
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\AbstractTaxDetector;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Swag\PayPal\AgenticCommerce\Routing\AgentRouteScope;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class AgenticTaxDetector extends AbstractTaxDetector
+{
+    public function __construct(
+        private readonly AbstractTaxDetector $decorated,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function getDecorated(): AbstractTaxDetector
+    {
+        return $this->decorated;
+    }
+
+    public function useGross(SalesChannelContext $context): bool
+    {
+        $routeScope = $this->requestStack->getMainRequest()?->attributes->get('_routeScope');
+        if (\is_array($routeScope) && \in_array(AgentRouteScope::ID, $routeScope, true)) {
+            return false;
+        }
+
+        return $this->getDecorated()->useGross($context);
+    }
+
+    public function isNetDelivery(SalesChannelContext $context): bool
+    {
+        return $this->getDecorated()->isNetDelivery($context);
+    }
+
+    public function getTaxState(SalesChannelContext $context): string
+    {
+        $routeScope = $this->requestStack->getMainRequest()?->attributes->get('_routeScope');
+        if (!\is_array($routeScope) || !\in_array(AgentRouteScope::ID, $routeScope, true)) {
+            return $this->getDecorated()->getTaxState($context);
+        }
+
+        if ($this->isNetDelivery($context)) {
+            return CartPrice::TAX_STATE_FREE;
+        }
+
+        if ($this->useGross($context)) {
+            return CartPrice::TAX_STATE_GROSS;
+        }
+
+        return CartPrice::TAX_STATE_NET;
+    }
+
+    public function isCompanyTaxFree(SalesChannelContext $context, CountryEntity $shippingLocationCountry): bool
+    {
+        return $this->getDecorated()->isCompanyTaxFree($context, $shippingLocationCountry);
+    }
+}

--- a/src/Resources/config/routes.yaml
+++ b/src/Resources/config/routes.yaml
@@ -3,7 +3,7 @@ swag_paypal.administration:
     type: attribute
 
 swag_paypal.agentic_commerce_controller:
-    resource: ../../AgenticCommerce/**/*Controller.
+    resource: ../../AgenticCommerce/**/*Controller.php
     type: attribute
 
 swag_paypal.agentic_commerce_route:

--- a/src/Resources/config/services/agentic_commerce.xml
+++ b/src/Resources/config/services/agentic_commerce.xml
@@ -114,6 +114,13 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Swag\PayPal\AgenticCommerce\Tax\AgenticTaxDetector"
+                 decorates="Shopware\Core\Checkout\Cart\Tax\TaxDetector"
+                 decoration-priority="-1000">
+            <argument type="service" id="Swag\PayPal\AgenticCommerce\Tax\AgenticTaxDetector.inner"/>
+            <argument type="service" id="request_stack"/>
+        </service>
+
         <service id="swag.paypal.honey_webhook" class="GuzzleHttp\Client" lazy="true">
             <argument type="collection">
                 <argument key="base_uri">https://d.joinhoney.com/</argument>


### PR DESCRIPTION
## Description

While reviewing the 6.6.x backport (#427) against the original trunk PR (#322), two fixes turned up that exist only on the backport branch and should be forward-ported to trunk:

### 1. Broken controller route glob in `routes.yaml`

The glob for agentic commerce controllers is missing the `.php` suffix:

```yaml
resource: ../../AgenticCommerce/**/*Controller.
```

This matches no files, so `HoneyWebhookController` (`api.action.paypal.honey.webhook.register`) is never registered on trunk — the webhook refresh action in the administration cannot work. The 6.6.x backport already uses the correct `*Controller.php` glob in its `routes.xml`.

### 2. Missing net-price tax handling for agentic commerce

The 6.6.x backport contains an `AgenticTaxDetector` (decorating `Shopware\Core\Checkout\Cart\Tax\TaxDetector`, forcing net prices for requests in the `paypal-agent` route scope) and a `ProductExportProductCriteriaEvent` handler in `ProductFilterSubscriber` that forces `TAX_STATE_NET` for agentic commerce product exports. Neither exists on trunk, so agentic carts and product exports are calculated with gross prices there.

Both are ported 1:1 from the backport branch, with two small adaptations:
- route scope compared via the `AgentRouteScope::ID` constant instead of the string literal
- nullsafe access on `ProductExportEntity::getSalesChannel()`
